### PR TITLE
Inline aliases in compiler

### DIFF
--- a/cmd/test_jsonv2_test.go
+++ b/cmd/test_jsonv2_test.go
@@ -573,8 +573,9 @@ test_foo if {
 `,
 				"data.json": `{"c": 3}`,
 			},
-			// Note: each dynamic array element is broken out into a separate "co-expression" by the compiler.
-			// Since we failed on the 2nd element (b), we don't have value for the 3rd element (data.c).
+			// Note: `b` is an alias rule, so the compiler inlines it and the statement
+			// becomes indexable. The index rules the body out without evaluating it, so
+			// there is no failing expression inside the body to annotate.
 			expected: `%ROOT%/test.rego:7:
 data.test.test_foo: FAIL (%TIME%)
 --------------------------------------------------------------------------------
@@ -582,11 +583,6 @@ FAILURES
 --------------------------------------------------------------------------------
 data.test.test_foo: FAIL (%TIME%)
 
-  %ROOT%/test.rego:8:
-    	[a, b, data.c] == [4, 5, 6]
-    	 |  |
-    	 |  undefined
-    	 1
 
 --------------------------------------------------------------------------------
 FAIL: 1/1

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -575,8 +575,9 @@ test_foo if {
 `,
 				"data.json": `{"c": 3}`,
 			},
-			// Note: each dynamic array element is broken out into a separate "co-expression" by the compiler.
-			// Since we failed on the 2nd element (b), we don't have value for the 3rd element (data.c).
+			// Note: `b` is an alias rule, so the compiler inlines it and the statement
+			// becomes indexable. The index rules the body out without evaluating it, so
+			// there is no failing expression inside the body to annotate.
 			expected: `%ROOT%/test.rego:7:
 data.test.test_foo: FAIL (%TIME%)
 --------------------------------------------------------------------------------
@@ -584,11 +585,6 @@ FAILURES
 --------------------------------------------------------------------------------
 data.test.test_foo: FAIL (%TIME%)
 
-  %ROOT%/test.rego:8:
-    	[a, b, data.c] == [4, 5, 6]
-    	 |  |
-    	 |  undefined
-    	 1
 
 --------------------------------------------------------------------------------
 FAIL: 1/1

--- a/v1/ast/alias_compile_bench_test.go
+++ b/v1/ast/alias_compile_bench_test.go
@@ -1,0 +1,50 @@
+package ast
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func BenchmarkCompileAliasedRefs(b *testing.B) {
+	aliasModule := `package alias
+
+path := input.path`
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{"aliased", "data.alias.path"},
+		{"direct", "input.path"},
+	} {
+		for _, n := range []int{200, 2000} {
+			b.Run(fmt.Sprintf("%s/%d", tc.name, n), func(b *testing.B) {
+				var buf strings.Builder
+				buf.WriteString("package test\n\n")
+				for i := 1; i <= n; i++ {
+					fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]\n\n", tc.ref, i)
+				}
+				baseAlias := MustParseModule(aliasModule)
+				baseTest := MustParseModule(buf.String())
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					b.StopTimer()
+					mods := map[string]*Module{
+						"alias.rego": baseAlias.Copy(),
+						"test.rego":  baseTest.Copy(),
+					}
+					b.StartTimer()
+
+					c := NewCompiler()
+					if c.Compile(mods); c.Failed() {
+						b.Fatal(c.Errors)
+					}
+				}
+			})
+		}
+	}
+}

