### PR TITLE
topdown: don't yield a key in both base and virtual docs twice

### DIFF
--- a/v1/test/cases/testdata/v1/baseandvirtualdocs/test-baseandvirtualdocs-enumerate-collision.yaml
+++ b/v1/test/cases/testdata/v1/baseandvirtualdocs/test-baseandvirtualdocs-enumerate-collision.yaml
@@ -1,0 +1,85 @@
+---
+# The order in which base and virtual document keys are enumerated is not part
+# of the language contract, so every case sorts the comprehension result. sort
+# does not deduplicate, so a key yielded twice still fails these assertions.
+cases:
+  - note: baseandvirtualdocs/enumerate/key in base and virtual doc yielded once
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := sort([key | data.a[key].metadata])
+      - |
+        package a.b
+
+        q := 1
+    data:
+      a:
+        b:
+          metadata: interesting
+        c:
+          metadata: other
+    want_result:
+      - x: ["b", "c"]
+  - note: baseandvirtualdocs/enumerate/key in base and virtual doc yielded once at data root
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := sort([key | data.a[key].metadata])
+      - |
+        package a.b
+    data:
+      a:
+        b:
+          metadata: interesting
+        c:
+          metadata: other
+    want_result:
+      - x: ["b", "c"]
+  - note: baseandvirtualdocs/enumerate/keys only in virtual doc still yielded
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := sort([key | data.a[key].metadata])
+      - |
+        package a.b
+
+        other := 1
+      - |
+        package a.d
+
+        metadata := "virtual"
+    data:
+      a:
+        b:
+          metadata: base-b
+        c:
+          metadata: base-c
+    want_result:
+      - x: ["b", "c", "d"]
+  - note: baseandvirtualdocs/enumerate/key in base and virtual doc yielded once with values
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := sort([{key: value} | value := data.a[key].metadata])
+      - |
+        package a.b
+
+        q := 1
+    data:
+      a:
+        b:
+          metadata: interesting
+        c:
+          metadata: other
+    want_result:
+      - x:
+          - b: interesting
+          - c: other

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -2843,6 +2843,13 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 	// Reuse the same enumerateNext for virtual documents
 	for _, k := range e.node.Sorted {
 		key := ast.NewTerm(k)
+
+		// next() descends into both the base document and the rule tree, so
+		// enumerating a key present in both would yield it twice.
+		if docHasKey(doc, key) {
+			continue
+		}
+
 		en.key = key
 		if err := e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, en.call); err != nil {
 			return err
@@ -2850,6 +2857,25 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 	}
 
 	return nil
+}
+
+// docHasKey returns true if key is one of the keys evalTree.enumerate yields
+// for the base document doc.
+func docHasKey(doc ast.Value, key *ast.Term) bool {
+	switch doc := doc.(type) {
+	case ast.Object:
+		return doc.Get(key) != nil
+	case *ast.Array:
+		i, ok := key.Value.(ast.Number)
+		if !ok {
+			return false
+		}
+		idx, ok := i.Int()
+		return ok && idx >= 0 && idx < doc.Len()
+	case ast.Set:
+		return doc.Contains(key)
+	}
+	return false
 }
 
 func (e evalTree) extent() (*ast.Term, error) {

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -4936,6 +4936,56 @@ q if { input.x = 7 }`},
 	}
 }
 
+func TestTopDownPartialEvalEnumerateBaseAndVirtualDocKeyOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	params := fixtureParams{
+		note:  "enumerate base doc key shadowed by rule tree node once (#4787)",
+		query: "data.test.p = x",
+		data:  `{"x": {"a": {"n": 1}, "b": {"n": 2}}}`,
+		modules: []string{
+			`package test
+			p contains k if { data.x[k] = input.y }`,
+			`package x.a
+			unrelated := 1`,
+		},
+	}
+
+	prepareTest(ctx, t, params, func(ctx context.Context, t *testing.T, f fixture) {
+		query := NewQuery(f.query).
+			WithCompiler(f.compiler).
+			WithStore(f.store).
+			WithTransaction(f.txn).
+			WithUnknowns([]*ast.Term{ast.MustParseTerm("input")})
+
+		_, support, err := query.PartialRun(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(support) != 1 {
+			t.Fatalf("expected 1 support module, got %d: %v", len(support), support)
+		}
+
+		exp := ast.MustParseModule(`package partial.test
+
+		p contains "a" if input.y = {"n": 1, "unrelated": 1}
+		p contains "b" if input.y = {"n": 2}`)
+
+		if len(support[0].Rules) != len(exp.Rules) {
+			t.Fatalf("expected %d support rules, got %d:\n%v", len(exp.Rules), len(support[0].Rules), support[0])
+		}
+
+		for i := range exp.Rules {
+			if !exp.Rules[i].Equal(support[0].Rules[i]) {
+				t.Fatalf("expected support module:\n%v\n\ngot:\n%v", exp, support[0])
+			}
+		}
+	})
+}
+
 func TestTopDownPartialEvalNegation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
fix: #4787

`evalTree.enumerate` walks the base document's keys and then the rule tree's children, so a key present in both was yielded twice: with a data file and `package a.b` both contributing to data.a, `[k | data.a[k].metadata]` returned "b" twice. Skip rule tree children the base document already enumerated.