### PR TITLE
ast/index: materialize data refs for rule indexing

### DIFF
--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -124,14 +124,15 @@ roles := {
 
 For simple equality statements (`=` and `==`) to be indexed one side must be a non-nested reference that does not contain any variables and the other side must be a variable, scalar, or array (which may contain scalars and variables). For example:
 
-| Expression                  | Indexed | Notes                        |
-| --------------------------- | ------- | ---------------------------- |
-| `input.x`                   | yes     |                              |
-| `input.x == "foo"`          | yes     |                              |
-| `input.x.y == "bar"`        | yes     |                              |
-| `input.x == ["foo", i]`     | yes     |                              |
-| `input.x[i] == "foo"`       | no      | reference contains variables |
-| `input.x[input.y] == "foo"` | no      | reference is nested          |
+| Expression                  | Indexed | Notes                                                       |
+| --------------------------- | ------- | ----------------------------------------------------------- |
+| `input.x`                   | yes     |                                                             |
+| `input.x == "foo"`          | yes     |                                                             |
+| `input.x.y == "bar"`        | yes     |                                                             |
+| `input.x == ["foo", i]`     | yes     |                                                             |
+| `input.x == data.config.x`  | yes     | see [statements that read data](#statements-that-read-data) |
+| `input.x[i] == "foo"`       | no      | reference contains variables                                |
+| `input.x[input.y] == "foo"` | no      | reference is nested                                         |
 
 #### Glob statements
 
@@ -152,14 +153,69 @@ For `value in collection` statements to be indexed, the value must be a scalar (
 
 Both directions of membership are supported:
 
-| Expression                                | Indexed | Notes                                   |
-| ----------------------------------------- | ------- | --------------------------------------- |
-| `input.role in {"admin", "user"}`         | yes     |                                         |
-| `"admin" in input.roles`                  | yes     |                                         |
-| `input.roles[_] == "admin"`               | yes     | treated as `"admin" in input.roles`     |
-| `x := input.role; x in {"admin", "user"}` | yes     | variable resolved to ref via assignment |
-| `{"nested": "obj"} in input.items`        | no      | non-scalar membership value             |
-| `some k, v in input.obj; v == "admin"`    | no      | three-operand `in` not indexed          |
+| Expression                                | Indexed | Notes                                                       |
+| ----------------------------------------- | ------- | ----------------------------------------------------------- |
+| `input.role in {"admin", "user"}`         | yes     |                                                             |
+| `"admin" in input.roles`                  | yes     |                                                             |
+| `input.roles[_] == "admin"`               | yes     | treated as `"admin" in input.roles`                         |
+| `x := input.role; x in {"admin", "user"}` | yes     | variable resolved to ref via assignment                     |
+| `input.role in data.admin_roles`          | yes     | see [statements that read data](#statements-that-read-data) |
+| `{"nested": "obj"} in input.items`        | no      | non-scalar membership value                                 |
+| `some k, v in input.obj; v == "admin"`    | no      | three-operand `in` not indexed                              |
+
+#### Statements that read data
+
+Equality and membership statements can compare against data instead of a literal:
+
+```rego
+package tenants
+
+allow if input.tenant == data.config.tenant
+
+allow if input.subject in data.groups.admins.members
+```
+
+An index is keyed on the values a rule compares against, so OPA reads these refs
+when it builds one and stores what it finds: the equality is indexed against
+whatever `data.config.tenant` held at that moment, and the membership as one
+entry per member of the collection. A lookup is then the same constant-time
+lookup it would be against a literal, however many rules of this shape a policy
+has — which is what makes a policy with one rule per group practical, instead of
+one that evaluates every group's rule on every decision.
+
+Because the index holds a copy, a data change reaching any of the refs it read
+must not leave it pruning against values that have moved. What happens instead is
+that the entries read from those refs stop excluding rules — leaving those rules
+as indexed as they were before the data was read into them, while the rest of the
+index keeps pruning — and the next compilation reads the current values back in.
+Nothing is recompiled on the write itself: a data update costs microseconds, not
+a policy compilation. The same applies, for a single evaluation, to a `with`
+statement replacing one of those refs and to partial evaluation treating it as
+unknown.
+
+So in a deployment where this data changes constantly and policies rarely do, the
+index settles back into the behaviour it had without this feature, and costs
+nothing. It pays where the data is stable between policy updates — including data
+delivered in bundles, since activating one compiles and reads the values it
+brought.
+
+Each value of a collection costs roughly 250 bytes of index per rule, so only
+collections up to 1000 values are stored; a larger one is left out, and the rules
+using it are candidates for every input value. So is a ref that rules contribute
+to, since resolving it would mean evaluating policy:
+
+| Expression                                           | Indexed | Notes                                              |
+| ---------------------------------------------------- | ------- | -------------------------------------------------- |
+| `input.tenant == data.config.tenant`                 | yes     | value read from data                               |
+| `input.subject in data.groups.eng.members`           | yes     | one index entry per member                         |
+| `xs := data.groups.eng.members; input.subject in xs` | yes     | variable resolved to the ref                       |
+| `input.subject in data.groups[input.team].members`   | no      | collection reference contains variables            |
+| `input.role in data.roles_of[input.user]`            | no      | same                                               |
+| `input.subject in data.computed_members`             | no      | `data.computed_members` is a rule, not stored data |
+
+Embedders can tune this: `plugins.RuleIndexData(n)` sets the largest collection
+stored in an index, and `plugins.RuleIndexData(0)` turns off reading data into
+indices altogether.
 
 #### Bare reference statements
 

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -690,6 +690,19 @@ func (c *Compiler) MaterializeIndexData(resolver ValueResolver, maxCollectionSiz
 	c.indexData = resolver
 	c.maxIndexCollection = maxCollectionSize
 
+	// An external source compiles its rules when a query reaches them, with a
+	// resolver of its own -- so it reads its own data in, and only needs to be
+	// told how much of it (see ExternalIndex.Tree).
+	if c.externalSources.Len() > 0 {
+		c.RuleTree.DepthFirst(func(node *TreeNode) bool {
+			if node.External != nil {
+				node.External.MaxIndexData = maxCollectionSize
+				return true
+			}
+			return false
+		})
+	}
+
 	if len(c.Modules) == 0 || len(c.indexDataRefs) == 0 {
 		// Either nothing is compiled yet, in which case the first build picks
 		// the resolver up, or nothing in this policy reads data and rebuilding
@@ -4515,6 +4528,13 @@ func (n *TreeNode) add(path Ref, val any) {
 type ExternalIndex struct {
 	Index ExternalRuleIndex
 	Ref   Ref
+
+	// MaxIndexData is how much data the indices built for this source's rules
+	// may read in, mirroring the maxCollectionSize of
+	// (*Compiler).MaterializeIndexData. The rules are compiled when a query
+	// reaches them, so Tree resolves that data itself, with the resolver it is
+	// given; all it needs from the surrounding compiler is the budget.
+	MaxIndexData int
 }
 
 // Tree resolves external rules for prefix, using resolver to resolve references
@@ -4560,8 +4580,10 @@ func (ei *ExternalIndex) Tree(ctx context.Context, rt *TreeNode, prefix Ref, par
 	}
 	c0 := NewCompiler()
 
+	var skipped []StageID
 	if o != nil {
 		if len(o.SkippedStages) > 0 {
+			skipped = o.SkippedStages
 			c0.WithSkipStages(o.SkippedStages...)
 		}
 
@@ -4593,6 +4615,14 @@ func (ei *ExternalIndex) Tree(ctx context.Context, rt *TreeNode, prefix Ref, par
 	c0.Compile(modules)
 	if c0.Failed() {
 		return nil, nil, c0.Errors
+	}
+
+	// Read the data these rules compare against into their indices, with the
+	// resolver the caller handed us -- which is the evaluator's, so the values
+	// are the ones this query sees, and nothing outlives it. A source that
+	// builds no indices at all is left alone.
+	if ei.MaxIndexData > 0 && !slices.Contains(skipped, StageBuildRuleIndices) {
+		c0.MaterializeIndexData(resolver, ei.MaxIndexData)
 	}
 
 	node := c0.RuleTree.Find(prefix)

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/open-policy-agent/opa/internal/debug"
 	"github.com/open-policy-agent/opa/internal/gojsonschema"
@@ -136,6 +137,10 @@ type Compiler struct {
 	pathExists                 func([]string) (bool, error)
 	pathConflictCheckRoots     []string
 	injectedVirtual            func(Ref) bool // optional custom virtual document checker
+	indexData                  ValueResolver  // optional data source for unrolling collections into the indices
+	maxIndexCollection         int            // largest collection unrolled into an index
+	indexDataRefs              []Ref          // data refs the indices read values from
+	staleIndexData             *staleIndexRefs
 	after                      map[string][]CompilerStageDefinition
 	metrics                    metrics.Metrics
 	capabilities               *Capabilities                 // user-supplied capabilities
@@ -433,6 +438,7 @@ func NewCompiler() *Compiler {
 
 	c.ModuleTree = NewModuleTree(nil)
 	c.RuleTree = NewRuleTree(c.ModuleTree)
+	c.staleIndexData = &staleIndexRefs{}
 
 	c.stages = []stage{
 		// Reference resolution should run first as it may be used to lazily
@@ -659,6 +665,126 @@ func (c *Compiler) QueryCompiler() QueryCompiler {
 func (c *Compiler) WithVirtual(fn func(Ref) bool) *Compiler {
 	c.injectedVirtual = fn
 	return c
+}
+
+// MaterializeIndexData resolves the collections of membership expressions -- the
+// `data.admin_roles` of `allow if input.role in data.admin_roles` -- through
+// resolver, and rebuilds the rule indices with their values unrolled into them,
+// the way a collection literal is. A lookup is then a single hash lookup on
+// input.role no matter how many such rules there are, and needs no access to
+// the collection at all.
+//
+// Collections holding more than maxCollectionSize values are not unrolled, since
+// each value costs a trie node; passing zero leaves the indices alone. See
+// IndexDataRefs for what to unroll again, and when.
+//
+// Call this after Compile -- and before the compiler serves any query, since it
+// mutates the rule indices in place. Calling it beforehand also works: the
+// resolver is then used by the first build, which is what a caller compiling
+// through another package (say rego.CompilerHook) is left with.
+func (c *Compiler) MaterializeIndexData(resolver ValueResolver, maxCollectionSize int) {
+	if maxCollectionSize <= 0 {
+		return
+	}
+
+	c.indexData = resolver
+	c.maxIndexCollection = maxCollectionSize
+
+	if len(c.Modules) == 0 || len(c.indexDataRefs) == 0 {
+		// Either nothing is compiled yet, in which case the first build picks
+		// the resolver up, or nothing in this policy reads data and rebuilding
+		// the indices would change nothing.
+		return
+	}
+
+	c.buildRuleIndices()
+	c.staleIndexData.clear()
+}
+
+// MarkIndexDataStale reports that the data at refs has changed since it was
+// read into the rule indices, so that values read from those refs stop being
+// used to exclude rules -- leaving them as indexed as they were before, and the
+// rest of each index pruning as usual. The next MaterializeIndexData picks the
+// new values up.
+//
+// This is the cheap alternative to recompiling on a data change: marking costs a
+// pointer swap, where recompiling a policy of any size does not belong on the
+// path of a data write. It is safe to call while queries are being evaluated.
+func (c *Compiler) MarkIndexDataStale(refs []Ref) {
+	c.staleIndexData.mark(refs)
+}
+
+// IndexDataStale reports whether the value the rule indices read from ref is
+// known to have changed since. See MarkIndexDataStale.
+func (c *Compiler) IndexDataStale(ref Ref) bool {
+	return c.staleIndexData.contains(ref)
+}
+
+// staleIndexRefs holds the refs whose data has moved out from under the rule
+// indices. It is read on every index lookup that has values to check and
+// written when data changes, so it is swapped rather than locked, and lives
+// behind a pointer so that copies of a Compiler share it.
+type staleIndexRefs struct {
+	refs atomic.Pointer[[]Ref]
+}
+
+func (s *staleIndexRefs) mark(refs []Ref) {
+	if s == nil || len(refs) == 0 {
+		return
+	}
+
+	for {
+		current := s.refs.Load()
+
+		marked := []Ref{}
+		if current != nil {
+			marked = append(marked, *current...)
+		}
+		for _, ref := range refs {
+			marked = appendUnique(marked, ref)
+		}
+
+		if len(marked) == lenRefs(current) {
+			return // all of them were marked already
+		}
+		if s.refs.CompareAndSwap(current, &marked) {
+			return
+		}
+	}
+}
+
+func (s *staleIndexRefs) contains(ref Ref) bool {
+	if s == nil {
+		return false
+	}
+	if current := s.refs.Load(); current != nil {
+		return containsRef(*current, ref)
+	}
+	return false
+}
+
+func (s *staleIndexRefs) clear() {
+	if s != nil {
+		s.refs.Store(nil)
+	}
+}
+
+func lenRefs(refs *[]Ref) int {
+	if refs == nil {
+		return 0
+	}
+	return len(*refs)
+}
+
+// IndexDataRefs returns the refs of the collections the rule indices are
+// built from, whether or not MaterializeIndexData has unrolled them: a collection
+// that was missing, or too large, is one whose data still decides what the
+// indices should look like.
+//
+// Nothing rebuilds a rule index by itself, so a caller that materializes data in has to
+// call MaterializeIndexData again when the data at any of these refs changes.
+func (c *Compiler) IndexDataRefs() []Ref {
+	return c.indexDataRefs
 }
 
 // Compile runs the compilation process on the input modules. The compiled
@@ -1120,6 +1246,8 @@ func (c *Compiler) counterAdd(name string, n uint64) {
 
 func (c *Compiler) buildRuleIndices() {
 
+	c.indexDataRefs = nil
+
 	c.RuleTree.DepthFirst(func(node *TreeNode) bool {
 		if len(node.Values) == 0 && node.External == nil {
 			return false
@@ -1153,9 +1281,13 @@ func (c *Compiler) buildRuleIndices() {
 			}
 		}
 
-		index := newBaseDocEqIndex(c.isVirtual)
+		index := newBaseDocEqIndex(c.isVirtual, withIndexData(c.indexData, c.maxIndexCollection))
 		if index.Build(rules) {
 			node.Index = index
+
+			for _, ref := range index.DataRefs() {
+				c.indexDataRefs = appendUnique(c.indexDataRefs, ref)
+			}
 		}
 		return hasNonGroundRef // currently, we don't allow those branches to go deeper
 	})

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -532,21 +532,71 @@ func (i *refindices) updateMemberRefInValue(rule *Rule, ref Ref, rhs *Term, cons
 		}
 	}
 
-	addRef := func(t *Term) error {
-		i.insert(rule, &refindex{Ref: ref, Value: t.Value})
+	switch rval.(type) {
+	case *Array, Set, Object:
+		i.insertCollection(rule, ref, rval)
+	}
+}
+
+// insertCollection records every value in collection as an alternative value
+// for ref: `x in <collection>` matches if any one of them matches.
+//
+// Only the "any" entries are reconciled up front, and the values themselves are
+// appended without the per-value scan insert does. Inserting them one by one
+// costs a scan over everything recorded for the rule so far -- which, for a
+// collection, is dominated by the values already appended, making the whole
+// thing quadratic in the collection's size. The scan only buys duplicate
+// suppression, and a duplicate value here is harmless: it appends a second,
+// identically prioritized rule node to the same trie child, which the traversal
+// already folds together.
+func (i *refindices) insertCollection(rule *Rule, ref Ref, collection Value) {
+	n := collectionLen(collection)
+	if n == 0 {
+		// `x in []` never holds, but the index records constraints, not
+		// contradictions: leave the rule to its other expressions.
+		return
+	}
+
+	// A value from the collection supersedes the "any" entry that the
+	// expression binding the value recorded for the same ref, exactly like a
+	// scalar does in insert.
+	i.rules[rule] = slices.DeleteFunc(i.rules[rule], func(other *refindex) bool {
+		return other.isVar() && other.Ref.Equal(ref)
+	})
+
+	entries := make([]*refindex, 0, n)
+	appendValue := func(t *Term) error {
+		entries = append(entries, &refindex{Ref: ref, Value: t.Value})
 		return nil
 	}
 
-	switch rcol := rval.(type) {
+	switch coll := collection.(type) {
 	case *Array:
-		_ = rcol.Iter(addRef)
+		_ = coll.Iter(appendValue)
 	case Set:
-		_ = rcol.Iter(addRef)
+		_ = coll.Iter(appendValue)
 	case Object:
-		_ = rcol.Iter(func(_, v *Term) error {
-			return addRef(v)
+		_ = coll.Iter(func(_, v *Term) error {
+			return appendValue(v)
 		})
 	}
+
+	i.rules[rule] = append(i.rules[rule], entries...)
+
+	count, _ := i.frequency.Get(ref)
+	i.frequency.Put(ref, count+len(entries))
+}
+
+func collectionLen(collection Value) int {
+	switch coll := collection.(type) {
+	case *Array:
+		return coll.Len()
+	case Set:
+		return coll.Len()
+	case Object:
+		return coll.Len()
+	}
+	return 0
 }
 
 func (i *refindices) resolveAndValidateRef(rule *Rule, args []*Term, term *Term) Ref {

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -53,8 +53,49 @@ type (
 		defaultRule    *Rule
 		kind           RuleKind
 		onlyGroundRefs bool
+		cfg            indexConfig
+		dataRefs       []Ref
+	}
+
+	// indexConfig holds the optional index features, see newBaseDocEqIndex.
+	indexConfig struct {
+		// data, when set, resolves the collection of a membership expression
+		// while the index is built, so that `x in <ref>` can be indexed like
+		// `x in <collection literal>`.
+		data ValueResolver
+
+		// maxCollection bounds the number of values a single collection may
+		// contribute to the trie. Larger collections aren't unrolled.
+		maxCollection int
+	}
+
+	// indexOption controls optional index features, see newBaseDocEqIndex.
+	indexOption func(*baseDocEqIndex)
+
+	// IndexDataChecker may be implemented by a ValueResolver to tell a rule
+	// index when data it resolved while being built cannot be trusted for the
+	// evaluation at hand.
+	IndexDataChecker interface {
+		// IndexDataStale reports whether the value at ref may differ from the
+		// one seen when the index was built, e.g. because a `with` statement
+		// replaced it, or because it is unknown during partial evaluation.
+		IndexDataStale(ref Ref) bool
 	}
 )
+
+// withIndexData lets the index resolve the collections of membership
+// expressions through resolver while it is built, so that `x in <ref>` is
+// unrolled into the trie like a collection literal. Collections holding more
+// than maxCollection values are left alone; a maxCollection of zero disables
+// unrolling, but the refs are still reported by CollectionRefs.
+func withIndexData(resolver ValueResolver, maxCollection int) indexOption {
+	return func(i *baseDocEqIndex) {
+		if maxCollection > 0 {
+			i.cfg.data = resolver
+			i.cfg.maxCollection = maxCollection
+		}
+	}
+}
 
 // NewIndexResult returns a new IndexResult object.
 func NewIndexResult(kind RuleKind) *IndexResult {
@@ -66,12 +107,16 @@ func (ir *IndexResult) Empty() bool {
 	return len(ir.Rules) == 0 && ir.Default == nil
 }
 
-func newBaseDocEqIndex(isVirtual func(Ref) bool) *baseDocEqIndex {
-	return &baseDocEqIndex{
+func newBaseDocEqIndex(isVirtual func(Ref) bool, opts ...indexOption) *baseDocEqIndex {
+	i := &baseDocEqIndex{
 		isVirtual:      isVirtual,
 		root:           newTrieNodeImpl(),
 		onlyGroundRefs: true,
 	}
+	for _, opt := range opts {
+		opt(i)
+	}
+	return i
 }
 
 func (i *baseDocEqIndex) Build(rules []*Rule) bool {
@@ -80,7 +125,7 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 	}
 
 	i.kind = rules[0].Head.RuleKind()
-	indices := newrefindices(i.isVirtual)
+	indices := newrefindices(i.isVirtual, i.cfg)
 	values := make(map[Var]Value)
 
 	// build indices for each rule.
@@ -122,7 +167,7 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 					if len(values) == 0 {
 						node = node.Insert(ref, nil, nil)
 					} else if len(values) == 1 {
-						node = node.Insert(ref, values[0].Value, values[0].Mapper)
+						node = node.insertIndex(ref, values[0])
 					} else {
 						if slices.ContainsFunc(values, (*refindex).isVar) {
 							child := node.Insert(ref, anyValue, values[0].Mapper)
@@ -138,7 +183,7 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 							// This creates separate paths for each value so different rules with overlapping
 							// values don't interfere with each other.
 							for _, val := range values {
-								child := node.Insert(ref, val.Value, val.Mapper)
+								child := node.insertIndex(ref, val)
 								child.append([...]int{idx, prio}, rule)
 							}
 							prio++
@@ -155,7 +200,22 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 			return false
 		})
 	}
+
+	i.dataRefs = indices.dataRefs
+
 	return true
+}
+
+// DataRefs returns the refs the index reads values from: the collection of a
+// membership expression, `data.groups.admins.members` for a rule saying
+// `input.subject in data.groups.admins.members`, and the value of an equality,
+// `data.config.tenant` for `input.tenant == data.config.tenant`.
+//
+// This is a property of the policy, reported whether or not the index resolved
+// any of them (see withIndexData): a collection that is missing, or too large
+// to unroll, is one whose data still decides what the index should look like.
+func (i *baseDocEqIndex) DataRefs() []Ref {
+	return i.dataRefs
 }
 
 func (i *baseDocEqIndex) Lookup(resolver ValueResolver) (*IndexResult, error) {
@@ -295,6 +355,11 @@ type refindex struct {
 	Ref    Ref
 	Value  Value
 	Mapper *valueMapper
+
+	// From, when set, is the ref of the collection this value was unrolled
+	// from: the index only holds it because the data at that ref said so, and
+	// has to stop relying on it when that data can't be trusted.
+	From Ref
 }
 
 type refindices struct {
@@ -302,13 +367,16 @@ type refindices struct {
 	rules     map[*Rule][]*refindex
 	frequency *util.HasherMap[Ref, int]
 	sorted    []Ref
+	cfg       indexConfig
+	dataRefs  []Ref
 }
 
-func newrefindices(isVirtual func(Ref) bool) *refindices {
+func newrefindices(isVirtual func(Ref) bool, cfg indexConfig) *refindices {
 	return &refindices{
 		isVirtual: isVirtual,
 		rules:     map[*Rule][]*refindex{},
 		frequency: util.NewHasherMap[Ref, int](RefEqual),
+		cfg:       cfg,
 	}
 }
 
@@ -532,10 +600,65 @@ func (i *refindices) updateMemberRefInValue(rule *Rule, ref Ref, rhs *Term, cons
 		}
 	}
 
+	// The collection is behind a ref: `input.role in data.admin_roles`.
+	// Constants take precedence -- a literal collection is right here, no need
+	// to look anywhere else.
+	if !IsConstant(rval) {
+		if cref := i.resolveAndValidateRef(rule, rule.Head.Args, rhs); cref != nil {
+			i.collect(cref)
+			if collection := i.unrollable(cref); collection != nil {
+				i.insertCollection(rule, ref, collection, cref)
+			}
+		}
+		return
+	}
+
 	switch rval.(type) {
 	case *Array, Set, Object:
-		i.insertCollection(rule, ref, rval)
+		i.insertCollection(rule, ref, rval, nil)
 	}
+}
+
+// unrollable resolves the collection at ref for unrolling into the index, and
+// returns nil if that isn't possible or isn't worth it: the data isn't
+// available while the index is built, the value isn't a collection, or it holds
+// more values than the trie should carry.
+func (i *refindices) unrollable(ref Ref) Value {
+	if i.cfg.data == nil {
+		return nil
+	}
+
+	v, err := i.cfg.data.Resolve(ref)
+	if err != nil || v == nil {
+		return nil
+	}
+
+	switch v.(type) {
+	case *Array, Set, Object:
+	default:
+		return nil
+	}
+
+	if n := collectionLen(v); n == 0 || n > i.cfg.maxCollection {
+		return nil
+	}
+
+	return v
+}
+
+func (i *refindices) collect(ref Ref) {
+	i.dataRefs = appendUnique(i.dataRefs, ref)
+}
+
+func appendUnique(refs []Ref, ref Ref) []Ref {
+	if containsRef(refs, ref) {
+		return refs
+	}
+	return append(refs, ref)
+}
+
+func containsRef(refs []Ref, ref Ref) bool {
+	return slices.ContainsFunc(refs, func(other Ref) bool { return RefEqual(other, ref) })
 }
 
 // insertCollection records every value in collection as an alternative value
@@ -549,7 +672,7 @@ func (i *refindices) updateMemberRefInValue(rule *Rule, ref Ref, rhs *Term, cons
 // suppression, and a duplicate value here is harmless: it appends a second,
 // identically prioritized rule node to the same trie child, which the traversal
 // already folds together.
-func (i *refindices) insertCollection(rule *Rule, ref Ref, collection Value) {
+func (i *refindices) insertCollection(rule *Rule, ref Ref, collection Value, from Ref) {
 	n := collectionLen(collection)
 	if n == 0 {
 		// `x in []` never holds, but the index records constraints, not
@@ -566,7 +689,7 @@ func (i *refindices) insertCollection(rule *Rule, ref Ref, collection Value) {
 
 	entries := make([]*refindex, 0, n)
 	appendValue := func(t *Term) error {
-		entries = append(entries, &refindex{Ref: ref, Value: t.Value})
+		entries = append(entries, &refindex{Ref: ref, Value: t.Value, From: from})
 		return nil
 	}
 
@@ -738,9 +861,59 @@ type trieNode struct {
 	undefined *trieNode
 	scalars   *util.HasherMap[Value, *trieNode]
 	array     *trieNode
+	fromData  []*dataChildren
 	rules     []*ruleNode
 	value     *Term
 	multiple  bool
+}
+
+// dataChildren are the children of a ref's node that only exist because the
+// data at ref said so: the values of a collection unrolled into the trie (see
+// withIndexData). When that data can't be trusted for an evaluation -- replaced
+// by a `with` statement, or unknown during partial evaluation -- these children
+// stop discriminating and are all visited, which leaves the rules below them
+// exactly as indexed as they were before their collection was unrolled. The
+// other children of the node keep pruning.
+type dataChildren struct {
+	ref      Ref
+	children []*trieNode
+}
+
+// addDataChild records that child is keyed on a value that came from the
+// collection at ref.
+func (node *trieNode) addDataChild(ref Ref, child *trieNode) {
+	for _, dc := range node.fromData {
+		if RefEqual(dc.ref, ref) {
+			if !slices.Contains(dc.children, child) {
+				dc.children = append(dc.children, child)
+			}
+			return
+		}
+	}
+	node.fromData = append(node.fromData, &dataChildren{ref: ref, children: []*trieNode{child}})
+}
+
+// traverseData visits the children whose collection can't be trusted for this
+// evaluation. Resolvers that don't implement IndexDataChecker are taken at
+// their word.
+func (node *trieNode) traverseData(resolver ValueResolver, tr *trieTraversalResult) error {
+	checker, ok := resolver.(IndexDataChecker)
+	if !ok {
+		return nil
+	}
+
+	for _, dc := range node.fromData {
+		if !checker.IndexDataStale(dc.ref) {
+			continue
+		}
+		for _, child := range dc.children {
+			if err := child.Traverse(resolver, tr); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (node *trieNode) append(prio [2]int, rule *Rule) {
@@ -791,6 +964,16 @@ func (node *trieNode) Do(walker trieWalker) {
 
 	node.array.Do(next)
 	node.next.Do(next)
+}
+
+// insertIndex inserts the child for a single refindex, remembering the ones
+// keyed on a value that came from data (see dataChildren).
+func (node *trieNode) insertIndex(ref Ref, ri *refindex) *trieNode {
+	child := node.Insert(ref, ri.Value, ri.Mapper)
+	if ri.From != nil {
+		node.next.addDataChild(ri.From, child)
+	}
+	return child
 }
 
 func (node *trieNode) Insert(ref Ref, value Value, mapper *valueMapper) *trieNode {
@@ -933,6 +1116,10 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		}
 	}
 
+	if len(node.fromData) > 0 {
+		return node.traverseData(resolver, tr)
+	}
+
 	return nil
 }
 
@@ -1062,6 +1249,16 @@ func (i *refindices) eqOperandsToRefAndValue(rule *Rule, args []*Term, a, b Valu
 			}
 		} else if bval, ok := indexValue(b); ok {
 			b = bval
+		} else if bref, ok := b.(Ref); ok {
+			// The value is behind a ref of its own -- `input.tenant ==
+			// data.config.tenant` -- so it is only a value once that ref is
+			// resolved. See materialize.
+			bval, from := i.materialized(rule, bref)
+			if bval == nil {
+				return false
+			}
+			i.insert(rule, &refindex{Ref: v, Value: bval, From: from})
+			return true
 		} else {
 			return false
 		}
@@ -1070,6 +1267,47 @@ func (i *refindices) eqOperandsToRefAndValue(rule *Rule, args []*Term, a, b Valu
 		return true
 	}
 	return false
+}
+
+// materialized resolves ref, for a value the index would otherwise have no way
+// to know, and reports the ref it came from so that the index can stop relying
+// on it when that data can't be trusted (see dataChildren). It returns nil
+// unless ref reaches a ground base document -- input isn't readable while the
+// index is built, and rules aren't resolvable at lookup time either -- and
+// unless what it resolves to is a value the trie can be keyed on.
+func (i *refindices) materialized(rule *Rule, ref Ref) (Value, Ref) {
+	// A ref rooted at a local -- `x := data.config; input.tenant == x.tenant` --
+	// holds what that local aliases, so long as the local resolves to a ref of
+	// its own.
+	if head, isVar := ref[0].Value.(Var); isVar && !RootDocumentNames.Contains(ref[0]) {
+		resolved := resolveVarToRef(i.rules[rule], rule.Head.Args, head)
+		if resolved == nil {
+			return nil, nil
+		}
+		ref = resolved.Concat(ref[1:])
+	}
+
+	if !ref.HasPrefix(DefaultRootRef) || !i.isValidIndexRef(ref) {
+		return nil, nil
+	}
+
+	i.collect(ref)
+
+	if i.cfg.data == nil {
+		return nil, nil
+	}
+
+	v, err := i.cfg.data.Resolve(ref)
+	if err != nil || v == nil {
+		return nil, nil
+	}
+
+	value, ok := indexValue(v)
+	if !ok {
+		return nil, nil
+	}
+
+	return value, ref
 }
 
 func indexValue(b Value) (Value, bool) {

--- a/v1/ast/index_bench_test.go
+++ b/v1/ast/index_bench_test.go
@@ -108,6 +108,54 @@ func BenchmarkBuildNonsensicalIndex(b *testing.B) {
 	}
 }
 
+// Index build for a single rule whose membership collection holds n values.
+// Recording collection values without the per-value duplicate scan took this
+// from quadratic to linear: at n = 8000, the build was 226ms before.
+//
+// BenchmarkBuildMembershipIndex/1000-16        272750 ns/op
+// BenchmarkBuildMembershipIndex/8000-16       2157209 ns/op
+// BenchmarkBuildMembershipIndex/100000-16    12888042 ns/op
+func BenchmarkBuildMembershipIndex(b *testing.B) {
+	for _, n := range []int{1000, 8000, 100000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			rules := membershipRules(b, n)
+
+			for b.Loop() {
+				index := newBaseDocEqIndex(isVirtual)
+				if !index.Build(rules) {
+					b.Fatal("failed to build index")
+				}
+			}
+		})
+	}
+}
+
+// membershipRules returns one compiled `allow if input.subject in {...}` rule
+// over a set of n values.
+func membershipRules(b *testing.B, n int) []*Rule {
+	b.Helper()
+
+	var sb strings.Builder
+	sb.WriteString("package p\n\nallow if input.subject in {")
+	for i := range n {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`"u`)
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteByte('"')
+	}
+	sb.WriteString("}\n")
+
+	c := NewCompiler()
+	c.Compile(map[string]*Module{"p.rego": MustParseModule(sb.String())})
+	if c.Failed() {
+		b.Fatal(c.Errors)
+	}
+
+	return c.Modules["p.rego"].Rules
+}
+
 type inputResolver struct {
 	input Value
 }

--- a/v1/ast/index_ordering_bench_test.go
+++ b/v1/ast/index_ordering_bench_test.go
@@ -38,7 +38,7 @@ func buildIndexWithOrder(rules []*Rule, orderFn func(*refindices) []Ref) *baseDo
 	idx := newBaseDocEqIndex(func(Ref) bool { return false })
 	idx.kind = rules[0].Head.RuleKind()
 
-	indices := newrefindices(idx.isVirtual)
+	indices := newrefindices(idx.isVirtual, idx.cfg)
 	values := make(map[Var]Value)
 
 	for ridx := range rules {

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -895,6 +895,34 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			},
 		},
 		{
+			note: "internal.member_2: duplicate values in rhs array match once",
+			module: module(`package test
+			p if {
+				__local0__ = input.role
+				internal.member_2(__local0__, ["admin", "admin"])
+			}`),
+			ruleset: "p",
+			input:   `{"role": "admin"}`,
+			expectedRS: []string{
+				`p if { __local0__ = input.role; internal.member_2(__local0__, ["admin", "admin"]) }`,
+			},
+		},
+		{
+			// Every "any" entry for the ref is superseded, not just the first
+			// one, so a second local bound to the same ref doesn't weaken the
+			// membership constraint.
+			note: "internal.member_2: two locals bound to the same ref (no match)",
+			module: module(`package test
+			p if {
+				__local0__ = input.role
+				__local1__ = input.role
+				internal.member_2(__local0__, {"admin", "foo"})
+			}`),
+			ruleset:    "p",
+			input:      `{"role": "guest"}`,
+			expectedRS: []string{},
+		},
+		{
 			note: "internal.member_2: unknown value triggers traverseUnknown (duplicate prevention)",
 			module: module(`package test
 			p if {

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -11,9 +11,16 @@ import (
 
 type testResolver struct {
 	input       *Term
+	data        *Term
 	failRef     Ref
 	unknownRefs Set
+	staleRefs   Set
 	args        []Value
+}
+
+// IndexDataStale implements IndexDataChecker.
+func (r testResolver) IndexDataStale(ref Ref) bool {
+	return r.staleRefs != nil && r.staleRefs.Contains(NewTerm(ref))
 }
 
 func (r testResolver) Resolve(ref Ref) (Value, error) {
@@ -32,6 +39,16 @@ func (r testResolver) Resolve(ref Ref) (Value, error) {
 	}
 	if ref.HasPrefix(InputRootRef) {
 		v, err := r.input.Value.Find(ref[1:])
+		if err != nil {
+			return nil, nil
+		}
+		return v, nil
+	}
+	if ref.HasPrefix(DefaultRootRef) {
+		if r.data == nil {
+			return nil, nil
+		}
+		v, err := r.data.Value.Find(ref[1:])
 		if err != nil {
 			return nil, nil
 		}
@@ -1442,6 +1459,333 @@ func TestBaseDocEqIndexing(t *testing.T) {
 
 }
 
+func TestBaseDocEqIndexingMaterializedData(t *testing.T) {
+	opts := ParserOptions{AllFutureKeywords: true}
+
+	// `p if input.role in data.admins`, sent through the compiler
+	mod := MustParseModuleWithOpts(`package test
+	p if {
+		__local0__ = input.role
+		__local1__ = data.admins
+		internal.member_2(__local0__, __local1__)
+	}`, opts)
+
+	build := func(t *testing.T, data string, maxCollection int, extra ...indexOption) *baseDocEqIndex {
+		t.Helper()
+
+		opts := append([]indexOption{
+			withIndexData(testResolver{data: MustParseTerm(data)}, maxCollection),
+		}, extra...)
+
+		index := newBaseDocEqIndex(func(Ref) bool { return false }, opts...)
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+		return index
+	}
+
+	lookup := func(t *testing.T, index *baseDocEqIndex, resolver testResolver) int {
+		t.Helper()
+
+		result, err := index.Lookup(resolver)
+		if err != nil {
+			t.Fatalf("unexpected error during index lookup: %v", err)
+		}
+		return len(result.Rules)
+	}
+
+	t.Run("prunes on the materialized values", func(t *testing.T) {
+		index := build(t, `{"admins": ["alice"]}`, 100)
+		data := MustParseTerm(`{"admins": ["alice"]}`)
+
+		if exp, act := 1, lookup(t, index, testResolver{input: MustParseTerm(`{"role": "alice"}`), data: data}); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+		if exp, act := 0, lookup(t, index, testResolver{input: MustParseTerm(`{"role": "eve"}`), data: data}); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+
+	t.Run("reports the data ref", func(t *testing.T) {
+		index := build(t, `{"admins": ["alice"]}`, 100)
+
+		refs := index.DataRefs()
+		if len(refs) != 1 || !refs[0].Equal(MustParseRef("data.admins")) {
+			t.Errorf("expected [data.admins], got %v", refs)
+		}
+	})
+
+	t.Run("object values are materialized, not keys", func(t *testing.T) {
+		index := build(t, `{"admins": {"a": "alice"}}`, 100)
+		data := MustParseTerm(`{"admins": {"a": "alice"}}`)
+
+		if exp, act := 1, lookup(t, index, testResolver{input: MustParseTerm(`{"role": "alice"}`), data: data}); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+		if exp, act := 0, lookup(t, index, testResolver{input: MustParseTerm(`{"role": "a"}`), data: data}); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+
+	t.Run("a collection over the cap is not unrolled, but still reported", func(t *testing.T) {
+		index := build(t, `{"admins": ["alice", "bob"]}`, 1)
+
+		if refs := index.DataRefs(); len(refs) != 1 {
+			t.Errorf("expected the collection ref to be reported, got %v", refs)
+		}
+		// nothing constrains input.role, so the rule stays a candidate
+		resolver := testResolver{
+			input: MustParseTerm(`{"role": "eve"}`),
+			data:  MustParseTerm(`{"admins": ["alice", "bob"]}`),
+		}
+		if exp, act := 1, lookup(t, index, resolver); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+
+	// Only the children that came from the collection stop discriminating: a
+	// rule constraining the same ref by other means keeps being pruned.
+	// `input.fox == data.whatever.token` -- the value is a ref too, and one
+	// scalar in the trie is all it takes to index it.
+	t.Run("a scalar behind a ref becomes the indexed value", func(t *testing.T) {
+		mod := MustParseModuleWithOpts(`package test
+		p if input.fox == data.whatever.token
+		p if input.fox == "literal"`, opts)
+
+		data := MustParseTerm(`{"whatever": {"token": "s3cret"}}`)
+		index := newBaseDocEqIndex(func(Ref) bool { return false },
+			withIndexData(testResolver{data: data}, 100))
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+
+		if refs := index.DataRefs(); len(refs) != 1 ||
+			!refs[0].Equal(MustParseRef("data.whatever.token")) {
+			t.Errorf("expected [data.whatever.token], got %v", refs)
+		}
+
+		for input, exp := range map[string]int{
+			`{"fox": "s3cret"}`:  1,
+			`{"fox": "literal"}`: 1,
+			`{"fox": "nope"}`:    0,
+		} {
+			result, err := index.Lookup(testResolver{input: MustParseTerm(input), data: data})
+			if err != nil {
+				t.Fatalf("unexpected error during index lookup: %v", err)
+			}
+			if act := len(result.Rules); exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", input, exp, act)
+			}
+		}
+	})
+
+	// `x := data.whatever; input.fox == x.token` -- the value's ref is rooted at a
+	// local, which resolves to the ref it aliases.
+	t.Run("a scalar behind a ref rooted at a local", func(t *testing.T) {
+		mod := MustParseModuleWithOpts(`package test
+		p if {
+			__local0__ = data.whatever
+			input.fox = __local0__.token
+		}`, opts)
+
+		data := MustParseTerm(`{"whatever": {"token": "s3cret"}}`)
+		index := newBaseDocEqIndex(func(Ref) bool { return false },
+			withIndexData(testResolver{data: data}, 100))
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+
+		if refs := index.DataRefs(); len(refs) != 1 ||
+			!refs[0].Equal(MustParseRef("data.whatever.token")) {
+			t.Errorf("expected [data.whatever.token], got %v", refs)
+		}
+
+		for input, exp := range map[string]int{
+			`{"fox": "s3cret"}`: 1,
+			`{"fox": "nope"}`:   0,
+		} {
+			result, err := index.Lookup(testResolver{input: MustParseTerm(input), data: data})
+			if err != nil {
+				t.Fatalf("unexpected error during index lookup: %v", err)
+			}
+			if act := len(result.Rules); exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", input, exp, act)
+			}
+		}
+	})
+
+	// The local has to resolve to a ref: aliasing a literal leaves nothing to read.
+	t.Run("a local that doesn't resolve to a ref", func(t *testing.T) {
+		mod := MustParseModuleWithOpts(`package test
+		p if {
+			__local0__ = {"token": "s3cret"}
+			input.fox = __local0__.token
+		}`, opts)
+
+		index := newBaseDocEqIndex(func(Ref) bool { return false },
+			withIndexData(testResolver{data: MustParseTerm(`{}`)}, 100))
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+
+		if refs := index.DataRefs(); len(refs) != 0 {
+			t.Errorf("expected no data refs, got %v", refs)
+		}
+	})
+
+	t.Run("a scalar behind a ref stops pruning when stale", func(t *testing.T) {
+		mod := MustParseModuleWithOpts(`package test
+		p if input.fox == data.whatever.token`, opts)
+
+		data := MustParseTerm(`{"whatever": {"token": "s3cret"}}`)
+		index := newBaseDocEqIndex(func(Ref) bool { return false },
+			withIndexData(testResolver{data: data}, 100))
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+
+		result, err := index.Lookup(testResolver{
+			input:     MustParseTerm(`{"fox": "nope"}`),
+			data:      data,
+			staleRefs: NewSet(NewTerm(MustParseRef("data.whatever.token"))),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during index lookup: %v", err)
+		}
+		if exp, act := 1, len(result.Rules); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+
+	t.Run("stale data leaves the rest of the index alone", func(t *testing.T) {
+		mod := MustParseModuleWithOpts(`package test
+		p if {
+			__local0__ = input.role
+			__local1__ = data.admins
+			internal.member_2(__local0__, __local1__)
+		}
+		p if {
+			input.role = "root"
+		}`, opts)
+
+		index := newBaseDocEqIndex(func(Ref) bool { return false },
+			withIndexData(testResolver{data: MustParseTerm(`{"admins": ["alice"]}`)}, 100))
+		if !index.Build(mod.Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+
+		// as if evaluated under `p with data.admins as ["eve"]`
+		result, err := index.Lookup(testResolver{
+			input:     MustParseTerm(`{"role": "eve"}`),
+			data:      MustParseTerm(`{"admins": ["eve"]}`),
+			staleRefs: NewSet(NewTerm(MustParseRef("data.admins"))),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during index lookup: %v", err)
+		}
+
+		// the membership rule is a candidate again, the `= "root"` rule is not
+		if len(result.Rules) != 1 || !result.Rules[0].Equal(mod.Rules[0]) {
+			t.Errorf("expected only the membership rule, got %v", result.Rules)
+		}
+	})
+
+	t.Run("no pruning when the resolver reports the data stale", func(t *testing.T) {
+		index := build(t, `{"admins": ["alice"]}`, 100)
+
+		// e.g. `p with data.admins as ["eve"]`: the materialized values say nothing
+		// about this evaluation, so every rule has to be evaluated.
+		resolver := testResolver{
+			input:     MustParseTerm(`{"role": "eve"}`),
+			data:      MustParseTerm(`{"admins": ["eve"]}`),
+			staleRefs: NewSet(NewTerm(MustParseRef("data.admins"))),
+		}
+		if exp, act := 1, lookup(t, index, resolver); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+
+	t.Run("materialized values are not refreshed by a lookup", func(t *testing.T) {
+		index := build(t, `{"admins": ["alice"]}`, 100)
+
+		// Pinning the contract of WithIndexData: the index prunes against the
+		// data it was built with, whatever the resolver says now, so whoever
+		// enables it has to recompile when that data changes.
+		resolver := testResolver{
+			input: MustParseTerm(`{"role": "eve"}`),
+			data:  MustParseTerm(`{"admins": ["eve"]}`),
+		}
+		if exp, act := 0, lookup(t, index, resolver); exp != act {
+			t.Errorf("expected %d rule(s), got %d", exp, act)
+		}
+	})
+}
+
+// A collection that a rule contributes to isn't in the store, so its values
+// can't be materializedto the index -- and can't be resolved on lookup either, which
+// is what isValidIndexRef rejects virtual refs for. Such a membership expression
+// contributes nothing to the index and the rule stays a candidate.
+func TestIndexDataNotMaterializedForVirtualCollections(t *testing.T) {
+	// what the store holds at those paths, shadowed by the rules below
+	data := MustParseTerm(`{"test": {
+		"groups": {"admins": {"members": ["alice"]}},
+		"members": ["alice"]
+	}}`)
+
+	tests := []struct {
+		note         string
+		module       string
+		materialized []string
+	}{
+		{
+			note: "collection is a complete rule",
+			module: `package test
+			groups.admins.members := ["carol"]
+			allow if input.subject in data.test.groups.admins.members`,
+		},
+		{
+			note: "collection is produced by a general ref rule",
+			module: `package test
+			groups[k].members := ["carol"] if some k in ["admins"]
+			allow if input.subject in data.test.groups.admins.members`,
+		},
+		{
+			note: "collection is a partial set rule",
+			module: `package test
+			members contains "carol"
+			allow if input.subject in data.test.members`,
+		},
+		{
+			note: "collection is base data, rules elsewhere in the package",
+			module: `package test
+			other := 1
+			allow if input.subject in data.test.groups.admins.members`,
+			materialized: []string{"data.test.groups.admins.members"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := NewCompiler()
+			c.Compile(map[string]*Module{"test.rego": MustParseModule(tc.module)})
+			if c.Failed() {
+				t.Fatal(c.Errors)
+			}
+			c.MaterializeIndexData(testResolver{data: data}, 100)
+
+			materialized := c.IndexDataRefs()
+			if len(materialized) != len(tc.materialized) {
+				t.Fatalf("expected %v to be reported, got %v", tc.materialized, materialized)
+			}
+			for i := range tc.materialized {
+				if !materialized[i].Equal(MustParseRef(tc.materialized[i])) {
+					t.Errorf("expected %v, got %v", tc.materialized[i], materialized[i])
+				}
+			}
+		})
+	}
+}
+
 func TestBaseDocEqIndexingPriorities(t *testing.T) {
 
 	module := module(`
@@ -1537,7 +1881,7 @@ func TestBaseDocEqIndexingErrors(t *testing.T) {
 }
 
 func TestRefIndicesSorted(t *testing.T) {
-	ri := newrefindices(func(Ref) bool { return false })
+	ri := newrefindices(func(Ref) bool { return false }, indexConfig{})
 
 	// Insert refs with distinct frequencies in an order that doesn't match
 	// the expected (frequency-descending) output, so that a sort which

--- a/v1/plugins/bundle/plugin_ruleindexdata_test.go
+++ b/v1/plugins/bundle/plugin_ruleindexdata_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
+	"github.com/open-policy-agent/opa/v1/download"
+	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/plugins"
+	inmemtst "github.com/open-policy-agent/opa/v1/storage/inmem/test"
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+const ruleIndexDataModule = `package test
+
+allow if input.subject in data.groups.admins.members
+`
+
+// materializedAdmins returns the members the rule index prunes against.
+func materializedAdmins(t *testing.T, manager *plugins.Manager) []string {
+	t.Helper()
+
+	compiler := manager.GetCompiler()
+	if compiler == nil {
+		t.Fatal("no compiler on the manager")
+	}
+
+	if refs := compiler.IndexDataRefs(); len(refs) != 1 ||
+		!refs[0].Equal(ast.MustParseRef("data.groups.admins.members")) {
+		t.Fatalf("expected data.groups.admins.members to be materialized, got %v", refs)
+	}
+
+	index := compiler.RuleIndex(ast.MustParseRef("data.test.allow"))
+	if index == nil {
+		t.Fatal("no rule index for data.test.allow")
+	}
+
+	var found []string
+	for _, candidate := range []string{"alice", "bob"} {
+		// The resolver's data is empty on purpose: only values materializedto the
+		// index at compile time can keep the rule a candidate here.
+		result, err := index.Lookup(indexDataTestResolver{
+			compiler: compiler,
+			input:    ast.MustParseTerm(`{"subject": "` + candidate + `"}`),
+			data:     ast.MustParseTerm(`{"groups": {"admins": {"members": []}}}`),
+		})
+		if err != nil {
+			t.Fatalf("index lookup: %v", err)
+		}
+		if len(result.Rules) > 0 {
+			found = append(found, candidate)
+		}
+	}
+	return found
+}
+
+type indexDataTestResolver struct {
+	compiler *ast.Compiler
+	input    *ast.Term
+	data     *ast.Term
+}
+
+func (r indexDataTestResolver) IndexDataStale(ref ast.Ref) bool {
+	return r.compiler.IndexDataStale(ref)
+}
+
+func (r indexDataTestResolver) Resolve(ref ast.Ref) (ast.Value, error) {
+	root := r.input
+	if ref.HasPrefix(ast.DefaultRootRef) {
+		root = r.data
+	}
+	v, err := root.Value.Find(ref[1:])
+	if err != nil {
+		return nil, nil
+	}
+	return v, nil
+}
+
+// A snapshot bundle carries the policy and the data it indexes in one
+// transaction, and the modules are compiled before that data reaches the store.
+func TestRuleIndexDataSnapshotBundle(t *testing.T) {
+	ctx := t.Context()
+
+	store := inmemtst.New()
+	manager, err := plugins.New(nil, "test-instance-id", store, plugins.RuleIndexData(100))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop(ctx)
+
+	plugin := New(&Config{}, manager)
+	bundleName := "test-bundle"
+	plugin.status[bundleName] = &Status{Name: bundleName, Metrics: metrics.New()}
+	plugin.downloaders[bundleName] = download.New(download.Config{}, plugin.manager.Client(""), bundleName)
+
+	b := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "one"},
+		Data:     util.MustUnmarshalJSON([]byte(`{"groups": {"admins": {"members": ["alice"]}}}`)).(map[string]any),
+		Modules: []bundle.ModuleFile{{
+			Path:   "/test.rego",
+			Parsed: ast.MustParseModule(ruleIndexDataModule),
+			Raw:    []byte(ruleIndexDataModule),
+		}},
+	}
+	b.Manifest.Init()
+
+	if err := plugin.oneShot(ctx, bundleName, download.Update{Bundle: &b, Metrics: metrics.New(), Size: snapshotBundleSize}); err != nil {
+		t.Fatal(err)
+	}
+
+	if act := materializedAdmins(t, manager); len(act) != 1 || act[0] != "alice" {
+		t.Fatalf("expected [alice] materialized, got %v", act)
+	}
+
+	// A second snapshot with different data: recompiled anyway, but the values
+	// have to come from the new bundle rather than the store's previous state.
+	b2 := b
+	b2.Manifest = bundle.Manifest{Revision: "two"}
+	b2.Data = util.MustUnmarshalJSON([]byte(`{"groups": {"admins": {"members": ["bob"]}}}`)).(map[string]any)
+	b2.Manifest.Init()
+
+	if err := plugin.oneShot(ctx, bundleName, download.Update{Bundle: &b2, Metrics: metrics.New(), Size: snapshotBundleSize}); err != nil {
+		t.Fatal(err)
+	}
+
+	if act := materializedAdmins(t, manager); len(act) != 1 || act[0] != "bob" {
+		t.Errorf("expected [bob] materialized after the second snapshot, got %v", act)
+	}
+}
+
+// A delta bundle patches data without compiling anything, so the values read into
+// the indices are the ones the last activation saw. The manager marks the refs it
+// moved rather than recompiling -- see plugins.Manager.onCommit.
+func TestRuleIndexDataDeltaBundle(t *testing.T) {
+	ctx := t.Context()
+
+	store := inmemtst.New()
+	manager, err := plugins.New(nil, "test-instance-id", store, plugins.RuleIndexData(100))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop(ctx)
+
+	plugin := New(&Config{}, manager)
+	bundleName := "test-bundle"
+	plugin.status[bundleName] = &Status{Name: bundleName, Metrics: metrics.New()}
+	plugin.downloaders[bundleName] = download.New(download.Config{}, plugin.manager.Client(""), bundleName)
+
+	b := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "one", Roots: &[]string{"groups", "test"}},
+		Data:     util.MustUnmarshalJSON([]byte(`{"groups": {"admins": {"members": ["alice"]}}}`)).(map[string]any),
+		Modules: []bundle.ModuleFile{{
+			Path:   "/test.rego",
+			Parsed: ast.MustParseModule(ruleIndexDataModule),
+			Raw:    []byte(ruleIndexDataModule),
+		}},
+	}
+
+	if err := plugin.oneShot(ctx, bundleName, download.Update{Bundle: &b, Metrics: metrics.New(), Size: snapshotBundleSize}); err != nil {
+		t.Fatal(err)
+	}
+	if act := materializedAdmins(t, manager); len(act) != 1 || act[0] != "alice" {
+		t.Fatalf("expected [alice] materialized, got %v", act)
+	}
+
+	delta := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "two", Roots: &[]string{"groups", "test"}},
+		Patch: bundle.Patch{Data: []bundle.PatchOperation{{
+			Op:    "upsert",
+			Path:  "/groups/admins/members",
+			Value: []any{"bob"},
+		}}},
+	}
+
+	if err := plugin.oneShot(ctx, bundleName, download.Update{Bundle: &delta, Metrics: metrics.New(), Size: deltaBundleSize}); err != nil {
+		t.Fatal(err)
+	}
+
+	membersRef := ast.MustParseRef("data.groups.admins.members")
+	if !manager.GetCompiler().IndexDataStale(membersRef) {
+		t.Errorf("expected %v to be marked stale by the delta bundle", membersRef)
+	}
+	if act := materializedAdmins(t, manager); len(act) != 2 {
+		t.Errorf("expected the rule to be a candidate for both subjects, got %v", act)
+	}
+
+	// The next snapshot compiles, so it reads the patched members.
+	snapshot := bundle.Bundle{
+		Manifest: bundle.Manifest{Revision: "three", Roots: &[]string{"groups", "test"}},
+		Data:     util.MustUnmarshalJSON([]byte(`{"groups": {"admins": {"members": ["bob"]}}}`)).(map[string]any),
+		Modules: []bundle.ModuleFile{{
+			Path:   "/test.rego",
+			Parsed: ast.MustParseModule(ruleIndexDataModule),
+			Raw:    []byte(ruleIndexDataModule),
+		}},
+	}
+
+	if err := plugin.oneShot(ctx, bundleName, download.Update{Bundle: &snapshot, Metrics: metrics.New(), Size: snapshotBundleSize}); err != nil {
+		t.Fatal(err)
+	}
+
+	if act := materializedAdmins(t, manager); len(act) != 1 || act[0] != "bob" {
+		t.Errorf("expected [bob] read into the index after the snapshot, got %v", act)
+	}
+}

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -6,6 +6,7 @@
 package plugins
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -222,6 +223,7 @@ type Manager struct {
 	serverInitializedOnce        sync.Once
 	printHook                    print.Hook
 	enablePrintStatements        bool
+	ruleIndexDataMaxCollection   int
 	router                       *http.ServeMux
 	prometheusRegister           prometheus.Registerer
 	tracerProvider               *trace.TracerProvider
@@ -422,6 +424,34 @@ func EnablePrintStatements(yes bool) func(*Manager) {
 	}
 }
 
+// DefaultRuleIndexDataMaxCollection is the largest collection materialized into
+// a rule index unless RuleIndexData says otherwise. It is a trade of memory for
+// lookup speed: each value costs around 250 bytes of trie per rule, so a
+// thousand of them is a quarter of a megabyte for a collection every rule in a
+// package shares.
+const DefaultRuleIndexDataMaxCollection = 1000
+
+// RuleIndexData sets how much data the rule indices may materialize: a
+// membership expression over a data ref, like `input.role in data.admin_roles`,
+// is indexed as the collection it resolves to, and an equality against one,
+// like `input.tenant == data.config.tenant`, as the value it resolves to (see
+// ast.Compiler.MaterializeIndexData). That turns a lookup into a single hash
+// lookup however many such rules there are, instead of leaving every one of
+// them a candidate.
+//
+// Collections holding more than maxCollectionSize values are left alone, since
+// each value costs a trie node. Zero disables materializing altogether; the
+// default is DefaultRuleIndexDataMaxCollection.
+//
+// The manager materializes into every compiler it installs, and recompiles when
+// a commit writes anywhere near the data the indices read -- see
+// Manager.onCommit.
+func RuleIndexData(maxCollectionSize int) func(*Manager) {
+	return func(m *Manager) {
+		m.ruleIndexDataMaxCollection = maxCollectionSize
+	}
+}
+
 func PrintHook(h print.Hook) func(*Manager) {
 	return func(m *Manager) {
 		m.printHook = h
@@ -541,16 +571,17 @@ func New(raw []byte, id string, store storage.Store, opts ...func(*Manager)) (*M
 	}
 
 	m := &Manager{
-		Store:                 store,
-		Config:                parsedConfig,
-		ID:                    id,
-		maxErrors:             -1,
-		serverInitialized:     make(chan struct{}),
-		bootstrapConfigLabels: parsedConfig.Labels,
-		extraRoutes:           map[string]ExtraRoute{},
-		pluginStatusCh:        make(chan pluginStatusMsg),
-		stopPluginStatusCh:    make(chan chan struct{}),
-		pluginStatusDoneCh:    make(chan struct{}),
+		Store:                      store,
+		Config:                     parsedConfig,
+		ID:                         id,
+		maxErrors:                  -1,
+		ruleIndexDataMaxCollection: DefaultRuleIndexDataMaxCollection,
+		serverInitialized:          make(chan struct{}),
+		bootstrapConfigLabels:      parsedConfig.Labels,
+		extraRoutes:                map[string]ExtraRoute{},
+		pluginStatusCh:             make(chan pluginStatusMsg),
+		stopPluginStatusCh:         make(chan chan struct{}),
+		pluginStatusDoneCh:         make(chan struct{}),
 	}
 
 	for _, f := range opts {
@@ -647,6 +678,8 @@ func (m *Manager) Init(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
+		m.materializeIndexData(ctx, txn, result.Compiler)
 
 		SetCompilerOnContext(params.Context, result.Compiler)
 
@@ -1098,6 +1131,27 @@ func (m *Manager) onCommit(ctx context.Context, txn storage.Transaction, event s
 		compiler, _ = loadCompilerFromStore(ctx, m.Store, txn, m.enablePrintStatements, m.ParserOptions(), m.GetExternalSources())
 	}
 
+	// The rule indices read the data they compare against when they were built,
+	// and nothing rebuilds a rule index by itself.
+	if inUse := m.GetCompiler(); compiler != nil && compiler != inUse {
+		// A compiler compiled for this transaction, not serving queries yet: it
+		// sees the data this transaction wrote, so read that data into its
+		// indices before installing it. This is also where a snapshot bundle's
+		// own data is picked up, which the activation itself compiled too early
+		// to see.
+		m.materializeIndexData(ctx, txn, compiler)
+	} else if serving := cmp.Or(compiler, inUse); serving != nil {
+		// The compiler in play read its values before this commit -- a write
+		// through the Data API, or a delta bundle, which patches data and hands
+		// back the very compiler already installed. Recompiling here would put a
+		// policy compilation on the path of every data write, which for
+		// deployments with dynamic data is most of them; mark the refs whose
+		// data moved instead. Values read from them stop excluding rules, which
+		// leaves those rules as indexed as they were before the data was read
+		// into them, and the next compilation picks the new values up.
+		serving.MarkIndexDataStale(m.indexDataRefsAffectedBy(event, serving))
+	}
+
 	if compiler != nil {
 		m.setCompiler(compiler)
 
@@ -1310,6 +1364,78 @@ func (m *Manager) PrintHook() print.Hook {
 
 func (m *Manager) EnablePrintStatements() bool {
 	return m.enablePrintStatements
+}
+
+// materializeIndexData unrolls the data behind the compiler's membership expressions
+// into its rule indices. compiler must not be serving queries yet.
+func (m *Manager) materializeIndexData(ctx context.Context, txn storage.Transaction, compiler *ast.Compiler) {
+	if m.ruleIndexDataMaxCollection > 0 && compiler != nil {
+		resolver := storeResolver{ctx: ctx, store: m.Store, txn: txn}
+		compiler.MaterializeIndexData(resolver, m.ruleIndexDataMaxCollection)
+	}
+}
+
+// storeResolver answers the compiler's data lookups out of the store, within
+// the transaction it was made for -- and only for as long as that is open.
+// Refs into anything else, input or function arguments, are unknown to it.
+type storeResolver struct {
+	ctx   context.Context
+	store storage.Store
+	txn   storage.Transaction
+}
+
+func (r storeResolver) Resolve(ref ast.Ref) (ast.Value, error) {
+	if !ref.HasPrefix(ast.DefaultRootRef) {
+		return nil, ast.UnknownValueErr{}
+	}
+
+	path, err := storage.NewPathForRef(ref)
+	if err != nil {
+		// Not a path into the data document, e.g. a ref with a composite or
+		// non-ground key: nothing is stored there.
+		return nil, nil
+	}
+
+	value, err := r.store.Read(r.ctx, r.txn, path)
+	if err != nil {
+		if storage.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if v, ok := value.(ast.Value); ok { // store returns AST values
+		return v, nil
+	}
+
+	return ast.InterfaceToValue(value)
+}
+
+// indexDataRefsAffectedBy returns the collection refs the compiler's rule
+// indices are built from that the event's writes reach, either because a write
+// lands inside one of the collections or because it replaces something they
+// live under.
+func (m *Manager) indexDataRefsAffectedBy(event storage.TriggerEvent, compiler *ast.Compiler) []ast.Ref {
+	if !event.DataChanged() || m.ruleIndexDataMaxCollection == 0 || compiler == nil {
+		return nil
+	}
+
+	var affected []ast.Ref
+
+	for _, ref := range compiler.IndexDataRefs() {
+		path, err := storage.NewPathForRef(ref)
+		if err != nil {
+			continue
+		}
+		for _, write := range event.Data {
+			if write.Path.HasPrefix(path) || path.HasPrefix(write.Path) {
+				affected = append(affected, ref)
+				break
+			}
+		}
+	}
+
+	return affected
 }
 
 // ServerInitialized signals a channel indicating that the OPA

--- a/v1/plugins/plugins_ruleindexdata_test.go
+++ b/v1/plugins/plugins_ruleindexdata_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
+	realinmem "github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+const ruleIndexDataPolicy = `package test
+
+allow if input.subject in data.groups.admins.members
+`
+
+var membersRef = ast.MustParseRef("data.groups.admins.members")
+
+// prunedTo returns the subjects the rule index keeps the rule a candidate for.
+// The resolver's own data is empty, so only members read into the index when it
+// was built survive -- and all three subjects coming back means the index holds
+// nothing it can use.
+func prunedTo(t *testing.T, m *Manager) []string {
+	t.Helper()
+
+	compiler := m.GetCompiler()
+	if compiler == nil {
+		t.Fatal("no compiler on the manager")
+	}
+
+	if refs := compiler.IndexDataRefs(); len(refs) != 1 || !refs[0].Equal(membersRef) {
+		t.Fatalf("expected %v to be reported, got %v", membersRef, refs)
+	}
+
+	index := compiler.RuleIndex(ast.MustParseRef("data.test.allow"))
+	if index == nil {
+		t.Fatal("no rule index for data.test.allow")
+	}
+
+	var found []string
+	for _, candidate := range []string{"alice", "bob", "eve"} {
+		result, err := index.Lookup(indexTestResolver{
+			compiler: compiler,
+			input:    ast.MustParseTerm(`{"subject": "` + candidate + `"}`),
+			data:     ast.MustParseTerm(`{"groups": {"admins": {"members": []}}}`),
+		})
+		if err != nil {
+			t.Fatalf("index lookup: %v", err)
+		}
+		if len(result.Rules) > 0 {
+			found = append(found, candidate)
+		}
+	}
+	return found
+}
+
+// indexTestResolver stands in for topdown's resolver, which reports the data the
+// manager has marked as moved (see ast.Compiler.MarkIndexDataStale).
+type indexTestResolver struct {
+	compiler *ast.Compiler
+	input    *ast.Term
+	data     *ast.Term
+}
+
+func (r indexTestResolver) Resolve(ref ast.Ref) (ast.Value, error) {
+	root := r.input
+	if ref.HasPrefix(ast.DefaultRootRef) {
+		root = r.data
+	}
+	v, err := root.Value.Find(ref[1:])
+	if err != nil {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (r indexTestResolver) IndexDataStale(ref ast.Ref) bool {
+	return r.compiler.IndexDataStale(ref)
+}
+
+func newRuleIndexDataManager(t *testing.T, ctx context.Context, store storage.Store) *Manager {
+	t.Helper()
+
+	m, err := New([]byte{}, "test", store, RuleIndexData(100))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		return store.UpsertPolicy(ctx, txn, "test.rego", []byte(ruleIndexDataPolicy))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func storeWithAdmins(members ...any) storage.Store {
+	return realinmem.NewFromObject(map[string]any{
+		"groups": map[string]any{"admins": map[string]any{"members": members}},
+	})
+}
+
+func upsertPolicy(t *testing.T, ctx context.Context, store storage.Store, name, module string) {
+	t.Helper()
+
+	if err := storage.Txn(ctx, store, storage.WriteParams, func(txn storage.Transaction) error {
+		return store.UpsertPolicy(ctx, txn, name, []byte(module))
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A data change marks the refs whose data moved rather than recompiling: putting
+// a policy compilation on the path of a data write would cost more than the
+// indexing saves for any deployment whose data is dynamic.
+func TestRuleIndexDataMarkedOnDataChange(t *testing.T) {
+	ctx := t.Context()
+	store := storeWithAdmins("alice")
+
+	m := newRuleIndexDataManager(t, ctx, store)
+
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Fatalf("expected the index to prune to [alice], got %v", act)
+	}
+
+	before := m.GetCompiler()
+	if err := storage.WriteOne(ctx, store, storage.AddOp,
+		storage.MustParsePath("/groups/admins/members/-"), "bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.GetCompiler() != before {
+		t.Error("expected no recompilation on a data change")
+	}
+	if !m.GetCompiler().IndexDataStale(membersRef) {
+		t.Errorf("expected %v to be marked stale", membersRef)
+	}
+	if act := prunedTo(t, m); len(act) != 3 {
+		t.Errorf("expected the rule to be a candidate for every subject, got %v", act)
+	}
+
+	// The next compilation reads the members as they are now, and stops marking.
+	upsertPolicy(t, ctx, store, "other.rego", "package other\n\nq := 1\n")
+
+	if m.GetCompiler().IndexDataStale(membersRef) {
+		t.Errorf("expected %v not to be marked after recompiling", membersRef)
+	}
+	if act := prunedTo(t, m); len(act) != 2 || act[0] != "alice" || act[1] != "bob" {
+		t.Errorf("expected the index to prune to [alice bob], got %v", act)
+	}
+}
+
+// Policies compiled first, data pushed afterwards: nothing was read into the
+// index, so nothing prunes until a compilation reads the data that arrived.
+func TestRuleIndexDataArrivingAfterThePolicies(t *testing.T) {
+	ctx := t.Context()
+	store := realinmem.NewFromObject(map[string]any{})
+
+	m := newRuleIndexDataManager(t, ctx, store)
+
+	if act := prunedTo(t, m); len(act) != 3 {
+		t.Fatalf("expected no pruning without the data, got %v", act)
+	}
+
+	if err := storage.WriteOne(ctx, store, storage.AddOp,
+		storage.MustParsePath("/groups"), map[string]any{
+			"admins": map[string]any{"members": []any{"alice"}},
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	if act := prunedTo(t, m); len(act) != 3 {
+		t.Errorf("expected the write not to reach the index by itself, got %v", act)
+	}
+
+	upsertPolicy(t, ctx, store, "other.rego", "package other\n\nq := 1\n")
+
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Errorf("expected the index to prune to [alice] after recompiling, got %v", act)
+	}
+}
+
+func TestRuleIndexDataIgnoresUnrelatedDataChange(t *testing.T) {
+	ctx := t.Context()
+	store := storeWithAdmins("alice")
+
+	m := newRuleIndexDataManager(t, ctx, store)
+
+	if err := storage.WriteOne(ctx, store, storage.AddOp,
+		storage.MustParsePath("/unrelated"), "x"); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.GetCompiler().IndexDataStale(membersRef) {
+		t.Error("expected a write outside the index's refs to leave it alone")
+	}
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Errorf("expected the index to still prune to [alice], got %v", act)
+	}
+}
+
+// A policy change recompiles without any data changing, so nothing about the
+// commit says the indices need data read into them again -- but the compiler
+// replacing the one in use has none.
+func TestRuleIndexDataSurvivesAPolicyChange(t *testing.T) {
+	ctx := t.Context()
+	store := storeWithAdmins("alice")
+
+	m := newRuleIndexDataManager(t, ctx, store)
+
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Fatalf("expected the index to prune to [alice], got %v", act)
+	}
+
+	upsertPolicy(t, ctx, store, "other.rego", "package other\n\nq := 1\n")
+
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Errorf("expected the index to still prune to [alice], got %v", act)
+	}
+}
+
+func TestRuleIndexDataOnByDefault(t *testing.T) {
+	ctx := t.Context()
+	store := storeWithAdmins("alice")
+
+	m, err := New([]byte{}, "test", store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upsertPolicy(t, ctx, store, "test.rego", ruleIndexDataPolicy)
+	if err := m.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if act := prunedTo(t, m); len(act) != 1 || act[0] != "alice" {
+		t.Errorf("expected the index to prune to [alice] without passing the option, got %v", act)
+	}
+}
+
+func TestRuleIndexDataOff(t *testing.T) {
+	ctx := t.Context()
+	store := storeWithAdmins("alice")
+
+	m, err := New([]byte{}, "test", store, RuleIndexData(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	upsertPolicy(t, ctx, store, "test.rego", ruleIndexDataPolicy)
+	if err := m.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The data ref is reported either way -- it is a property of the policy --
+	// but nothing was read into the index, so nothing is pruned.
+	if act := prunedTo(t, m); len(act) != 3 {
+		t.Errorf("expected no pruning with the option off, got %v", act)
+	}
+
+	if err := storage.WriteOne(ctx, store, storage.AddOp,
+		storage.MustParsePath("/groups/admins/members/-"), "bob"); err != nil {
+		t.Fatal(err)
+	}
+	if m.GetCompiler().IndexDataStale(membersRef) {
+		t.Error("expected no marking with the option off")
+	}
+}

--- a/v1/rego/rego_index_data_test.go
+++ b/v1/rego/rego_index_data_test.go
@@ -1,0 +1,503 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/topdown"
+)
+
+// dataResolver answers the compiler's data lookups from a snapshot of the store.
+// This is the part a caller enabling WithIndexData has to provide; a
+// store-backed one lives with the plugin that recompiles on data changes.
+type dataResolver struct {
+	data ast.Value
+}
+
+func newDataResolver(t *testing.T, ctx context.Context, store storage.Store) dataResolver {
+	t.Helper()
+
+	v, err := storage.ReadOne(ctx, store, storage.Path{})
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	data, err := ast.InterfaceToValue(v)
+	if err != nil {
+		t.Fatalf("convert data: %v", err)
+	}
+	return dataResolver{data: data}
+}
+
+func (r dataResolver) Resolve(ref ast.Ref) (ast.Value, error) {
+	if !ref.HasPrefix(ast.DefaultRootRef) {
+		return nil, ast.UnknownValueErr{}
+	}
+	v, err := r.data.Find(ref[1:])
+	if err != nil {
+		return nil, nil // undefined, not an error
+	}
+	return v, nil
+}
+
+const groupsModule = `package test
+
+allow if input.subject in data.groups.admins.members
+
+allow if input.subject in data.groups.devs.members
+`
+
+func TestIndexMaterializedDataEndToEnd(t *testing.T) {
+	ctx := t.Context()
+
+	store := inmem.NewFromObject(map[string]any{
+		"groups": map[string]any{
+			"admins": map[string]any{"members": []any{"alice"}},
+			"devs":   map[string]any{"members": []any{"bob"}},
+		},
+	})
+
+	prepare := func(t *testing.T, maxCollection int) PreparedEvalQuery {
+		t.Helper()
+
+		resolver := newDataResolver(t, ctx, store)
+		pq, err := New(
+			Query("data.test.allow"),
+			Module("test.rego", groupsModule),
+			Store(store),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(resolver, maxCollection)
+			}),
+		).PrepareForEval(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		return pq
+	}
+
+	eval := func(t *testing.T, pq PreparedEvalQuery, subject string, opts ...EvalOption) bool {
+		t.Helper()
+
+		rs, err := pq.Eval(ctx, append(opts, EvalInput(map[string]any{"subject": subject}))...)
+		if err != nil {
+			t.Fatalf("eval: %v", err)
+		}
+		if len(rs) == 0 {
+			return false
+		}
+		allowed, ok := rs[0].Expressions[0].Value.(bool)
+		if !ok {
+			t.Fatalf("expected boolean result, got %[1]v (%[1]T)", rs[0].Expressions[0].Value)
+		}
+		return allowed
+	}
+
+	rulesEntered := func(tracer *topdown.BufferTracer) int {
+		count := 0
+		for _, event := range *tracer {
+			if event.Op == topdown.EnterOp {
+				if _, ok := event.Node.(*ast.Rule); ok {
+					count++
+				}
+			}
+		}
+		return count
+	}
+
+	t.Run("materialized values prune without resolving any collection", func(t *testing.T) {
+		pq := prepare(t, 1000)
+		tracer := topdown.NewBufferTracer()
+
+		if !eval(t, pq, "alice", EvalQueryTracer(tracer)) {
+			t.Error("expected alice to be allowed")
+		}
+		if exp, act := 1, rulesEntered(tracer); exp != act {
+			t.Errorf("expected %d rule(s) to be evaluated, got %d", exp, act)
+		}
+		if eval(t, pq, "eve") {
+			t.Error("expected eve not to be allowed")
+		}
+	})
+
+	t.Run("compiler reports the collection refs", func(t *testing.T) {
+		resolver := newDataResolver(t, ctx, store)
+		c := ast.NewCompiler()
+		c.Compile(map[string]*ast.Module{
+			"test.rego": ast.MustParseModuleWithOpts(groupsModule, ast.ParserOptions{}),
+		})
+		if c.Failed() {
+			t.Fatal(c.Errors)
+		}
+		c.MaterializeIndexData(resolver, 1000)
+
+		refs := c.IndexDataRefs()
+		if len(refs) != 2 {
+			t.Fatalf("expected 2 materialized refs, got %v", refs)
+		}
+		for _, exp := range []string{"data.groups.admins.members", "data.groups.devs.members"} {
+			if !refs[0].Equal(ast.MustParseRef(exp)) && !refs[1].Equal(ast.MustParseRef(exp)) {
+				t.Errorf("expected %v among the materialized refs, got %v", exp, refs)
+			}
+		}
+	})
+
+	// A `with` statement replaces the collection for one evaluation only, so the
+	// materialized values say nothing about it: the index stops pruning instead of
+	// answering from stale data.
+	t.Run("honors with-replacement of a materialized collection", func(t *testing.T) {
+		resolver := newDataResolver(t, ctx, store)
+		pq, err := New(
+			Query(`data.test.allow with data.groups.admins.members as ["eve"]`),
+			Module("test.rego", groupsModule),
+			Store(store),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(resolver, 1000)
+			}),
+		).PrepareForEval(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+
+		tracer := topdown.NewBufferTracer()
+		if !eval(t, pq, "eve", EvalQueryTracer(tracer)) {
+			t.Error("expected eve to be allowed through the replaced collection")
+		}
+		if eval(t, pq, "alice") {
+			t.Error("expected alice not to be allowed through the replaced collection")
+		}
+
+		// Only the rule over the replaced collection loses its pruning: the one
+		// over data.groups.devs.members is still indexed on its own values.
+		if exp, act := 1, rulesEntered(tracer); exp != act {
+			t.Errorf("expected %d rule(s) to be evaluated, got %d", exp, act)
+		}
+	})
+
+	// ... and so does a replacement *inside* a materialized collection's path.
+	t.Run("honors with-replacement above a materialized collection", func(t *testing.T) {
+		resolver := newDataResolver(t, ctx, store)
+		pq, err := New(
+			Query(`data.test.allow with data.groups as {"admins": {"members": ["eve"]}}`),
+			Module("test.rego", groupsModule),
+			Store(store),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(resolver, 1000)
+			}),
+		).PrepareForEval(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+
+		if !eval(t, pq, "eve") {
+			t.Error("expected eve to be allowed through the replaced collection")
+		}
+	})
+
+	// A replacement *inside* a materialized collection leaves the ref itself in
+	// place while changing what it holds, so it has to be caught by comparing
+	// refs in both directions (refStack.Overlaps, not Prefixed).
+	t.Run("honors with-replacement inside a materialized collection", func(t *testing.T) {
+		membersStore := inmem.NewFromObject(map[string]any{
+			"members": map[string]any{"a": "alice", "b": "bob"},
+		})
+		module := `package test
+
+		allow if input.subject in data.members`
+
+		pq, err := New(
+			Query(`data.test.allow with data.members.a as "eve"`),
+			Module("test.rego", module),
+			Store(membersStore),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(newDataResolver(t, ctx, membersStore), 1000)
+			}),
+		).PrepareForEval(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+
+		if !eval(t, pq, "eve") {
+			t.Error("expected eve to be allowed through the replaced member")
+		}
+		if eval(t, pq, "alice") {
+			t.Error("expected alice not to be allowed once her entry was replaced")
+		}
+	})
+
+	t.Run("partial evaluation keeps all candidates", func(t *testing.T) {
+		resolver := newDataResolver(t, ctx, store)
+		pq, err := New(
+			Query("data.test.allow"),
+			Module("test.rego", groupsModule),
+			Store(store),
+			Unknowns([]string{"input"}),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(resolver, 1000)
+			}),
+		).PrepareForPartial(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+
+		pqs, err := pq.Partial(ctx, EvalInput(map[string]any{"subject": "eve"}))
+		if err != nil {
+			t.Fatalf("partial: %v", err)
+		}
+		if exp, act := 2, len(pqs.Queries); exp != act {
+			t.Errorf("expected %d partially evaluated queries, got %d: %v", exp, act, pqs.Queries)
+		}
+	})
+
+	// The contract of WithIndexData: a data change alone doesn't reach the
+	// index, so whoever enables it has to recompile.
+	t.Run("a data change needs a recompile", func(t *testing.T) {
+		pq := prepare(t, 1000)
+
+		if err := storage.WriteOne(ctx, store, storage.AddOp,
+			storage.MustParsePath("/groups/admins/members/-"), "eve"); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		if eval(t, pq, "eve") {
+			t.Error("expected the index built before the write to still prune eve")
+		}
+		if !eval(t, prepare(t, 1000), "eve") {
+			t.Error("expected eve to be allowed after recompiling")
+		}
+	})
+
+	// A collection past the cap isn't unrolled -- but it is still watched, so
+	// that shrinking it below the cap (or any other change) is noticed.
+	t.Run("collections over the cap are watched but not materialized", func(t *testing.T) {
+		capStore := inmem.NewFromObject(map[string]any{
+			"groups": map[string]any{
+				"admins": map[string]any{"members": []any{"alice", "eve"}},
+				"devs":   map[string]any{"members": []any{"bob"}},
+			},
+		})
+
+		prepareCapped := func(t *testing.T, maxCollection int) PreparedEvalQuery {
+			t.Helper()
+
+			resolver := newDataResolver(t, ctx, capStore)
+			pq, err := New(
+				Query("data.test.allow"),
+				Module("test.rego", groupsModule),
+				Store(capStore),
+				CompilerHook(func(c *ast.Compiler) {
+					c.MaterializeIndexData(resolver, maxCollection)
+				}),
+			).PrepareForEval(ctx)
+			if err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+			return pq
+		}
+
+		// "zed" is in neither collection: with both materialized, no rule survives
+		// the lookup; with admins over the cap, its rule has to be evaluated.
+		for _, tc := range []struct {
+			maxCollection int
+			entered       int
+		}{
+			{maxCollection: 1000, entered: 0},
+			{maxCollection: 1, entered: 1},
+		} {
+			tracer := topdown.NewBufferTracer()
+			if eval(t, prepareCapped(t, tc.maxCollection), "zed", EvalQueryTracer(tracer)) {
+				t.Error("expected zed not to be allowed")
+			}
+			if act := rulesEntered(tracer); tc.entered != act {
+				t.Errorf("maxCollection %d: expected %d rule(s) evaluated, got %d",
+					tc.maxCollection, tc.entered, act)
+			}
+		}
+
+		resolver := newDataResolver(t, ctx, capStore)
+		c := ast.NewCompiler()
+		c.Compile(map[string]*ast.Module{
+			"test.rego": ast.MustParseModuleWithOpts(groupsModule, ast.ParserOptions{}),
+		})
+		if c.Failed() {
+			t.Fatal(c.Errors)
+		}
+		c.MaterializeIndexData(resolver, 1)
+
+		if refs := c.IndexDataRefs(); len(refs) != 2 {
+			t.Errorf("expected both collections to be watched, got %v", refs)
+		}
+	})
+}
+
+// One rule per group, membership through a data ref, resource conditions
+// unknown: the Compile API shape. The unknowns say nothing about the groups, so
+// the index has to keep pruning on the subject -- which is the whole point of
+// unrolling them.
+func TestIndexMaterializedDataPartialEval(t *testing.T) {
+	ctx := t.Context()
+
+	store := inmem.NewFromObject(map[string]any{
+		"groups": map[string]any{
+			"admins": map[string]any{"members": []any{"alice"}},
+			"devs":   map[string]any{"members": []any{"bob"}},
+		},
+	})
+
+	const module = `package test
+
+filter if {
+	input.subject in data.groups.admins.members
+	input.resource.root == "admins-root"
+}
+
+filter if {
+	input.subject in data.groups.devs.members
+	input.resource.root == "devs-root"
+}
+`
+
+	partial := func(t *testing.T, unknowns []string) (*PartialQueries, int) {
+		t.Helper()
+
+		resolver := newDataResolver(t, ctx, store)
+		pq, err := New(
+			Query("data.test.filter = true"),
+			Module("test.rego", module),
+			Store(store),
+			Unknowns(unknowns),
+			CompilerHook(func(c *ast.Compiler) {
+				c.MaterializeIndexData(resolver, 1000)
+			}),
+		).PrepareForPartial(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+
+		tracer := topdown.NewBufferTracer()
+		pqs, err := pq.Partial(ctx,
+			EvalInput(map[string]any{"subject": "alice"}),
+			EvalQueryTracer(tracer))
+		if err != nil {
+			t.Fatalf("partial: %v", err)
+		}
+
+		entered := 0
+		for _, event := range *tracer {
+			if event.Op == topdown.EnterOp {
+				if _, ok := event.Node.(*ast.Rule); ok {
+					entered++
+				}
+			}
+		}
+
+		return pqs, entered
+	}
+
+	t.Run("prunes on data the unknowns don't cover", func(t *testing.T) {
+		pqs, entered := partial(t, []string{"input.resource"})
+
+		if exp, act := 1, len(pqs.Queries); exp != act {
+			t.Errorf("expected %d query, got %d: %v", exp, act, pqs.Queries)
+		}
+		if exp, act := 1, entered; exp != act {
+			t.Errorf("expected %d rule(s) to be evaluated, got %d", exp, act)
+		}
+	})
+
+	t.Run("keeps candidates when the collections are unknown", func(t *testing.T) {
+		_, entered := partial(t, []string{"input.resource", "data.groups"})
+
+		if exp, act := 2, entered; exp != act {
+			t.Errorf("expected %d rule(s) to be evaluated, got %d", exp, act)
+		}
+	})
+}
+
+// A data change doesn't recompile anything: the refs it moved are marked, and the
+// values read from them stop excluding rules until the next materialization.
+func TestIndexMaterializedDataMarkedStale(t *testing.T) {
+	ctx := t.Context()
+
+	store := inmem.NewFromObject(map[string]any{
+		"groups": map[string]any{
+			"admins": map[string]any{"members": []any{"alice"}},
+			"devs":   map[string]any{"members": []any{"bob"}},
+		},
+	})
+
+	var compiler *ast.Compiler
+	pq, err := New(
+		Query("data.test.allow"),
+		Module("test.rego", groupsModule),
+		Store(store),
+		CompilerHook(func(c *ast.Compiler) {
+			compiler = c
+			c.MaterializeIndexData(newDataResolver(t, ctx, store), 1000)
+		}),
+	).PrepareForEval(ctx)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	eval := func(t *testing.T, subject string) (bool, int) {
+		t.Helper()
+
+		tracer := topdown.NewBufferTracer()
+		rs, err := pq.Eval(ctx,
+			EvalInput(map[string]any{"subject": subject}),
+			EvalQueryTracer(tracer))
+		if err != nil {
+			t.Fatalf("eval: %v", err)
+		}
+
+		entered := 0
+		for _, event := range *tracer {
+			if event.Op == topdown.EnterOp {
+				if _, ok := event.Node.(*ast.Rule); ok {
+					entered++
+				}
+			}
+		}
+
+		if len(rs) == 0 {
+			return false, entered
+		}
+		allowed, ok := rs[0].Expressions[0].Value.(bool)
+		if !ok {
+			t.Fatalf("expected boolean result, got %[1]v (%[1]T)", rs[0].Expressions[0].Value)
+		}
+		return allowed, entered
+	}
+
+	if allowed, entered := eval(t, "eve"); allowed || entered != 0 {
+		t.Fatalf("expected eve to be denied without evaluating a rule, got allowed=%v entered=%d", allowed, entered)
+	}
+
+	// eve joins the admins, and the data ref is marked instead of recompiled
+	if err := storage.WriteOne(ctx, store, storage.AddOp,
+		storage.MustParsePath("/groups/admins/members/-"), "eve"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compiler.MarkIndexDataStale([]ast.Ref{ast.MustParseRef("data.groups.admins.members")})
+
+	// the admins rule has to be evaluated again, and eve is allowed by it -- while
+	// the devs rule stays indexed on the values it read
+	if allowed, entered := eval(t, "eve"); !allowed || entered != 1 {
+		t.Errorf("expected eve to be allowed after one rule, got allowed=%v entered=%d", allowed, entered)
+	}
+
+	// materializing again picks the new members up, and stops marking
+	compiler.MaterializeIndexData(newDataResolver(t, ctx, store), 1000)
+	if compiler.IndexDataStale(ast.MustParseRef("data.groups.admins.members")) {
+		t.Error("expected materializing to clear the mark")
+	}
+	if allowed, entered := eval(t, "eve"); !allowed || entered != 1 {
+		t.Errorf("expected eve to be allowed after one rule, got allowed=%v entered=%d", allowed, entered)
+	}
+}

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -238,6 +238,24 @@ func (s *refStack) Prefixed(ref ast.Ref) bool {
 	return false
 }
 
+// Overlaps reports whether any replacement target shares a prefix with ref in
+// either direction. Unlike Prefixed, which answers "is ref's value replaced",
+// this also catches a replacement *below* ref -- which leaves ref itself in
+// place but changes what is inside it.
+func (s *refStack) Overlaps(ref ast.Ref) bool {
+	if s != nil {
+		sl := s.sl.Slice()
+		for _, s := range slices.Backward(sl) {
+			if slices.ContainsFunc(s.refs, func(target ast.Ref) bool {
+				return ref.HasPrefix(target) || target.HasPrefix(ref)
+			}) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type comprehensionCache struct {
 	stack util.SliceStack[map[*ast.Term]*comprehensionCacheElem]
 }

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1818,6 +1818,19 @@ type evalResolver struct {
 	args []*ast.Term
 }
 
+// IndexDataStale tells a rule index that a value it read from data can't be
+// used: a `with` statement replaced it for this evaluation (at, above, or below
+// ref), partial evaluation must treat it as unknown, or the data has changed
+// since it was read (ast.Compiler.MarkIndexDataStale). Only ref itself is
+// checked -- during partial evaluation the unknowns are usually input, which
+// says nothing about the data an index read. See ast.IndexDataChecker.
+func (e *evalResolver) IndexDataStale(ref ast.Ref) bool {
+	return e.e.targetStack.Overlaps(ref) ||
+		e.e.saveSet.Contains(ast.NewTerm(ref), nil) ||
+		e.e.inliningControl.Disabled(ref, true) ||
+		e.e.compiler.IndexDataStale(ref)
+}
+
 func (e *evalResolver) Resolve(ref ast.Ref) (ast.Value, error) {
 	e.e.instr.startTimer(evalOpResolve)
 

--- a/v1/topdown/external_source_test.go
+++ b/v1/topdown/external_source_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -725,4 +726,133 @@ check if data.authz.allowed with input as {"user": "alice"}`)
 	if len(qrs) != 1 {
 		t.Errorf("Expected 1 result, got %d", len(qrs))
 	}
+}
+
+// spExternalSource stands in for a structured-policy plugin with incremental
+// loading: the rules arrive per query and compare against data delivered in a
+// bundle -- one rule per group.
+type spExternalSource struct {
+	rules []*ast.Rule
+	opts  *ast.ExternalSourceOptions
+}
+
+func (s *spExternalSource) Init(context.Context, ast.Ref) (ast.ExternalRuleIndex, error) {
+	return &spExternalIndex{rules: s.rules, opts: s.opts}, nil
+}
+
+func (*spExternalSource) Refs() []ast.Ref { return []ast.Ref{ast.MustParseRef("data.sp")} }
+
+type spExternalIndex struct {
+	rules []*ast.Rule
+	opts  *ast.ExternalSourceOptions
+}
+
+func (i *spExternalIndex) Opts() *ast.ExternalSourceOptions { return i.opts }
+
+func (i *spExternalIndex) Lookup(context.Context, ...ast.LookupOption) ([]*ast.Rule, ast.ExternalRuleIndex, error) {
+	return i.rules, nil, nil
+}
+
+// storeDataResolver resolves data refs for the compiler, as the plugin manager
+// does for the compilers it installs.
+type storeDataResolver struct{ data *ast.Term }
+
+func (r storeDataResolver) Resolve(ref ast.Ref) (ast.Value, error) {
+	if !ref.HasPrefix(ast.DefaultRootRef) {
+		return nil, ast.UnknownValueErr{}
+	}
+	v, err := r.data.Value.Find(ref[1:])
+	if err != nil {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func TestExternalSourceMaterializesIndexData(t *testing.T) {
+	const groups = 5
+
+	data := ast.MustParseTerm(`{"groups": {
+		"g0": {"members": ["person-0"]},
+		"g1": {"members": ["person-1"]},
+		"g2": {"members": ["person-2"]},
+		"g3": {"members": ["person-3"]},
+		"g4": {"members": ["person-4"]}
+	}}`)
+
+	rules := make([]*ast.Rule, 0, groups)
+	for g := range groups {
+		id := "g" + strconv.Itoa(g)
+		rules = append(rules, ast.MustParseModule(`package sp
+
+		allow contains "` + id + `" if input.subject in data.groups.` + id + `.members`).Rules[0])
+	}
+
+	// what the index was able to exclude, which is the point of reading the data
+	matched := func(t *testing.T, maxIndexData int, opts *ast.ExternalSourceOptions) []string {
+		t.Helper()
+
+		compiler := ast.NewCompiler()
+		compiler.WithExternalSource(ast.MustParseRef("data.sp"), &spExternalSource{rules: rules, opts: opts})
+		compiler.Compile(map[string]*ast.Module{})
+		if compiler.Failed() {
+			t.Fatal(compiler.Errors)
+		}
+		compiler.MaterializeIndexData(storeDataResolver{data: data}, maxIndexData)
+
+		store := inmem.NewFromObject(map[string]any{
+			"groups": map[string]any{
+				"g0": map[string]any{"members": []any{"person-0"}},
+				"g1": map[string]any{"members": []any{"person-1"}},
+				"g2": map[string]any{"members": []any{"person-2"}},
+				"g3": map[string]any{"members": []any{"person-3"}},
+				"g4": map[string]any{"members": []any{"person-4"}},
+			},
+		})
+		ctx := t.Context()
+		txn, err := store.NewTransaction(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Abort(ctx, txn)
+
+		tracer := NewBufferTracer()
+		if _, err := NewQuery(ast.MustParseBody("data.sp.allow")).
+			WithCompiler(compiler).
+			WithStore(store).
+			WithTransaction(txn).
+			WithInput(ast.MustParseTerm(`{"subject": "person-3"}`)).
+			WithQueryTracer(tracer).
+			Run(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		var messages []string
+		for _, event := range *tracer {
+			if event.Op == IndexOp {
+				messages = append(messages, event.Message)
+			}
+		}
+		return messages
+	}
+
+	t.Run("only the group the subject is in survives the lookup", func(t *testing.T) {
+		if act := matched(t, 1000, nil); len(act) != 1 || act[0] != "(matched 1 rule)" {
+			t.Errorf("expected one rule to match, got %v", act)
+		}
+	})
+
+	t.Run("nothing is read in when the budget is zero", func(t *testing.T) {
+		if act := matched(t, 0, nil); len(act) != 1 || act[0] != "(matched 5 rules)" {
+			t.Errorf("expected every rule to match, got %v", act)
+		}
+	})
+
+	// A source handing over pre-compiled rules and skipping index building gets
+	// no indices, and so nothing to read data into either.
+	t.Run("a source that skips index building is left alone", func(t *testing.T) {
+		opts := &ast.ExternalSourceOptions{SkippedStages: []ast.StageID{ast.StageBuildRuleIndices}}
+		if act := matched(t, 1000, opts); len(act) != 0 {
+			t.Errorf("expected no index lookup at all, got %v", act)
+		}
+	})
 }


### PR DESCRIPTION
Previously, a rule like
```rego
allow if input.user in data.admins.members
```
would not be subject to rule indexing.

Now, the compiler will materialize the data.admins.members collection, and add one edge to the index per element, treating it the same as a literal collection:
```rego
allow if input.user in { "alice", "bob", ... }
```

The plugin manager ensures that we re-materialize on data changes for the relevant paths.

Since it's become a low-hanging fruit, the same now happens for constants, e.g.
```rego
allow if input.token == data.config.magic_token
```
(Less important, but added for consistency.)