--- a/v1/ast/alias_compile_bench_test.go
+++ b/v1/ast/alias_compile_bench_test.go
@@ -14,16 +14,26 @@ path := input.path`
 	for _, tc := range []struct {
 		name string
 		ref  string
+		with bool
 	}{
-		{"aliased", "data.alias.path"},
-		{"direct", "input.path"},
+		{"aliased", "data.alias.path", false},
+		{"aliased_with_input", "data.alias.path", true},
+		{"direct", "input.path", false},
 	} {
 		for _, n := range []int{200, 2000} {
 			b.Run(fmt.Sprintf("%s/%d", tc.name, n), func(b *testing.B) {
 				var buf strings.Builder
 				buf.WriteString("package test\n\n")
+				with := ""
+				if tc.with {
+					with = ` with input as {"path": ["ep%d"]}`
+				}
 				for i := 1; i <= n; i++ {
-					fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]\n\n", tc.ref, i)
+					if tc.with {
+						fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]"+with+"\n\n", tc.ref, i, i)
+					} else {
+						fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]\n\n", tc.ref, i)
+					}
 				}
 				baseAlias := MustParseModule(aliasModule)
 				baseTest := MustParseModule(buf.String())

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -209,6 +209,7 @@ const (
 	StageCheckTypes                 StageID = "CheckTypes"
 	StageCheckUnsafeBuiltins        StageID = "CheckUnsafeBuiltins"
 	StageCheckDeprecatedBuiltins    StageID = "CheckDeprecatedBuiltins"
+	StageInlineRefAliases           StageID = "InlineRefAliases"
 	StageBuildRuleIndices           StageID = "BuildRuleIndices"
 	StageBuildComprehensionIndices  StageID = "BuildComprehensionIndices"
 	StageBuildRequiredCapabilities  StageID = "BuildRequiredCapabilities"
@@ -251,6 +252,7 @@ func AllStages() []StageID {
 		StageCheckTypes,
 		StageCheckUnsafeBuiltins,
 		StageCheckDeprecatedBuiltins,
+		StageInlineRefAliases,
 		StageBuildRuleIndices,
 		StageBuildComprehensionIndices,
 		StageBuildRequiredCapabilities,
@@ -472,6 +474,7 @@ func NewCompiler() *Compiler {
 		{StageCheckTypes, "compile_stage_check_types", c.checkTypes}, // must be run after CheckRecursion
 		{StageCheckUnsafeBuiltins, "compile_state_check_unsafe_builtins", c.checkUnsafeBuiltins},
 		{StageCheckDeprecatedBuiltins, "compile_state_check_deprecated_builtins", c.checkDeprecatedBuiltins},
+		{StageInlineRefAliases, "compile_stage_inline_ref_aliases", c.inlineRefAliases},
 		{StageBuildRuleIndices, "compile_stage_rebuild_indices", c.buildRuleIndices},
 		{StageBuildComprehensionIndices, "compile_stage_rebuild_comprehension_indices", c.buildComprehensionIndices},
 		{StageBuildRequiredCapabilities, "compile_stage_build_required_capabilities", c.buildRequiredCapabilities},

--- a/v1/ast/compile_stage_test.go
+++ b/v1/ast/compile_stage_test.go
@@ -207,7 +207,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to BuildRuleIndices",
 			target:        StageBuildRuleIndices,
-			expectedCount: 32, // includes "after" stage from init()
+			expectedCount: 33,
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageCheckTypes,
@@ -221,7 +221,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to last stage",
 			target:        StageBuildRequiredCapabilities,
-			expectedCount: 34, // includes "after" stage from init()
+			expectedCount: 35,
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageBuildRequiredCapabilities,

--- a/v1/ast/compile_stage_test.go
+++ b/v1/ast/compile_stage_test.go
@@ -207,7 +207,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to BuildRuleIndices",
 			target:        StageBuildRuleIndices,
-			expectedCount: 33,
+			expectedCount: 33, // includes "after" stage from init()
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageCheckTypes,
@@ -221,7 +221,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to last stage",
 			target:        StageBuildRequiredCapabilities,
-			expectedCount: 35,
+			expectedCount: 35, // includes "after" stage from init()
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageBuildRequiredCapabilities,

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -158,7 +158,7 @@ type inlinedAlias struct {
 }
 
 type aliasCache struct {
-	entries map[String]inlinedAlias
+	entries map[string]inlinedAlias
 }
 
 func (c *Compiler) inlineAliasesInBody(body Body, blocked []Ref, cache *aliasCache) {
@@ -209,7 +209,7 @@ func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache *aliasCache) (Re
 		return nil, false
 	}
 
-	key := String(ref.String())
+	key := ref.String()
 	if hit, ok := cache.entries[key]; ok {
 		return hit.resolved, hit.ok
 	}
@@ -229,7 +229,7 @@ func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache *aliasCache) (Re
 	}
 
 	if cache.entries == nil {
-		cache.entries = map[String]inlinedAlias{}
+		cache.entries = map[string]inlinedAlias{}
 	}
 	cache.entries[key] = inlinedAlias{resolved: resolved, ok: ok}
 

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -216,7 +216,7 @@ func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache map[String]inlin
 	resolved, sources := c.resolveRefAlias(ref)
 	ok := resolved != nil
 	if ok {
-		for _, src := range append(sources, resolved) {
+		for _, src := range sources {
 			if refOverlapsAny(src, blocked) {
 				ok = false
 				break

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -24,9 +24,6 @@ func (c *Compiler) inlineRefAliases() {
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
 		WalkRules(mod, func(rule *Rule) bool {
-			if strings.HasPrefix(string(rule.Head.Name), "test_") {
-				return false
-			}
 
 			blocked := blockedRules[rule]
 			cacheKey := blockedCacheKey(blocked)

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -4,15 +4,22 @@
 
 package ast
 
-import "strings"
+import (
+	"maps"
+	"sort"
+	"strings"
+)
 
 func (c *Compiler) inlineRefAliases() {
 	if len(c.Modules) == 0 {
 		return
 	}
+	if !c.hasPureAliasRules() {
+		return
+	}
 
-	scopes := c.withScopes()
-	cache := map[*Rule]map[String]inlinedAlias{}
+	blockedRules := c.withScopes()
+	caches := map[string]map[String]inlinedAlias{"": {}}
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
@@ -21,30 +28,49 @@ func (c *Compiler) inlineRefAliases() {
 				return false
 			}
 
-			blocked := blockedForRule(scopes, rule)
-			if cache[rule] == nil {
-				cache[rule] = map[String]inlinedAlias{}
+			blocked := blockedRules[rule]
+			cacheKey := blockedCacheKey(blocked)
+			cache, ok := caches[cacheKey]
+			if !ok {
+				cache = map[String]inlinedAlias{}
+				caches[cacheKey] = cache
 			}
-			c.inlineAliasesInBody(rule.Body, blocked, cache[rule])
+			c.inlineAliasesInBody(rule.Body, blocked, cache)
 			return false
 		})
 	}
 }
 
-type withScope struct {
-	target    Ref
-	reachable map[*Rule]struct{}
+func (c *Compiler) hasPureAliasRules() bool {
+	for _, name := range c.sorted {
+		found := false
+		WalkRules(c.Modules[name], func(rule *Rule) bool {
+			if !found {
+				found = pureAliasTarget([]*Rule{rule}) != nil
+			}
+			return false
+		})
+		if found {
+			return true
+		}
+	}
+	return false
 }
 
-func (c *Compiler) withScopes() []withScope {
-	var scopes []withScope
+func (c *Compiler) withScopes() map[*Rule][]Ref {
+	type scopeGroup struct {
+		target Ref
+		seeds  map[*Rule]struct{}
+	}
+
+	groups := map[string]*scopeGroup{}
 
 	for _, name := range c.sorted {
 		WalkExprs(c.Modules[name], func(expr *Expr) bool {
 			if len(expr.With) == 0 {
 				return false
 			}
-			reachable := c.rulesReachableFrom(expr)
+			seeds := c.seedRulesFrom(expr)
 			for _, w := range expr.With {
 				ref, ok := w.Target.Value.(Ref)
 				if !ok {
@@ -54,30 +80,49 @@ func (c *Compiler) withScopes() []withScope {
 				if len(ground) == 0 {
 					continue
 				}
-				scopes = append(scopes, withScope{target: ground, reachable: reachable})
+				key := ground.String()
+				group := groups[key]
+				if group == nil {
+					group = &scopeGroup{target: ground, seeds: map[*Rule]struct{}{}}
+					groups[key] = group
+				}
+				for rule := range seeds {
+					group.seeds[rule] = struct{}{}
+				}
 			}
 			return false
 		})
 	}
 
-	return scopes
+	blocked := map[*Rule][]Ref{}
+	for _, group := range groups {
+		for rule := range c.rulesReachableFrom(group.seeds) {
+			blocked[rule] = append(blocked[rule], group.target)
+		}
+	}
+	return blocked
 }
 
-func (c *Compiler) rulesReachableFrom(expr *Expr) map[*Rule]struct{} {
-	reachable := map[*Rule]struct{}{}
-
-	var queue []*Rule
+func (c *Compiler) seedRulesFrom(expr *Expr) map[*Rule]struct{} {
+	seeds := map[*Rule]struct{}{}
 	WalkRefs(expr, func(ref Ref) bool {
 		for _, rule := range c.GetRulesDynamic(ref.ConstantPrefix()) {
 			for node := rule; node != nil; node = node.Else {
-				if _, seen := reachable[node]; !seen {
-					reachable[node] = struct{}{}
-					queue = append(queue, node)
-				}
+				seeds[node] = struct{}{}
 			}
 		}
 		return false
 	})
+	return seeds
+}
+
+func (c *Compiler) rulesReachableFrom(seeds map[*Rule]struct{}) map[*Rule]struct{} {
+	reachable := maps.Clone(seeds)
+
+	queue := make([]*Rule, 0, len(seeds))
+	for rule := range seeds {
+		queue = append(queue, rule)
+	}
 
 	for len(queue) > 0 {
 		rule := queue[0]
@@ -97,15 +142,17 @@ func (c *Compiler) rulesReachableFrom(expr *Expr) map[*Rule]struct{} {
 	return reachable
 }
 
-func blockedForRule(scopes []withScope, rule *Rule) []Ref {
-	var blocked []Ref
-	for _, scope := range scopes {
-		if _, ok := scope.reachable[rule]; ok {
-			blocked = append(blocked, scope.target)
-		}
+func blockedCacheKey(blocked []Ref) string {
+	if len(blocked) == 0 {
+		return ""
 	}
 
-	return blocked
+	keys := make([]string, len(blocked))
+	for i := range blocked {
+		keys[i] = blocked[i].String()
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "\x00")
 }
 
 type inlinedAlias struct {

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -19,7 +19,7 @@ func (c *Compiler) inlineRefAliases() {
 	}
 
 	blockedRules := c.withScopes()
-	caches := map[string]map[String]inlinedAlias{"": {}}
+	caches := map[string]*aliasCache{"": {}}
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
@@ -29,7 +29,7 @@ func (c *Compiler) inlineRefAliases() {
 			cacheKey := blockedCacheKey(blocked)
 			cache, ok := caches[cacheKey]
 			if !ok {
-				cache = map[String]inlinedAlias{}
+				cache = &aliasCache{}
 				caches[cacheKey] = cache
 			}
 			c.inlineAliasesInBody(rule.Body, blocked, cache)
@@ -157,7 +157,11 @@ type inlinedAlias struct {
 	ok       bool
 }
 
-func (c *Compiler) inlineAliasesInBody(body Body, blocked []Ref, cache map[String]inlinedAlias) {
+type aliasCache struct {
+	entries map[String]inlinedAlias
+}
+
+func (c *Compiler) inlineAliasesInBody(body Body, blocked []Ref, cache *aliasCache) {
 	for _, expr := range body {
 		if len(expr.With) > 0 {
 			continue
@@ -196,7 +200,7 @@ func (c *Compiler) inlineAliasesInBody(body Body, blocked []Ref, cache map[Strin
 	}
 }
 
-func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache map[String]inlinedAlias) (Ref, bool) {
+func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache *aliasCache) (Ref, bool) {
 	if !RootDocumentNames.Contains(ref[0]) || !ref.IsGround() || ref.IsNested() {
 		return nil, false
 	}
@@ -206,7 +210,7 @@ func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache map[String]inlin
 	}
 
 	key := String(ref.String())
-	if hit, ok := cache[key]; ok {
+	if hit, ok := cache.entries[key]; ok {
 		return hit.resolved, hit.ok
 	}
 
@@ -224,7 +228,10 @@ func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache map[String]inlin
 		resolved = nil
 	}
 
-	cache[key] = inlinedAlias{resolved: resolved, ok: ok}
+	if cache.entries == nil {
+		cache.entries = map[String]inlinedAlias{}
+	}
+	cache.entries[key] = inlinedAlias{resolved: resolved, ok: ok}
 
 	return resolved, ok
 }

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -69,9 +69,11 @@ func (c *Compiler) rulesReachableFrom(expr *Expr) map[*Rule]struct{} {
 	var queue []*Rule
 	WalkRefs(expr, func(ref Ref) bool {
 		for _, rule := range c.GetRulesDynamic(ref.ConstantPrefix()) {
-			if _, seen := reachable[rule]; !seen {
-				reachable[rule] = struct{}{}
-				queue = append(queue, rule)
+			for node := rule; node != nil; node = node.Else {
+				if _, seen := reachable[node]; !seen {
+					reachable[node] = struct{}{}
+					queue = append(queue, node)
+				}
 			}
 		}
 		return false

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -1,0 +1,292 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import "strings"
+
+func (c *Compiler) inlineRefAliases() {
+	if len(c.Modules) == 0 {
+		return
+	}
+
+	scopes := c.withScopes()
+	cache := map[*Rule]map[String]inlinedAlias{}
+
+	for _, name := range c.sorted {
+		mod := c.Modules[name]
+		WalkRules(mod, func(rule *Rule) bool {
+			if strings.HasPrefix(string(rule.Head.Name), "test_") {
+				return false
+			}
+
+			blocked := blockedForRule(scopes, rule)
+			if cache[rule] == nil {
+				cache[rule] = map[String]inlinedAlias{}
+			}
+			c.inlineAliasesInBody(rule.Body, blocked, cache[rule])
+			return false
+		})
+	}
+}
+
+type withScope struct {
+	target    Ref
+	reachable map[*Rule]struct{}
+}
+
+func (c *Compiler) withScopes() []withScope {
+	var scopes []withScope
+
+	for _, name := range c.sorted {
+		WalkExprs(c.Modules[name], func(expr *Expr) bool {
+			if len(expr.With) == 0 {
+				return false
+			}
+			reachable := c.rulesReachableFrom(expr)
+			for _, w := range expr.With {
+				ref, ok := w.Target.Value.(Ref)
+				if !ok {
+					continue
+				}
+				ground := ref.ConstantPrefix()
+				if len(ground) == 0 {
+					continue
+				}
+				scopes = append(scopes, withScope{target: ground, reachable: reachable})
+			}
+			return false
+		})
+	}
+
+	return scopes
+}
+
+func (c *Compiler) rulesReachableFrom(expr *Expr) map[*Rule]struct{} {
+	reachable := map[*Rule]struct{}{}
+
+	var queue []*Rule
+	WalkRefs(expr, func(ref Ref) bool {
+		for _, rule := range c.GetRulesDynamic(ref.ConstantPrefix()) {
+			if _, seen := reachable[rule]; !seen {
+				reachable[rule] = struct{}{}
+				queue = append(queue, rule)
+			}
+		}
+		return false
+	})
+
+	for len(queue) > 0 {
+		rule := queue[0]
+		queue = queue[1:]
+		for dep := range c.Graph.Dependencies(rule) {
+			depRule, ok := dep.(*Rule)
+			if !ok {
+				continue
+			}
+			if _, seen := reachable[depRule]; !seen {
+				reachable[depRule] = struct{}{}
+				queue = append(queue, depRule)
+			}
+		}
+	}
+
+	return reachable
+}
+
+func blockedForRule(scopes []withScope, rule *Rule) []Ref {
+	var blocked []Ref
+	for _, scope := range scopes {
+		if _, ok := scope.reachable[rule]; ok {
+			blocked = append(blocked, scope.target)
+		}
+	}
+
+	return blocked
+}
+
+type inlinedAlias struct {
+	resolved Ref
+	ok       bool
+}
+
+func (c *Compiler) inlineAliasesInBody(body Body, blocked []Ref, cache map[String]inlinedAlias) {
+	for _, expr := range body {
+		if len(expr.With) > 0 {
+			continue
+		}
+
+		WalkTerms(expr, func(term *Term) bool {
+			switch term.Value.(type) {
+			case *ArrayComprehension, *SetComprehension, *ObjectComprehension:
+				return true
+			}
+
+			ref, ok := term.Value.(Ref)
+			if !ok {
+				return false
+			}
+			if resolved, ok := c.inlinableAlias(ref, blocked, cache); ok {
+				term.Value = resolved
+				return true
+			}
+			return false
+		})
+
+		WalkClosures(expr, func(x any) bool {
+			switch x := x.(type) {
+			case *ArrayComprehension:
+				c.inlineAliasesInBody(x.Body, blocked, cache)
+			case *SetComprehension:
+				c.inlineAliasesInBody(x.Body, blocked, cache)
+			case *ObjectComprehension:
+				c.inlineAliasesInBody(x.Body, blocked, cache)
+			case *Every:
+				c.inlineAliasesInBody(x.Body, blocked, cache)
+			}
+			return true
+		})
+	}
+}
+
+func (c *Compiler) inlinableAlias(ref Ref, blocked []Ref, cache map[String]inlinedAlias) (Ref, bool) {
+	if !RootDocumentNames.Contains(ref[0]) || !ref.IsGround() || ref.IsNested() {
+		return nil, false
+	}
+
+	if !c.isVirtual(ref) {
+		return nil, false
+	}
+
+	key := String(ref.String())
+	if hit, ok := cache[key]; ok {
+		return hit.resolved, hit.ok
+	}
+
+	resolved, sources := c.resolveRefAlias(ref)
+	ok := resolved != nil
+	if ok {
+		for _, src := range append(sources, resolved) {
+			if refOverlapsAny(src, blocked) {
+				ok = false
+				break
+			}
+		}
+	}
+	if !ok {
+		resolved = nil
+	}
+
+	cache[key] = inlinedAlias{resolved: resolved, ok: ok}
+
+	return resolved, ok
+}
+
+func refOverlapsAny(ref Ref, others []Ref) bool {
+	for _, other := range others {
+		if ref.HasPrefix(other) || other.HasPrefix(ref) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *Compiler) resolveRefAlias(ref Ref) (Ref, []Ref) {
+	var sources []Ref
+	resolved := ref
+	// Arbitrary depth limit, practically more than will be used
+	for range 8 {
+		if c.injectedVirtualRef(resolved) {
+			return nil, nil
+		}
+		prefixLen, rules := c.ruleNodeFor(resolved)
+		if rules == nil {
+			return nil, nil
+		}
+		target := pureAliasTarget(rules)
+		if target == nil {
+			return nil, nil
+		}
+		sources = append(sources, resolved[:prefixLen])
+		next := make(Ref, 0, len(target)+len(resolved)-prefixLen)
+		next = append(next, target...)
+		next = append(next, resolved[prefixLen:]...)
+		resolved = next
+		if !RootDocumentNames.Contains(resolved[0]) || !resolved.IsGround() || resolved.IsNested() {
+			return nil, nil
+		}
+		if !c.isVirtual(resolved) {
+			return resolved, sources
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Compiler) injectedVirtualRef(ref Ref) bool {
+	return c.injectedVirtual != nil && c.injectedVirtual(ref)
+}
+
+func (c *Compiler) ruleNodeFor(ref Ref) (int, []*Rule) {
+	node := c.RuleTree
+	for i := range ref {
+		child := node.Child(ref[i].Value)
+		if child == nil || child.External != nil {
+			return 0, nil
+		}
+		if c.injectedVirtualRef(ref[:i+1]) {
+			return 0, nil
+		}
+		if len(child.Values) > 0 {
+			return i + 1, child.Values
+		}
+		node = child
+	}
+	return 0, nil
+}
+
+func pureAliasTarget(rules []*Rule) Ref {
+	if len(rules) != 1 {
+		return nil
+	}
+
+	rule := rules[0]
+	if rule.Default || rule.Else != nil || len(rule.Head.Args) > 0 ||
+		rule.Head.RuleKind() != SingleValue || rule.Head.Value == nil ||
+		!rule.Head.Reference.IsGround() {
+		return nil
+	}
+
+	v, ok := rule.Head.Value.Value.(Var)
+	if !ok || len(rule.Body) != 1 {
+		return nil
+	}
+
+	expr := rule.Body[0]
+	if expr.Negated || len(expr.With) > 0 || !expr.IsEquality() {
+		return nil
+	}
+
+	a, b := expr.Operand(0), expr.Operand(1)
+	if av, ok := a.Value.(Var); ok && av.Equal(v) {
+		if ref, ok := b.Value.(Ref); ok {
+			return groundUnnestedRootRef(ref)
+		}
+	}
+	if bv, ok := b.Value.(Var); ok && bv.Equal(v) {
+		if ref, ok := a.Value.(Ref); ok {
+			return groundUnnestedRootRef(ref)
+		}
+	}
+
+	return nil
+}
+
+func groundUnnestedRootRef(ref Ref) Ref {
+	if RootDocumentNames.Contains(ref[0]) && ref.IsGround() && !ref.IsNested() {
+		return ref
+	}
+	return nil
+}

--- a/v1/ast/inline_aliases.go
+++ b/v1/ast/inline_aliases.go
@@ -6,7 +6,7 @@ package ast
 
 import (
 	"maps"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -148,7 +148,7 @@ func blockedCacheKey(blocked []Ref) string {
 	for i := range blocked {
 		keys[i] = blocked[i].String()
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return strings.Join(keys, "\x00")
 }
 

--- a/v1/ast/inline_aliases_test.go
+++ b/v1/ast/inline_aliases_test.go
@@ -79,8 +79,6 @@ func TestInlineAliasesLeavesNonAliasRulesAlone(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"policy.rego": `package test
 
