### PR TITLE
Index aliases

### DIFF
--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -171,6 +171,62 @@ A bare reference used as a boolean check (without an explicit comparison) is als
 | `input.x.y`  | yes     |                               |
 | `input.x[i]` | no      | reference contains a variable |
 
+#### References through alias rules
+
+References to other rules (virtual documents) are not indexed, because their value
+is only known once the rule has been evaluated. There is one exception: a rule whose
+only job is to give another reference a shorter name. The indexer resolves such an
+alias to the reference it reads, and then indexes the statement as if it had been
+written against that reference directly. This keeps the ergonomics of aliases without
+giving up indexing:
+
+```rego
+package http
+
+request := input.attributes.request.http
+method := request.method
+```
+
+```rego
+package example
+
+import data.http.method
+
+# indexed as if written 'input.attributes.request.http.method == "GET"'
+allow if method == "GET"
+```
+
+Aliases are resolved through any number of steps (`method` above reads through
+`request`), and a reference below an alias is resolved too, so
+`data.http.request.host == "example.com"` is indexed as
+`input.attributes.request.http.host == "example.com"`.
+
+Only rules of the shape below are treated as aliases. Any other rule is left
+unindexed, as before:
+
+| Rule                                        | Alias | Notes                               |
+| ------------------------------------------- | ----- | ----------------------------------- |
+| `path := input.path`                        | yes   |                                     |
+| `path := data.request.path`                 | yes   | any root document, not just `input` |
+| `path := input.path if input.mode == "x"`   | no    | body is more than the reference     |
+| `path := input.path` + `default path := []` | no    | has a default value                 |
+| `path := input.path` + `path := ["z"]`      | no    | more than one definition            |
+| `paths[k] := input.paths[k]`                | no    | rule head is not ground             |
+| `path := input.paths[_]`                    | no    | reference contains a variable       |
+| `path := input[input.key]`                  | no    | reference is nested                 |
+
+Statements that capture the alias value in a variable before using it are not
+resolved either, so bare reference checks (`path`), `glob.match`, and `in` where the
+collection is an alias stay unindexed. Comparisons (`path == ["a"]`, `path[_] == "a"`)
+are.
+
+The value read through an alias is the same value the rule would have produced, so
+this does not change evaluation results. Where the alias itself is replaced or
+unknown, the rules are evaluated without the index: statements using a
+[`with`](./policy-language/#with-keyword) mock on the alias (or on a document
+containing it), and, during [partial evaluation](/blog/partial-evaluation-162750eaf422),
+an alias that is unknown or excluded from inlining.
+
 ### Early Exit in Rule Evaluation
 
 In general, OPA has to iterate all potential variable bindings to determine the outcome

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -1162,7 +1162,7 @@ func (c *Compiler) buildRuleIndices() {
 			}
 		}
 
-		index := newBaseDocEqIndex(c.isVirtual)
+		index := newBaseDocEqIndex(c.isVirtual, c.resolveRefAlias)
 		if index.Build(rules) {
 			node.Index = index
 		}
