### PR TITLE
format: converge object comprehension layout

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -2107,11 +2107,13 @@ func (w *writer) writeObjectComprehension(object *ast.ObjectComprehension, loc *
 	w.write("{")
 	defer w.write("}")
 
-	object.Value.Location = object.Key.Location // Ensure the value is not written on the next line.
-	if object.Key.Location.Row-loc.Row > 1 {
-		w.endLine()
-		w.startLine()
-	}
+	// Ensure the value is not written on the next line. writeComprehension
+	// breaks before the term whenever the term's row is below the row the
+	// comprehension opened on, so the value is given a location on that row
+	// rather than the key's, which may already be a row further down.
+	valueLoc := *object.Key.Location
+	valueLoc.Row = loc.Row
+	object.Value.Location = &valueLoc
 
 	paren := isUnionCall(object.Key)
 	if paren {

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -2110,8 +2110,10 @@ func (w *writer) writeObjectComprehension(object *ast.ObjectComprehension, loc *
 	// Ensure the value is not written on the next line. writeComprehension
 	// breaks before the term whenever the term's row is below the row the
 	// comprehension opened on, so the value is given a location on that row
-	// rather than the key's, which may already be a row further down.
-	valueLoc := *object.Key.Location
+	// rather than its own, which may already be a row further down. Copying
+	// the value's own location rather than the key's keeps Text intact, which
+	// writeComprehension reads to decide whether a call term was parenthesised.
+	valueLoc := *object.Value.Location
 	valueLoc.Row = loc.Row
 	object.Value.Location = &valueLoc
 

--- a/v1/format/testfiles/v0/test_object_comprehension_multiline.rego
+++ b/v1/format/testfiles/v0/test_object_comprehension_multiline.rego
@@ -1,0 +1,28 @@
+package test
+
+objects := {"a": 1, "b": 2}
+
+keys := ["a", "b"]
+
+# the key sits on the row directly below the opening brace
+p {
+	x := {
+		k: objects[k] | k := keys[_]
+	}
+	x
+}
+
+# the key sits more than one row below the opening brace
+q {
+	x := {
+
+		k: objects[k] | k := keys[_]
+	}
+	x
+}
+
+# already on one line
+r {
+	x := {k: objects[k] | k := keys[_]}
+	x
+}

--- a/v1/format/testfiles/v0/test_object_comprehension_multiline.rego.formatted
+++ b/v1/format/testfiles/v0/test_object_comprehension_multiline.rego.formatted
@@ -1,0 +1,27 @@
+package test
+
+objects := {"a": 1, "b": 2}
+
+keys := ["a", "b"]
+
+# the key sits on the row directly below the opening brace
+p {
+	x := {k: objects[k] |
+		k := keys[_]
+	}
+	x
+}
+
+# the key sits more than one row below the opening brace
+q {
+	x := {k: objects[k] |
+		k := keys[_]
+	}
+	x
+}
+
+# already on one line
+r {
+	x := {k: objects[k] | k := keys[_]}
+	x
+}

--- a/v1/format/testfiles/v0/test_object_comprehension_parenthesized_value.rego
+++ b/v1/format/testfiles/v0/test_object_comprehension_parenthesized_value.rego
@@ -1,0 +1,18 @@
+package test
+
+keys := ["a", "b"]
+
+# a parenthesized value keeps its parentheses: without them the comprehension
+# bar reads as a set union and the formatted output no longer parses
+p {
+	x := {k: (1 + 2) | k := keys[_]}
+	x
+}
+
+# the same value, written on the row below the key
+q {
+	x := {
+		k: (1 + 2) | k := keys[_]
+	}
+	x
+}

--- a/v1/format/testfiles/v0/test_object_comprehension_parenthesized_value.rego.formatted
+++ b/v1/format/testfiles/v0/test_object_comprehension_parenthesized_value.rego.formatted
@@ -1,0 +1,18 @@
+package test
+
+keys := ["a", "b"]
+
+# a parenthesized value keeps its parentheses: without them the comprehension
+# bar reads as a set union and the formatted output no longer parses
+p {
+	x := {k: (1 + 2) | k := keys[_]}
+	x
+}
+
+# the same value, written on the row below the key
+q {
+	x := {k: (1 + 2) |
+		k := keys[_]
+	}
+	x
+}

--- a/v1/format/testfiles/v1/test_object_comprehension_multiline.rego
+++ b/v1/format/testfiles/v1/test_object_comprehension_multiline.rego
@@ -1,0 +1,28 @@
+package test
+
+objects := {"a": 1, "b": 2}
+
+keys := ["a", "b"]
+
+# the key sits on the row directly below the opening brace
+p if {
+	x := {
+		k: objects[k] | k := keys[_]
+	}
+	x
+}
+
+# the key sits more than one row below the opening brace
+q if {
+	x := {
+
+		k: objects[k] | k := keys[_]
+	}
+	x
+}
+
+# already on one line
+r if {
+	x := {k: objects[k] | k := keys[_]}
+	x
+}

--- a/v1/format/testfiles/v1/test_object_comprehension_multiline.rego.formatted
+++ b/v1/format/testfiles/v1/test_object_comprehension_multiline.rego.formatted
@@ -1,0 +1,27 @@
+package test
+
+objects := {"a": 1, "b": 2}
+
+keys := ["a", "b"]
+
+# the key sits on the row directly below the opening brace
+p if {
+	x := {k: objects[k] |
+		k := keys[_]
+	}
+	x
+}
+
+# the key sits more than one row below the opening brace
+q if {
+	x := {k: objects[k] |
+		k := keys[_]
+	}
+	x
+}
+
+# already on one line
+r if {
+	x := {k: objects[k] | k := keys[_]}
+	x
+}

--- a/v1/format/testfiles/v1/test_object_comprehension_parenthesized_value.rego
+++ b/v1/format/testfiles/v1/test_object_comprehension_parenthesized_value.rego
@@ -1,0 +1,18 @@
+package test
+
+keys := ["a", "b"]
+
+# a parenthesized value keeps its parentheses: without them the comprehension
+# bar reads as a set union and the formatted output no longer parses
+p if {
+	x := {k: (1 + 2) | k := keys[_]}
+	x
+}
+
+# the same value, written on the row below the key
+q if {
+	x := {
+		k: (1 + 2) | k := keys[_]
+	}
+	x
+}

--- a/v1/format/testfiles/v1/test_object_comprehension_parenthesized_value.rego.formatted
+++ b/v1/format/testfiles/v1/test_object_comprehension_parenthesized_value.rego.formatted
@@ -1,0 +1,18 @@
+package test
+
+keys := ["a", "b"]
+
+# a parenthesized value keeps its parentheses: without them the comprehension
+# bar reads as a set union and the formatted output no longer parses
+p if {
+	x := {k: (1 + 2) | k := keys[_]}
+	x
+}
+
+# the same value, written on the row below the key
+q if {
+	x := {k: (1 + 2) |
+		k := keys[_]
+	}
+	x
+}


### PR DESCRIPTION
Fixes #9075.

## The bug

`opa fmt` did not reach its final layout in one pass for an object comprehension whose key is written below the opening brace, and its first pass left trailing whitespace behind:

```console
$ cat p.rego
package test

p if {
	x := {
		k: objects[k] | k := keys[_]
	}
	x
}

$ opa fmt -w p.rego && cat -A p.rego
p if {$
^Ix := {k: $          <- trailing space, value pushed to the next line
^Iobjects[k] | k := keys[_]}$

$ opa fmt --fail p.rego
unexpected diff       <- exit 1, on a file opa fmt -w had just written
```

## Why it happened

`writeObjectComprehension` copies the key's location onto the value, with the comment *"Ensure the value is not written on the next line"*. `writeComprehension` then breaks before its term whenever `term.Location.Row - loc.Row >= 1`. A key one row under the brace still satisfies that, so the break fired anyway — right after `": "` had been written, which is where the trailing space came from.

The two row tests in the same path also disagreed: `writeObjectComprehension` used `> 1`, `writeComprehension` `>= 1`. A key placed further down took the other branch and was moved onto a line of its own at one tab of indent, out of step with the closing brace.

Neither layout is one the formatter itself produces, so the second pass met neither condition and undid both.

## The fix

Give the value a location on the row the comprehension opened on. The break condition is then false in every case, which is what copying the key's location was reaching for, and the separate test before the key is no longer needed.

The location is now copied rather than shared with the key, so writing the value can no longer disturb the key's own location — the previous line assigned the same `*ast.Location` pointer to both.

## Tests

Test files rather than a new test function: `TestFormatV0Source` and `TestFormatV1Source` already format each file, re-format the result and compare both against the `.formatted` fixture, so the idempotence check comes for free and the new files simply give it a case to work on. That the property was already asserted and this still slipped through is just a gap in the corpus — there was no multi-line object comprehension in `testfiles/`.

Each new file covers all three shapes: key one row below the brace, key further below, and key already alongside it.

- **Revert-checked**: with `format.go` restored to `main` and the fixtures kept, exactly the two new files fail — `testfiles/v0/test_object_comprehension_multiline.rego` and `testfiles/v1/...` — and nothing else changes.
- `./v1/format/...` and `./cmd/...`: **the failure set is identical to a pristine tree** on this machine (27 tests, all Windows path-handling and pre-existing, including `TestFormatV0SourceToRegoV1`, which fails on `main` here with the same message).
- End to end with a locally built binary: the input above now settles in one pass, `opa fmt --fail` exits 0, and no trailing whitespace is written.
- `gofmt` clean.

## How it was found

By checking `format(format(x)) == format(x)` over every `.rego` and `.rego.formatted` file in the repository, formatting each with the Rego version it actually parses in. One file in-tree trips it, `v1/rego/testdata/aci/framework.rego`, and it is stable again with this change — the sweep now reports no violations across 343 files.

## Follow-up on @sspaink's review

The value now takes a copy of **its own** location with only `Row` overridden, rather than a copy of the key's. `writeComprehension` reads `term.Location.Text[0]` to decide whether a call term was written in parentheses, and the key's text was answering that question for the wrong term.

That turned out to be more than layout. Against `main`:

```console
$ cat p.rego
package test

keys := ["a", "b"]

p if {
	x := {k: (1 + 2) | k := keys[_]}
	x
}

$ opa fmt p.rego
...
	x := {k: 1 + 2 | k := keys[_]}      <- parentheses dropped
```

and that output does not parse — `rego_parse_error: unexpected assign token: non-terminated object`, because the bar now reads as a set union. `opa fmt -w` writes it over the original, so the file has to be recovered from version control.

Two more test files cover it, `test_object_comprehension_parenthesized_value.rego` in v0 and v1, with the value on the key's row and on the row below. Both fail against the previous revision of this PR (byte 198, `got '1', expected '('`) and pass with the follow-up commit.

---

*Disclosure, per the [AI guidelines](https://www.openpolicyagent.org/docs/contrib-code#ai-guidelines): I used Claude (Opus 5) while investigating and writing this. The diagnosis, the fix and every number above I ran and checked myself, and any review comments will be answered by me, not by a tool.*