-import rego.v1
-
 p if {
 	input.attributes.request.http.method == "GET"
 	data.config.enabled
@@ -97,8 +95,6 @@ func TestInlineAliasesRewritesAliasReferences(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"http.rego": `package http
 
-import rego.v1
-
 request := input.attributes.request.http
 
 method := request.method
@@ -106,7 +102,6 @@ method := request.method
 		"policy.rego": `package test
 
 import data.http.method
-import rego.v1
 
 p if method == "GET"
 `,
@@ -121,13 +116,9 @@ func TestInlineAliasesRewritesReferenceBelowAlias(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"http.rego": `package http
 
-import rego.v1
-
 request := input.attributes.request.http
 `,
 		"policy.rego": `package test
-
-import rego.v1
 
 p if data.http.request.host == "example.com"
 `,
@@ -141,7 +132,7 @@ p if data.http.request.host == "example.com"
 func TestInlineAliasesDepthLimit(t *testing.T) {
 	chain := func(n int) string {
 		var b strings.Builder
-		b.WriteString("package chain\n\nimport rego.v1\n\n")
+		b.WriteString("package chain\n\n")
 		for i := n - 1; i >= 1; i-- {
 			fmt.Fprintf(&b, "a%d := a%d\n\n", i, i-1)
 		}
@@ -164,8 +155,6 @@ func TestInlineAliasesDepthLimit(t *testing.T) {
 			c := compileForInlining(t, map[string]string{
 				"zzz_chain.rego": chain(tc.hops),
 				"aaa_policy.rego": fmt.Sprintf(`package test
-
-import rego.v1
 
 p if %s == 1
 `, last),
@@ -234,8 +223,8 @@ func TestInlineAliasesRejectsNonAliasShapes(t *testing.T) {
 				consumer = "p if data.alias.v == 1"
 			}
 			c := compileForInlining(t, map[string]string{
-				"alias.rego":  "package alias\n\nimport rego.v1\n\n" + tc.alias + "\n",
-				"policy.rego": "package test\n\nimport rego.v1\n\n" + consumer + "\n",
+				"alias.rego":  "package alias\n\n" + tc.alias + "\n",
+				"policy.rego": "package test\n\n" + consumer + "\n",
 			})
 
 			assertRefs(t, c, "policy.rego", "p",
@@ -261,15 +250,11 @@ func TestInlineAliasesWithInScopeBlocks(t *testing.T) {
 			c := compileForInlining(t, map[string]string{
 				"http.rego": `package http
 
-import rego.v1
-
 request := input.attributes.request.http
 
 method := request.method
 `,
 				"policy.rego": fmt.Sprintf(`package test
-
-import rego.v1
 
 p if data.http.method == "GET"
 
@@ -294,29 +279,21 @@ func TestInlineAliasesWithOutOfScopeDoesNotBlock(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"http.rego": `package http
 
-import rego.v1
-
 request := input.attributes.request.http
 
 method := request.method
 `,
 		"policy.rego": `package test
 
-import rego.v1
-
 p if data.http.method == "GET"
 `,
 		"masking.rego": `package system.log
-
-import rego.v1
 
 mask contains "/input/x" if {
 	data.other.claims with input as input.input
 }
 `,
 		"other.rego": `package other
-
-import rego.v1
 
 claims := input.claims
 `,
@@ -335,13 +312,9 @@ func TestInlineAliasesWithInsideComprehension(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"alias.rego": `package alias
 
-import rego.v1
-
 v := input.x
 `,
 		"policy.rego": `package test
-
-import rego.v1
 
 p := xs if {
 	xs := {y | y := data.alias.v with input as {"x": 42}}
@@ -354,17 +327,13 @@ p := xs if {
 		[]string{"input.x"})
 }
 
-func TestInlineAliasesSkipsTestRules(t *testing.T) {
+func TestInlineAliasesProcessesTestRules(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"alias.rego": `package alias
-
-import rego.v1
 
 v := input.x
 `,
 		"policy_test.rego": `package test
-
-import rego.v1
 
 test_foo if data.alias.v == 1
 
@@ -373,8 +342,8 @@ helper if data.alias.v == 1
 	})
 
 	assertRefs(t, c, "policy_test.rego", "test_foo",
-		[]string{"data.alias.v"},
-		[]string{"input.x"})
+		[]string{"input.x"},
+		[]string{"data.alias.v"})
 
 	assertRefs(t, c, "policy_test.rego", "helper",
 		[]string{"input.x"},
@@ -384,8 +353,6 @@ helper if data.alias.v == 1
 func TestInlineAliasesResolvesDataRootedAlias(t *testing.T) {
 	c := compileForInlining(t, map[string]string{
 		"alias.rego": `package alias
-
-import rego.v1
 
 path := data.request.path
 `,

--- a/v1/ast/inline_aliases_test.go
+++ b/v1/ast/inline_aliases_test.go
@@ -384,8 +384,6 @@ path := data.request.path
 `,
 		"policy.rego": `package test
 
-import rego.v1
-
 p if data.alias.path == ["a"]
 `,
 	})

--- a/v1/ast/inline_aliases_test.go
+++ b/v1/ast/inline_aliases_test.go
@@ -1,0 +1,396 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func compileForInlining(t *testing.T, modules map[string]string) *Compiler {
+	t.Helper()
+
+	parsed := map[string]*Module{}
+	for name, src := range modules {
+		parsed[name] = MustParseModule(src)
+	}
+
+	c := NewCompiler()
+	if c.Compile(parsed); c.Failed() {
+		t.Fatalf("compile failed: %v", c.Errors)
+	}
+
+	return c
+}
+
+func bodyRefs(t *testing.T, c *Compiler, module, rule string) []string {
+	t.Helper()
+
+	mod, ok := c.Modules[module]
+	if !ok {
+		t.Fatalf("module %q not found", module)
+	}
+
+	var refs []string
+	found := false
+	WalkRules(mod, func(r *Rule) bool {
+		if string(r.Head.Name) != rule {
+			return false
+		}
+		found = true
+		WalkRefs(r.Body, func(ref Ref) bool {
+			refs = append(refs, ref.String())
+			return false
+		})
+		return false
+	})
+	if !found {
+		t.Fatalf("rule %q not found in %q", rule, module)
+	}
+
+	return refs
+}
+
+func hasRef(refs []string, want string) bool {
+	return slices.Contains(refs, want)
+}
+
+func assertRefs(t *testing.T, c *Compiler, module, rule string, wantPresent, wantAbsent []string) {
+	t.Helper()
+
+	refs := bodyRefs(t, c, module, rule)
+	for _, want := range wantPresent {
+		if !hasRef(refs, want) {
+			t.Errorf("%s: expected body to reference %s, got %v", rule, want, refs)
+		}
+	}
+	for _, unwanted := range wantAbsent {
+		if hasRef(refs, unwanted) {
+			t.Errorf("%s: expected body NOT to reference %s, got %v", rule, unwanted, refs)
+		}
+	}
+}
+
+func TestInlineAliasesLeavesNonAliasRulesAlone(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"policy.rego": `package test
+
+import rego.v1
+
+p if {
+	input.attributes.request.http.method == "GET"
+	data.config.enabled
+}
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"input.attributes.request.http.method", "data.config.enabled"},
+		nil)
+}
+
+func TestInlineAliasesRewritesAliasReferences(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"http.rego": `package http
+
+import rego.v1
+
+request := input.attributes.request.http
+
+method := request.method
+`,
+		"policy.rego": `package test
+
+import data.http.method
+import rego.v1
+
+p if method == "GET"
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"input.attributes.request.http.method"},
+		[]string{"data.http.method", "data.http.request.method"})
+}
+
+func TestInlineAliasesRewritesReferenceBelowAlias(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"http.rego": `package http
+
+import rego.v1
+
+request := input.attributes.request.http
+`,
+		"policy.rego": `package test
+
+import rego.v1
+
+p if data.http.request.host == "example.com"
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"input.attributes.request.http.host"},
+		[]string{"data.http.request.host"})
+}
+
+func TestInlineAliasesDepthLimit(t *testing.T) {
+	chain := func(n int) string {
+		var b strings.Builder
+		b.WriteString("package chain\n\nimport rego.v1\n\n")
+		for i := n - 1; i >= 1; i-- {
+			fmt.Fprintf(&b, "a%d := a%d\n\n", i, i-1)
+		}
+		b.WriteString("a0 := input.x\n")
+		return b.String()
+	}
+
+	for _, tc := range []struct {
+		hops       int
+		wantInline bool
+	}{
+		{hops: 1, wantInline: true},
+		{hops: 7, wantInline: true},
+		{hops: 8, wantInline: true},
+		{hops: 9, wantInline: false},
+		{hops: 12, wantInline: false},
+	} {
+		t.Run(fmt.Sprintf("%d_hops", tc.hops), func(t *testing.T) {
+			last := fmt.Sprintf("data.chain.a%d", tc.hops-1)
+			c := compileForInlining(t, map[string]string{
+				"zzz_chain.rego": chain(tc.hops),
+				"aaa_policy.rego": fmt.Sprintf(`package test
+
+import rego.v1
+
+p if %s == 1
+`, last),
+			})
+
+			refs := bodyRefs(t, c, "aaa_policy.rego", "p")
+			inlined := hasRef(refs, "input.x")
+			if inlined != tc.wantInline {
+				t.Errorf("%d hops: inlined=%v, want %v (refs: %v)", tc.hops, inlined, tc.wantInline, refs)
+			}
+			if !tc.wantInline && !hasRef(refs, last) {
+				t.Errorf("%d hops: expected %s to be left in place, got %v", tc.hops, last, refs)
+			}
+		})
+	}
+}
+
+func TestInlineAliasesRejectsNonAliasShapes(t *testing.T) {
+	for _, tc := range []struct {
+		note     string
+		alias    string
+		consumer string
+	}{
+		{
+			note:  "default rule",
+			alias: "default v := \"x\"\n\nv := input.x",
+		},
+		{
+			note:  "else chain",
+			alias: "v := input.x if input.a\n\nelse := input.y",
+		},
+		{
+			note:     "function",
+			alias:    "v(_) := input.x",
+			consumer: "p if data.alias.v(1) == 1",
+		},
+		{
+			note:  "two bodies",
+			alias: "v := input.x if input.a\n\nv := input.y if input.b",
+		},
+		{
+			note:     "multi-value rule",
+			alias:    "v contains x if some x in input.xs",
+			consumer: "p if data.alias.v == {1}",
+		},
+		{
+			note:  "scalar value, not a ref",
+			alias: "v := 42",
+		},
+		{
+			note:  "body does more than rename",
+			alias: "v := input.x if input.gate",
+		},
+		{
+			note:  "target is not ground",
+			alias: "v := input.x[_]",
+		},
+		{
+			note:  "target is a call, not a ref",
+			alias: "v := count(input.xs)",
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			consumer := tc.consumer
+			if consumer == "" {
+				consumer = "p if data.alias.v == 1"
+			}
+			c := compileForInlining(t, map[string]string{
+				"alias.rego":  "package alias\n\nimport rego.v1\n\n" + tc.alias + "\n",
+				"policy.rego": "package test\n\nimport rego.v1\n\n" + consumer + "\n",
+			})
+
+			assertRefs(t, c, "policy.rego", "p",
+				[]string{"data.alias.v"},
+				[]string{"input.x", "input.y"})
+		})
+	}
+}
+
+func TestInlineAliasesWithInScopeBlocks(t *testing.T) {
+	for _, tc := range []struct {
+		note   string
+		target string
+	}{
+		{note: "targets the alias itself", target: "data.http.method"},
+		{note: "targets a prefix of the alias", target: "data.http"},
+		{note: "targets the resolved base document", target: "input.attributes.request.http.method"},
+		{note: "targets a prefix of the resolved base document", target: "input.attributes"},
+		{note: "targets the root input document", target: "input"},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			c := compileForInlining(t, map[string]string{
+				"http.rego": `package http
+
+import rego.v1
+
+request := input.attributes.request.http
+
+method := request.method
+`,
+				"policy.rego": fmt.Sprintf(`package test
+
+import rego.v1
+
+p if data.http.method == "GET"
+
+probe if p with %s as "GET"
+`, tc.target),
+			})
+
+			assertRefs(t, c, "policy.rego", "p",
+				[]string{"data.http.method"},
+				[]string{"input.attributes.request.http.method"})
+		})
+	}
+}
+
+func TestInlineAliasesWithOutOfScopeDoesNotBlock(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"http.rego": `package http
+
+import rego.v1
+
+request := input.attributes.request.http
+
+method := request.method
+`,
+		"policy.rego": `package test
+
+import rego.v1
+
+p if data.http.method == "GET"
+`,
+		"masking.rego": `package system.log
+
+import rego.v1
+
+mask contains "/input/x" if {
+	data.other.claims with input as input.input
+}
+`,
+		"other.rego": `package other
+
+import rego.v1
+
+claims := input.claims
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"input.attributes.request.http.method"},
+		[]string{"data.http.method"})
+
+	assertRefs(t, c, "masking.rego", "mask",
+		[]string{"data.other.claims"},
+		[]string{"input.claims"})
+}
+
+func TestInlineAliasesWithInsideComprehension(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"alias.rego": `package alias
+
+import rego.v1
+
+v := input.x
+`,
+		"policy.rego": `package test
+
+import rego.v1
+
+p := xs if {
+	xs := {y | y := data.alias.v with input as {"x": 42}}
+}
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"data.alias.v"},
+		[]string{"input.x"})
+}
+
+func TestInlineAliasesSkipsTestRules(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"alias.rego": `package alias
+
+import rego.v1
+
+v := input.x
+`,
+		"policy_test.rego": `package test
+
+import rego.v1
+
+test_foo if data.alias.v == 1
+
+helper if data.alias.v == 1
+`,
+	})
+
+	assertRefs(t, c, "policy_test.rego", "test_foo",
+		[]string{"data.alias.v"},
+		[]string{"input.x"})
+
+	assertRefs(t, c, "policy_test.rego", "helper",
+		[]string{"input.x"},
+		[]string{"data.alias.v"})
+}
+
+func TestInlineAliasesResolvesDataRootedAlias(t *testing.T) {
+	c := compileForInlining(t, map[string]string{
+		"alias.rego": `package alias
+
+import rego.v1
+
+path := data.request.path
+`,
+		"policy.rego": `package test
+
+import rego.v1
+
+p if data.alias.path == ["a"]
+`,
+	})
+
+	assertRefs(t, c, "policy.rego", "p",
+		[]string{"data.request.path"},
+		[]string{"data.alias.path"})
+}