@@ -4569,6 +4569,104 @@ func (n *TreeNode) DepthFirst(f func(*TreeNode) bool) {
 func (c *Compiler) isVirtual(ref Ref) bool {
 	return (c.injectedVirtual != nil && c.injectedVirtual(ref)) ||
 		c.RuleTree.isVirtual(ref.GroundPrefix())
+}
+
+func (c *Compiler) resolveRefAlias(ref Ref) (Ref, []Ref) {
+	var sources []Ref
+	resolved := ref
+	// Arbitrary depth limit, practically more than will be used
+	for range 8 {
+		if c.injectedVirtualRef(resolved) {
+			return nil, nil
+		}
+		prefixLen, rules := c.ruleNodeFor(resolved)
+		if rules == nil {
+			return nil, nil
+		}
+		target := pureAliasTarget(rules)
+		if target == nil {
+			return nil, nil
+		}
+		sources = append(sources, resolved[:prefixLen])
+		next := make(Ref, 0, len(target)+len(resolved)-prefixLen)
+		next = append(next, target...)
+		next = append(next, resolved[prefixLen:]...)
+		resolved = next
+		if !RootDocumentNames.Contains(resolved[0]) || !resolved.IsGround() || resolved.IsNested() {
+			return nil, nil
+		}
+		if !c.isVirtual(resolved) {
+			return resolved, sources
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Compiler) injectedVirtualRef(ref Ref) bool {
+	return c.injectedVirtual != nil && c.injectedVirtual(ref)
+}
+
+func (c *Compiler) ruleNodeFor(ref Ref) (int, []*Rule) {
+	node := c.RuleTree
+	for i := range ref {
+		child := node.Child(ref[i].Value)
+		if child == nil || child.External != nil {
+			return 0, nil
+		}
+		if c.injectedVirtualRef(ref[:i+1]) {
+			return 0, nil
+		}
+		if len(child.Values) > 0 {
+			return i + 1, child.Values
+		}
+		node = child
+	}
+	return 0, nil
+}
+
+func pureAliasTarget(rules []*Rule) Ref {
+	if len(rules) != 1 {
+		return nil
+	}
+
+	rule := rules[0]
+	if rule.Default || rule.Else != nil || len(rule.Head.Args) > 0 ||
+		rule.Head.RuleKind() != SingleValue || rule.Head.Value == nil ||
+		!rule.Head.Reference.IsGround() {
+		return nil
+	}
+
+	v, ok := rule.Head.Value.Value.(Var)
+	if !ok || len(rule.Body) != 1 {
+		return nil
+	}
+
+	expr := rule.Body[0]
+	if expr.Negated || len(expr.With) > 0 || !expr.IsEquality() {
+		return nil
+	}
+
+	a, b := expr.Operand(0), expr.Operand(1)
+	if av, ok := a.Value.(Var); ok && av.Equal(v) {
+		if ref, ok := b.Value.(Ref); ok {
+			return groundUnnestedRootRef(ref)
+		}
+	}
+	if bv, ok := b.Value.(Var); ok && bv.Equal(v) {
+		if ref, ok := a.Value.(Ref); ok {
+			return groundUnnestedRootRef(ref)
+		}
+	}
+
+	return nil
+}
+
+func groundUnnestedRootRef(ref Ref) Ref {
+	if RootDocumentNames.Contains(ref[0]) && ref.IsGround() && !ref.IsNested() {
+		return ref
+	}
+	return nil
 }
 
 // isVirtual returns true if the ref is virtual (has rules).

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -16312,3 +16312,354 @@ func TestQueryCompilerAndOrImports(t *testing.T) {
 		})
 	}
 }
+
+func TestRuleIndexAliasResolution(t *testing.T) {
+	tests := []struct {
+		note       string
+		modules    map[string]string
+		virtual    []string
+		ruleset    string
+		input      string
+		data       string
+		expRules   int
+		expSources []string
+	}{
+		{
+			note: "pure alias substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]
+p if path == ["c"]`,
+			},
+			ruleset:    "data.test.p",
+			input:      `{"path": ["b"]}`,
+			expRules:   1,
+			expSources: []string{"data.alias.path"},
+		},
+		{
+			note: "chained alias substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+req := input.attributes
+method := req.method`,
+				"test.rego": `package test
+import data.alias.method
+p if method == "GET"
+p if method == "PUT"
+p if method == "POST"`,
+			},
+			ruleset:    "data.test.p",
+			input:      `{"attributes": {"method": "GET"}}`,
+			expRules:   1,
+			expSources: []string{"data.alias.method", "data.alias.req"},
+		},
+		{
+			note: "ref suffix below the alias substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+query := input.parsed_query`,
+				"test.rego": `package test
+import data.alias.query
+p if query.plan == ["core"]
+p if query.plan == ["plus"]`,
+			},
+			ruleset:    "data.test.p",
+			input:      `{"parsed_query": {"plan": ["core"]}}`,
+			expRules:   1,
+			expSources: []string{"data.alias.query"},
+		},
+		{
+			note: "alias with default not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+default path := []
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]
+p if path == ["c"]`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"]}`,
+			expRules: 3,
+		},
+		{
+			note: "conditional alias not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path if input.mode == "x"`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"], "mode": "x"}`,
+			expRules: 2,
+		},
+		{
+			note: "multiple alias definitions not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path if input.a
+path := ["z"] if input.b`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"], "a": true}`,
+			expRules: 2,
+		},
+		{
+			note: "alias of a conditional virtual document not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+thing := input.thing if input.mode == "x"
+q := data.alias.thing`,
+				"test.rego": `package test
+import data.alias.q
+p if q == ["a"]
+p if q == ["b"]`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"thing": ["b"], "mode": "x"}`,
+			expRules: 2,
+		},
+		{
+			note: "presence check through alias adds no index dimension",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path
+p if path
+p if path`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"]}`,
+			expRules: 3,
+		},
+		{
+			note: "wildcard ref through alias substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+roles := input.roles`,
+				"test.rego": `package test
+import data.alias.roles
+p if roles[_] == "admin"
+p if roles[_] == "hr"
+p if roles[_] == "dev"`,
+			},
+			ruleset:    "data.test.p",
+			input:      `{"roles": ["hr"]}`,
+			expRules:   1,
+			expSources: []string{"data.alias.roles"},
+		},
+		{
+			note: "membership through alias not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+roles := input.roles`,
+				"test.rego": `package test
+import data.alias.roles
+p if "admin" in roles
+p if "hr" in roles
+p if "dev" in roles`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"roles": ["hr"]}`,
+			expRules: 3,
+		},
+		{
+			note: "glob match through alias not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if glob.match("a:*", [":"], path)
+p if glob.match("b:*", [":"], path)
+p if glob.match("c:*", [":"], path)`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"path": "b:1"}`,
+			expRules: 3,
+		},
+		{
+			note: "alias to a base document under data substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := data.raw.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]
+p if path == ["c"]`,
+			},
+			ruleset:    "data.test.p",
+			input:      `{}`,
+			data:       `{"raw": {"path": ["b"]}}`,
+			expRules:   1,
+			expSources: []string{"data.alias.path"},
+		},
+		{
+			note: "alias to a ref containing a variable not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.paths[_]`,
+				"test.rego": `package test
+import data.alias.path
+p if path == "a"
+p if path == "b"`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"paths": ["b"]}`,
+			expRules: 2,
+		},
+		{
+			note: "alias to a nested ref not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input[input.key]`,
+				"test.rego": `package test
+import data.alias.path
+p if path == "a"
+p if path == "b"`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"key": "k", "k": "b"}`,
+			expRules: 2,
+		},
+		{
+			note: "alias rule with a non-ground head not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+paths[k] := input.paths[k]`,
+				"test.rego": `package test
+p if data.alias.paths.a == "x"
+p if data.alias.paths.a == "y"`,
+			},
+			ruleset:  "data.test.p",
+			input:    `{"paths": {"a": "y"}}`,
+			expRules: 2,
+		},
+		{
+			note: "alias claimed by injected virtual document checker not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]
+p if path == ["c"]`,
+			},
+			virtual:  []string{"data.alias.path"},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"]}`,
+			expRules: 3,
+		},
+		{
+			note: "alias claimed by injected virtual document checker not substituted below the alias",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path[0] == "a"
+p if path[0] == "b"
+p if path[0] == "c"`,
+			},
+			virtual:  []string{"data.alias.path"},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"]}`,
+			expRules: 3,
+		},
+		{
+			note: "alias prefix claimed by injected virtual document checker not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+path := input.path`,
+				"test.rego": `package test
+import data.alias.path
+p if path == ["a"]
+p if path == ["b"]
+p if path == ["c"]`,
+			},
+			virtual:  []string{"data.alias"},
+			ruleset:  "data.test.p",
+			input:    `{"path": ["b"]}`,
+			expRules: 3,
+		},
+		{
+			note: "chained alias claimed by injected virtual document checker not substituted",
+			modules: map[string]string{
+				"alias.rego": `package alias
+req := input.attributes
+method := req.method`,
+				"test.rego": `package test
+import data.alias.method
+p if method == "GET"
+p if method == "PUT"
+p if method == "POST"`,
+			},
+			virtual:  []string{"data.alias.req"},
+			ruleset:  "data.test.p",
+			input:    `{"attributes": {"method": "GET"}}`,
+			expRules: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := NewCompiler()
+			if tc.virtual != nil {
+				c = c.WithVirtual(func(ref Ref) bool { return slices.Contains(tc.virtual, ref.String()) })
+			}
+			names := util.KeysSorted(tc.modules)
+			for _, name := range names {
+				c.Modules[name] = MustParseModule(tc.modules[name])
+				c.sorted = append(c.sorted, name)
+			}
+			compileStages(c, StageBuildRuleIndices)
+			if c.Failed() {
+				t.Fatal(c.Errors)
+			}
+
+			idx := c.RuleIndex(MustParseRef(tc.ruleset))
+			if idx == nil {
+				t.Fatalf("expected rule index for %v", tc.ruleset)
+			}
+
+			resolver := testResolver{input: MustParseTerm(tc.input)}
+			if tc.data != "" {
+				resolver.data = MustParseTerm(tc.data)
+			}
+			result, err := idx.Lookup(resolver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Rules) != tc.expRules {
+				t.Errorf("expected %d candidate rules, got %d", tc.expRules, len(result.Rules))
+			}
+
+			sources := idx.(*baseDocEqIndex).AliasSources()
+			if len(sources) != len(tc.expSources) {
+				t.Fatalf("expected alias sources %v, got %v", tc.expSources, sources)
+			}
+			for _, exp := range tc.expSources {
+				if !slices.ContainsFunc(sources, func(r Ref) bool { return r.String() == exp }) {
+					t.Errorf("expected alias source %v in %v", exp, sources)
+				}
+			}
+		})
+	}
+}

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -49,10 +49,12 @@ type (
 	}
 	baseDocEqIndex struct {
 		isVirtual      func(Ref) bool
+		resolveAlias   func(Ref) (Ref, []Ref)
 		root           *trieNode
 		defaultRule    *Rule
 		kind           RuleKind
 		onlyGroundRefs bool
+		aliasSources   []Ref
 	}
 )
 