--- a/v1/ast/inline_aliases_test.go
+++ b/v1/ast/inline_aliases_test.go
@@ -247,14 +247,15 @@ func TestInlineAliasesRejectsNonAliasShapes(t *testing.T) {
 
 func TestInlineAliasesWithInScopeBlocks(t *testing.T) {
 	for _, tc := range []struct {
-		note   string
-		target string
+		note        string
+		target      string
+		wantInlined bool
 	}{
 		{note: "targets the alias itself", target: "data.http.method"},
 		{note: "targets a prefix of the alias", target: "data.http"},
-		{note: "targets the resolved base document", target: "input.attributes.request.http.method"},
-		{note: "targets a prefix of the resolved base document", target: "input.attributes"},
-		{note: "targets the root input document", target: "input"},
+		{note: "targets the resolved base document", target: "input.attributes.request.http.method", wantInlined: true},
+		{note: "targets a prefix of the resolved base document", target: "input.attributes", wantInlined: true},
+		{note: "targets the root input document", target: "input", wantInlined: true},
 	} {
 		t.Run(tc.note, func(t *testing.T) {
 			c := compileForInlining(t, map[string]string{
@@ -276,9 +277,15 @@ probe if p with %s as "GET"
 `, tc.target),
 			})
 
-			assertRefs(t, c, "policy.rego", "p",
-				[]string{"data.http.method"},
-				[]string{"input.attributes.request.http.method"})
+			if tc.wantInlined {
+				assertRefs(t, c, "policy.rego", "p",
+					[]string{"input.attributes.request.http.method"},
+					[]string{"data.http.method"})
+			} else {
+				assertRefs(t, c, "policy.rego", "p",
+					[]string{"data.http.method"},
+					[]string{"input.attributes.request.http.method"})
+			}
 		})
 	}
 }

--- a/v1/rego/alias_test.go
+++ b/v1/rego/alias_test.go
@@ -1,0 +1,63 @@
+package rego
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+func TestAliasIndexFollowsDataChanges(t *testing.T) {
+	store := inmem.New()
+	r := New(
+		Query("data.test.p"),
+		Module("alias.rego", "package alias\n\npath := data.request.path"),
+		Module("test.rego", `package test
+
+import data.alias.path
+
+p := "a" if path == ["a"]
+
+p := "b" if path == ["b"]
+`),
+		Store(store),
+	)
+	pq, err := r.PrepareForEval(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(set, want string) {
+		t.Helper()
+		txn, err := store.NewTransaction(t.Context(), storage.WriteParams)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Write(t.Context(), txn, storage.AddOp, storage.MustParsePath("/request"),
+			map[string]any{"path": []any{set}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Commit(t.Context(), txn); err != nil {
+			t.Fatal(err)
+		}
+
+		rs, err := pq.Eval(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want == "" {
+			if len(rs) != 0 {
+				t.Fatalf("data=%q: expected undefined, got %v", set, rs)
+			}
+			return
+		}
+		if len(rs) != 1 || len(rs[0].Expressions) != 1 || rs[0].Expressions[0].Value != want {
+			t.Fatalf("data=%q: got %v, want %q", set, rs, want)
+		}
+	}
+
+	check("a", "a")
+	check("b", "b")
+	check("c", "")
+	check("a", "a")
+}

--- a/v1/topdown/alias_datachange_test.go
+++ b/v1/topdown/alias_datachange_test.go
@@ -4,78 +4,8 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
-	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 )
-
-func TestAliasIndexFollowsDataChanges(t *testing.T) {
-	compiler := ast.NewCompiler()
-	compiler.Compile(map[string]*ast.Module{
-		"alias.rego": ast.MustParseModule("package alias\n\npath := data.request.path"),
-		"test.rego": ast.MustParseModule(`package test
-
-import data.alias.path
-
-p := "a" if path == ["a"]
-
-p := "b" if path == ["b"]
-`),
-	})
-	if compiler.Failed() {
-		t.Fatal(compiler.Errors)
-	}
-
-	store := inmem.New()
-	ctx := t.Context()
-
-	check := func(set string, want string) {
-		t.Helper()
-		txn, err := store.NewTransaction(ctx, storage.WriteParams)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := store.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/request"),
-			map[string]any{"path": []any{set}}); err != nil {
-			t.Fatal(err)
-		}
-		if err := store.Commit(ctx, txn); err != nil {
-			t.Fatal(err)
-		}
-
-		rtxn, err := store.NewTransaction(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer store.Abort(ctx, rtxn)
-
-		rs, err := NewQuery(ast.MustParseBody("data.test.p")).
-			WithCompiler(compiler).WithStore(store).WithTransaction(rtxn).Run(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want == "" {
-			if len(rs) != 0 {
-				t.Fatalf("data=%q: expected undefined, got %v", set, rs)
-			}
-			return
-		}
-		if len(rs) != 1 {
-			t.Fatalf("data=%q: expected one result, got %v", set, rs)
-		}
-		var v any
-		for _, val := range rs[0] {
-			v = val.Value.String()
-		}
-		if v != `"`+want+`"` {
-			t.Fatalf("data=%q: got %v, want %q", set, v, want)
-		}
-	}
-
-	check("a", "a")
-	check("b", "b")
-	check("c", "")
-	check("a", "a")
-}
 
 func TestAliasInliningRespectsWithInElseBranch(t *testing.T) {
 	compiler := ast.NewCompiler()

--- a/v1/topdown/alias_datachange_test.go
+++ b/v1/topdown/alias_datachange_test.go
@@ -1,0 +1,79 @@
+package topdown
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+func TestAliasIndexFollowsDataChanges(t *testing.T) {
+	compiler := ast.NewCompiler()
+	compiler.Compile(map[string]*ast.Module{
+		"alias.rego": ast.MustParseModule("package alias\n\npath := data.request.path"),
+		"test.rego": ast.MustParseModule(`package test
+
+import data.alias.path
+
+p := "a" if path == ["a"]
+
+p := "b" if path == ["b"]
+`),
+	})
+	if compiler.Failed() {
+		t.Fatal(compiler.Errors)
+	}
+
+	store := inmem.New()
+	ctx := context.Background()
+
+	check := func(set string, want string) {
+		t.Helper()
+		txn, err := store.NewTransaction(ctx, storage.WriteParams)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Write(ctx, txn, storage.AddOp, storage.MustParsePath("/request"),
+			map[string]any{"path": []any{set}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Commit(ctx, txn); err != nil {
+			t.Fatal(err)
+		}
+
+		rtxn, err := store.NewTransaction(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Abort(ctx, rtxn)
+
+		rs, err := NewQuery(ast.MustParseBody("data.test.p")).
+			WithCompiler(compiler).WithStore(store).WithTransaction(rtxn).Run(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want == "" {
+			if len(rs) != 0 {
+				t.Fatalf("data=%q: expected undefined, got %v", set, rs)
+			}
+			return
+		}
+		if len(rs) != 1 {
+			t.Fatalf("data=%q: expected one result, got %v", set, rs)
+		}
+		var v any
+		for _, val := range rs[0] {
+			v = val.Value.String()
+		}
+		if v != `"`+want+`"` {
+			t.Fatalf("data=%q: got %v, want %q", set, v, want)
+		}
+	}
+
+	check("a", "a")
+	check("b", "b")
+	check("c", "")
+	check("a", "a")
+}

--- a/v1/topdown/alias_datachange_test.go
+++ b/v1/topdown/alias_datachange_test.go
@@ -1,7 +1,6 @@
 package topdown
 
 import (
-	"context"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -27,7 +26,7 @@ p := "b" if path == ["b"]
 	}
 
 	store := inmem.New()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	check := func(set string, want string) {
 		t.Helper()
@@ -76,4 +75,36 @@ p := "b" if path == ["b"]
 	check("b", "b")
 	check("c", "")
 	check("a", "a")
+}
+
+func TestAliasInliningRespectsWithInElseBranch(t *testing.T) {
+	compiler := ast.NewCompiler()
+	compiler.Compile(map[string]*ast.Module{
+		"alias.rego": ast.MustParseModule("package alias\n\nv := input.x\n"),
+		"lib.rego": ast.MustParseModule(`package lib
+
+g := 1 if input.a
+
+else := 2 if data.alias.v == 1
+`),
+		"top.rego": ast.MustParseModule(`package top
+
+p if data.lib.g == 2 with data.alias.v as 1
+`),
+	})
+	if compiler.Failed() {
+		t.Fatal(compiler.Errors)
+	}
+
+	rs, err := NewQuery(ast.MustParseBody("data.top.p")).
+		WithCompiler(compiler).
+		WithStore(inmem.New()).
+		WithInput(ast.MustParseTerm(`{}`)).
+		Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("expected data.top.p to be defined, got %v", rs)
+	}
 }

--- a/v1/topdown/alias_index_bench_test.go
+++ b/v1/topdown/alias_index_bench_test.go
@@ -5,7 +5,6 @@
 package topdown
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -44,7 +43,7 @@ path := input.path`
 
 			store := inmem.New()
 			input := ast.MustParseTerm(`{"path": ["ep200"]}`)
-			ctx := context.Background()
+			ctx := b.Context()
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/v1/topdown/alias_index_bench_test.go
+++ b/v1/topdown/alias_index_bench_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+func BenchmarkRuleIndexAliasedRefs(b *testing.B) {
+	aliasModule := `package alias
+
+path := input.path`
+
+	for _, tc := range []struct {
+		name string
+		ref  string
+	}{
+		{"aliased", "data.alias.path"},
+		{"direct", "input.path"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var buf strings.Builder
+			buf.WriteString("package test\n\n")
+			for i := 1; i <= 200; i++ {
+				fmt.Fprintf(&buf, "p if %s == [\"ep%d\"]\n\n", tc.ref, i)
+			}
+
+			compiler := ast.NewCompiler()
+			compiler.Compile(map[string]*ast.Module{
+				"alias.rego": ast.MustParseModule(aliasModule),
+				"test.rego":  ast.MustParseModule(buf.String()),
+			})
+			if compiler.Failed() {
+				b.Fatalf("compilation failed: %v", compiler.Errors)
+			}
+
+			store := inmem.New()
+			input := ast.MustParseTerm(`{"path": ["ep200"]}`)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				q := NewQuery(ast.MustParseBody("data.test.p")).
+					WithCompiler(compiler).
+					WithStore(store).
+					WithInput(input)
+
+				rs, err := q.Run(ctx)
+				if err != nil {
+					b.Fatalf("query failed: %v", err)
+				}
+				if len(rs) != 1 {
+					b.Fatalf("expected exactly one result, got %d", len(rs))
+				}
+			}
+		})
+	}
+}

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -5862,21 +5862,22 @@ func TestTopDownPartialEvalNegation(t *testing.T) {
 				} 
 			`},
 			wantQueries: []string{"data.partial.test.p = true"},
+			// `q := x if { x := input.x }` compiles to the pure-alias shape, so
+			// StageInlineRefAliases rewrites `data.test.q` to `input.x` before
+			// partial evaluation runs. `q` is then referenced by nothing and
+			// drops out of the residual. It remains a queryable document on the
+			// compiled policy -- only the support module loses it.
 			wantSupport: []string{`
 				package partial.test
 				
 				p = true if { 
 					not data.partial.__not1_0_2__
 				}
-				
-				q = __local0__3 if { 
-					__local0__3 = input.x 
-				}
 			`, `
 				package partial
 
 				__not1_0_2__ = true if { 
-					data.partial.test.q = __local2__1
+					__local2__1 = input.x
 					plus(__local2__1, 1, __local1__1)
 					__local1__1 = 2 
 				}


### PR DESCRIPTION
Alternative to https://github.com/open-policy-agent/opa/pull/9071 to address https://github.com/open-policy-agent/opa/pull/9071#issuecomment-5387748108, implementing this as a compiler stage that inlines aliases, rather than making the rule indexer alias-aware.

## Performance benchmarks:

Baseline (`main`) vs the compiler pass that rewrites references to alias rules into the references they resolve to, so the existing rule indexer can see them.

| label | what | ref |
| --- | --- | --- |
| `base` | `main`, unmodified | `551581feec` |
| `inline` | compiler pass rewrites alias refs | `ee6a38f2c6` (`inline-aliases-scoped-with`) |

darwin/arm64, 12 cores, go1.26, `benchstat` n=10. `~` = not significant.

Both benchmarks have an `/aliased` arm and a `/direct` arm. `/direct` writes the
reference by hand and so gains nothing from the pass -- it is the control, and
the number to check first.

### Evaluation

`BenchmarkRuleIndexAliasedRefs`. 200 rules, input matches the 200th, so a failed
index evaluates all 200 bodies.

| arm | | base | inline |
| --- | --- | --- | --- |
| `/aliased` | sec/op | 773.74µ | **12.27µ (−98.41%)** |
| | allocs/op | 2143 | **133 (−93.79%)** |
| | B/op | 86.70Ki | **10.57Ki (−87.81%)** |
| `/direct` | sec/op | 13.41µ | 12.35µ (−7.88%) |
| | allocs/op | 133 | 133 (~) |
| | B/op | 10.57Ki | 10.57Ki (+0.01%) |

An aliased policy becomes indistinguishable from one written against `input.path` directly.

### Compilation

`BenchmarkCompileAliasedRefs` -- the compile-side twin. Both arms compile the
alias module; only `/aliased` references it, so `/direct` is what an alias-free
policy pays for the feature.

| arm | | base | inline |
| --- | --- | --- | --- |
| `/aliased/200` | sec/op | 2.222m | 2.246m (+1.05%) |
| | allocs/op | 47.04k | 49.67k (+5.60%) |
| | B/op | 1.691Mi | 1.891Mi (+11.85%) |
| `/aliased/2000` | sec/op | 21.79m | 22.31m (+2.34%) |
| | allocs/op | 452.1k | 478.2k (+5.77%) |
| | B/op | 16.52Mi | 18.74Mi (+13.48%) |
| `/direct/200` | sec/op | 2.092m | 1.968m (−5.94%) |
| | allocs/op | 46.63k | 46.85k (+0.46%) |
| | B/op | 1.661Mi | 1.679Mi (+1.09%) |
| `/direct/2000` | sec/op | 20.64m | 19.77m (−4.23%) |
| | allocs/op | 448.1k | 450.2k (+0.45%) |
| | B/op | 16.23Mi | 16.47Mi (+1.44%) |