@@ -66,9 +68,15 @@ func (ir *IndexResult) Empty() bool {
 	return len(ir.Rules) == 0 && ir.Default == nil
 }
 
-func newBaseDocEqIndex(isVirtual func(Ref) bool) *baseDocEqIndex {
+func newBaseDocEqIndex(isVirtual func(Ref) bool, resolveAliases ...func(Ref) (Ref, []Ref)) *baseDocEqIndex {
+	var resolveAlias func(Ref) (Ref, []Ref)
+	if len(resolveAliases) > 0 {
+		resolveAlias = resolveAliases[0]
+	}
+
 	return &baseDocEqIndex{
 		isVirtual:      isVirtual,
+		resolveAlias:   resolveAlias,
 		root:           newTrieNodeImpl(),
 		onlyGroundRefs: true,
 	}
@@ -81,6 +89,7 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 
 	i.kind = rules[0].Head.RuleKind()
 	indices := newrefindices(i.isVirtual)
+	indices.resolveAlias = i.resolveAlias
 	values := make(map[Var]Value)
 
 	// build indices for each rule.
@@ -102,6 +111,8 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 			return false
 		})
 	}
+
+	i.aliasSources = indices.aliasSources
 
 	// build trie out of indices.
 	for idx := range rules {
@@ -156,6 +167,10 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 		})
 	}
 	return true
+}
+
+func (i *baseDocEqIndex) AliasSources() []Ref {
+	return i.aliasSources
 }
 
 func (i *baseDocEqIndex) Lookup(resolver ValueResolver) (*IndexResult, error) {
@@ -298,10 +313,12 @@ type refindex struct {
 }
 
 type refindices struct {
-	isVirtual func(Ref) bool
-	rules     map[*Rule][]*refindex
-	frequency *util.HasherMap[Ref, int]
-	sorted    []Ref
+	isVirtual    func(Ref) bool
+	resolveAlias func(Ref) (Ref, []Ref)
+	rules        map[*Rule][]*refindex
+	frequency    *util.HasherMap[Ref, int]
+	sorted       []Ref
+	aliasSources []Ref
 }
 
 func newrefindices(isVirtual func(Ref) bool) *refindices {
@@ -376,7 +393,15 @@ func (i *refindices) isValidIndexRef(ref Ref) bool {
 	return RootDocumentNames.Contains(ref[0]) &&
 		!ref.IsNested() &&
 		ref.IsGround() &&
-		!i.isVirtual(ref)
+		(!i.isVirtual(ref) || i.aliasTarget(ref) != nil)
+}
+
+func (i *refindices) aliasTarget(ref Ref) Ref {
+	if i.resolveAlias == nil {
+		return nil
+	}
+	target, _ := i.resolveAlias(ref)
+	return target
 }
 
 // Sorted returns a sorted list of references that the indices were built from.
@@ -604,6 +629,20 @@ func resolveVarToRef(ri []*refindex, args []*Term, v Var) Ref {
 }
 
 func (i *refindices) insert(rule *Rule, index *refindex) {
+	if i.resolveAlias != nil {
+		if resolved, sources := i.resolveAlias(index.Ref); resolved != nil {
+			if _, isVar := index.Value.(Var); isVar {
+				return
+			}
+			index.Ref = resolved
+			for _, src := range sources {
+				if !slices.ContainsFunc(i.aliasSources, func(r Ref) bool { return RefEqual(r, src) }) {
+					i.aliasSources = append(i.aliasSources, src)
+				}
+			}
+		}
+	}
+
 	count, _ := i.frequency.Get(index.Ref)
 	i.frequency.Put(index.Ref, count+1)
 

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -11,6 +11,7 @@ import (
 
 type testResolver struct {
 	input       *Term
+	data        *Term
 	failRef     Ref
 	unknownRefs Set
 	args        []Value
@@ -32,6 +33,16 @@ func (r testResolver) Resolve(ref Ref) (Value, error) {
 	}
 	if ref.HasPrefix(InputRootRef) {
 		v, err := r.input.Value.Find(ref[1:])
+		if err != nil {
+			return nil, nil
+		}
+		return v, nil
+	}
+	if ref.HasPrefix(DefaultRootRef) {
+		if r.data == nil {
+			return nil, nil
+		}
+		v, err := r.data.Value.Find(ref[1:])
 		if err != nil {
 			return nil, nil
 		}

--- a/v1/topdown/alias_index_bench_test.go
+++ b/v1/topdown/alias_index_bench_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+func BenchmarkRuleIndexAliasedRefs(b *testing.B) {
+	aliasModule := `package alias
+
+path := input.path`
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{"aliased", "data.alias.path"},
+		{"direct", "input.path"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var buf strings.Builder
+			buf.WriteString("package test\n\n")
+			for i := 1; i <= 200; i++ {
+				fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]\n\n", tc.ref, i)
+			}
+
+			compiler := ast.NewCompiler()
+			compiler.Compile(map[string]*ast.Module{
+				"alias.rego": ast.MustParseModule(aliasModule),
+				"test.rego":  ast.MustParseModule(buf.String()),
+			})
+			if compiler.Failed() {
+				b.Fatalf("compilation failed: %v", compiler.Errors)
+			}
+
+			store := inmem.New()
+			input := ast.MustParseTerm(`{"path": ["ep200"]}`)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				q := NewQuery(ast.MustParseBody("data.test.p")).
+					WithCompiler(compiler).
+					WithStore(store).
+					WithInput(input)
+
+				rs, err := q.Run(ctx)
+				if err != nil {
+					b.Fatalf("query failed: %v", err)
+				}
+				if len(rs) != 1 {
+					b.Fatalf("expected exactly one result, got %d", len(rs))
+				}
+			}
+		})
+	}
+}

--- a/v1/topdown/alias_index_test.go
+++ b/v1/topdown/alias_index_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "testing"
+
+func TestTopDownRuleIndexAliases(t *testing.T) {
+	aliasModule := `package alias
+
+path := input.path`
+
+	chainedModule := `package alias
+
+req := input.attributes
+
+method := req.method`
+
+	tests := []struct {
+		note     string
+		rules    []string
+		modules  []string
+		input    string
+		expected any
+	}{
+		{
+			note:     "match through alias",
+			rules:    []string{`p if { data.alias.path == ["b"] }`},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["b"]}`,
+			expected: "true",
+		},
+		{
+			note:     "match through chained alias",
+			rules:    []string{`p if { data.alias.method == "GET" }`},
+			modules:  []string{chainedModule},
+			input:    `{"attributes": {"method": "GET"}}`,
+			expected: "true",
+		},
+		{
+			note: "wildcard ref through alias",
+			rules: []string{
+				`p if { data.alias.path[_] == "a" }`,
+				`p if { data.alias.path[_] == "b" }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["b"]}`,
+			expected: "true",
+		},
+		{
+			note: "membership through alias",
+			rules: []string{
+				`p if { "a" in data.alias.path }`,
+				`p if { "b" in data.alias.path }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["b"]}`,
+			expected: "true",
+		},
+		{
+			note: "no wildcard match through alias leaves the rule undefined",
+			rules: []string{
+				`p if { not q }`,
+				`q if { data.alias.path[_] == "a" }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["b"]}`,
+			expected: "true",
+		},
+		{
+			note: "with mock on the alias falls back to the unindexed rule set",
+			rules: []string{
+				`p if { q with data.alias.path as ["b"] }`,
+				`q if { data.alias.path == ["b"] }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["a"]}`,
+			expected: "true",
+		},
+		{
+			note: "with mock on the alias package falls back to the unindexed rule set",
+			rules: []string{
+				`p if { q with data.alias as {"path": ["b"]} }`,
+				`q if { data.alias.path == ["b"] }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["a"]}`,
+			expected: "true",
+		},
+		{
+			note: "with mock on input resolves through the index",
+			rules: []string{
+				`p if { q with input.path as ["b"] }`,
+				`q if { data.alias.path == ["b"] }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{"path": ["a"]}`,
+			expected: "true",
+		},
+		{
+			note: "missing input key leaves the rule undefined",
+			rules: []string{
+				`p if { not q }`,
+				`q if { data.alias.path == ["b"] }`,
+			},
+			modules:  []string{aliasModule},
+			input:    `{}`,
+			expected: "true",
+		},
+	}
+
+	for _, tc := range tests {
+		runTopDownTestCaseWithModules(t, map[string]any{}, tc.note, tc.rules, tc.modules, tc.input, tc.expected)
+	}
+}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1772,7 +1772,13 @@ func (e *eval) getRules(ref ast.Ref, args []*ast.Term, index ast.RuleIndex) (*as
 	var err error
 
 	resolver.e = e
-	if e.indexing {
+	useIndex := e.indexing
+	if useIndex {
+		if asi, ok := index.(aliasSourceIndex); ok {
+			useIndex = !slices.ContainsFunc(asi.AliasSources(), e.aliasSourceOverridden)
+		}
+	}
+	if useIndex {
 		resolver.args = args
 		result, err = index.Lookup(resolver)
 	} else {
@@ -1810,6 +1816,14 @@ func (e *eval) getRules(ref ast.Ref, args []*ast.Term, index ast.RuleIndex) (*as
 
 func (e *eval) Resolve(ref ast.Ref) (ast.Value, error) {
 	return (&evalResolver{e: e}).Resolve(ref)
+}
+
+type aliasSourceIndex interface {
+	AliasSources() []ast.Ref
+}
+
+func (e *eval) aliasSourceOverridden(ref ast.Ref) bool {
+	return e.targetStack.Prefixed(ref) || e.unknownRef(ref, nil)
 }
 
 type evalResolver struct {

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -4824,6 +4824,95 @@ q if { input.x = 7 }`},
 				`x1 = input.y[c1]; x1.z = 1 and {__local0__1 = x1.z; neq(__local0__1, 2)}`,
 			},
 		},
+		{
+			note:  "alias index: alias source known",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package alias
+
+				path := input.path`,
+				`package test
+
+				import data.alias.path
+
+				p if path == ["a"]
+				p if path == ["b"]
+				p if path == ["c"]`,
+			},
+			unknowns:    []string{`data.other`},
+			input:       `{"path": ["b"]}`,
+			wantQueries: []string{``},
+		},
+		{
+			note:  "alias index: alias source unknown",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package alias
+
+				path := input.path`,
+				`package test
+
+				import data.alias.path
+
+				p if path == ["a"]
+				p if path == ["b"]
+				p if path == ["c"]`,
+			},
+			unknowns: []string{`data.alias`},
+			input:    `{"path": ["b"]}`,
+			wantQueries: []string{
+				`data.alias.path = ["a"]`,
+				`data.alias.path = ["b"]`,
+				`data.alias.path = ["c"]`,
+			},
+		},
+		{
+			note:  "alias index: alias source unknown by exact ref",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package alias
+
+				path := input.path`,
+				`package test
+
+				import data.alias.path
+
+				p if path == ["a"]
+				p if path == ["b"]
+				p if path == ["c"]`,
+			},
+			unknowns: []string{`data.alias.path`},
+			input:    `{"path": ["b"]}`,
+			wantQueries: []string{
+				`data.alias.path = ["a"]`,
+				`data.alias.path = ["b"]`,
+				`data.alias.path = ["c"]`,
+			},
+		},
+		{
+			note:  "alias index: intermediate alias source unknown",
+			query: `data.test.p = true`,
+			modules: []string{
+				`package alias
+
+				req := input.attributes
+				method := req.method`,
+				`package test
+
+				import data.alias.method
+
+				p if method == "GET"
+				p if method == "PUT"
+				p if method == "POST"`,
+			},
+			unknowns: []string{`data.alias.req`},
+			input:    `{"attributes": {"method": "GET"}}`,
+			wantQueries: []string{
+				`"GET" = data.alias.req.method`,
+				`"PUT" = data.alias.req.method`,
+				`"POST" = data.alias.req.method`,
+			},
+		},
 	}
 
 	ctx := t.Context()


### PR DESCRIPTION
### Why the changes in this PR are needed?

Indexing aliases allows rules that use aliases to get the performance benefits of indexing, while keeping the ergonomics of aliases/variables. I believe this addresses the theme of https://github.com/open-policy-agent/opa/issues/642 but am happy to open an issue for discussion if anyone disagrees.

I run OPA as an external authorization service for Istio, and we use aliases for every rule. Our setup looks like
```rego
# http_request.rego
request := input.attributes.request.http
method := request.method
path := input.parsed_path
query := input.parsed_query
api_version := request.headers["accept-version"]
```

then our service policies typically look like
```rego
allow if {
	api_version == "2"
	method == "GET"
	path = ["accounts", account_id] # Account ID from user JWT
	groups.members
}
```

Today these are not indexable without replacing references to `input` directly (eg `method` -> `input.attributes.request.http.method` in my `allow` rule)

### What are the changes in this PR?

Index simple aliases

### Notes to assist PR review:

Performance was tested with:

```rego
# alias.rego
package example

import rego.v1

path := input.path
```

```rego
# rules.rego - 200 rules matching through the alias
package t

import rego.v1

import data.example.path

allow if path == ["ep1"]
allow if path == ["ep2"]
# ... continuing through ep200
```

```sh
echo '{"path": ["ep200"]}' > input.json
opa bench -d alias.rego -d rules.rego -i input.json --benchmem 'data.t.allow'
```

Matching the last of the 200 rules (darwin/arm64, median of 3):

| spelling | main (551581fee) | this change |
| --- | --- | --- |
| `path == ["ep200"]` (alias) | 774 us / 2,074 allocs | **7.8 us / 83 allocs** |
| `input.path == ["ep200"]` (direct) | 6.6 us / 65 allocs | 6.3 us / 65 allocs |
