### PR TITLE
ast: index refs rooted at a local variable (ref of root doc)

### DIFF
--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -122,16 +122,21 @@ roles := {
 
 #### Equality statements
 
-For simple equality statements (`=` and `==`) to be indexed one side must be a non-nested reference that does not contain any variables and the other side must be a variable, scalar, or array (which may contain scalars and variables). For example:
+For simple equality statements (`=` and `==`) to be indexed one side must be a non-nested reference that does not contain any variables and the other side must be a variable, scalar, or array (which may contain scalars and variables).
 
-| Expression                  | Indexed | Notes                        |
-| --------------------------- | ------- | ---------------------------- |
-| `input.x`                   | yes     |                              |
-| `input.x == "foo"`          | yes     |                              |
-| `input.x.y == "bar"`        | yes     |                              |
-| `input.x == ["foo", i]`     | yes     |                              |
-| `input.x[i] == "foo"`       | no      | reference contains variables |
-| `input.x[input.y] == "foo"` | no      | reference is nested          |
+A reference whose **last** element is a variable is indexed as well, as long as the other side is a scalar. The indexer then indexes the ground prefix of the reference, selecting the rules whose scalar occurs among the values found there — the exact match is still established when the rule body is evaluated. For example:
+
+| Expression                  | Indexed | Notes                                                 |
+| --------------------------- | ------- | ----------------------------------------------------- |
+| `input.x`                   | yes     |                                                       |
+| `input.x == "foo"`          | yes     |                                                       |
+| `input.x.y == "bar"`        | yes     |                                                       |
+| `input.x == ["foo", i]`     | yes     |                                                       |
+| `input.x[i] == "foo"`       | yes     | ground prefix `input.x` is indexed                    |
+| `input.x[_] == "foo"`       | yes     | ground prefix `input.x` is indexed                    |
+| `input.x[input.y] == "foo"` | yes     | ground prefix `input.x` is indexed                    |
+| `input.x[i].y == "foo"`     | no      | variable is not the reference's last element          |
+| `input.x[i] == ["foo"]`     | no      | non-scalar value on a reference containing a variable |
 
 #### Glob statements
 
@@ -183,6 +188,29 @@ Statements joined by the [`and` and `or` keywords](./policy-reference/keywords/l
 | `input.x == 1 or input.y == 2`         | yes     | both operands are indexed             |
 | `input.x == 1 or count(input.y) == 3`  | no      | `count(...)` is not indexable         |
 | `not (input.x == 1 and input.y == 2)`  | no      | negated expressions are never indexed |
+
+#### References rooted at a local variable
+
+Building a reference on top of a local variable does not defeat the indexer. When the head of a reference is a variable that was assigned a reference earlier in the rule body, the indexer resolves that head and indexes the statement as if the whole reference had been spelled out: `x := input; x.foo == "a"` is indexed just like `input.foo == "a"`.
+
+The head must resolve to a reference rooted at `input` or `data`, and the resolved reference is then subject to exactly the same conditions as one written out by hand. A head that resolves to a document produced by another rule is not indexed, since the indexer only looks up base documents. `in` and `glob.match` statements benefit from the same resolution: the compiler hoists their reference operand into a local variable of its own, which the indexer then resolves.
+
+The resolution also applies where a local stands in for a whole value rather than the head of a reference, chained assignments included, and inside the operands of an `and` or `or`, where a local assigned in the enclosing rule body still resolves.
+
+| Expression                                    | Indexed | Notes                                    |
+| --------------------------------------------- | ------- | ---------------------------------------- |
+| `x := input; x.foo == "a"`                    | yes     | indexed as `input.foo == "a"`            |
+| `x := input.a.b; x.c == "a"`                  | yes     | indexed as `input.a.b.c == "a"`          |
+| `x := input.a; y := x; y.b == "a"`            | yes     | chains of assignments resolve            |
+| `x := input.role; y := x; y == "a"`           | yes     | indexed as `input.role == "a"`           |
+| `x := input; "a" in x.foo`                    | yes     |                                          |
+| `x := input; glob.match("a/*", ["/"], x.foo)` | yes     |                                          |
+| `x := input; x.foo`                           | yes     | bare reference                           |
+| `x := input; x.foo[i] == "a"`                 | yes     | ground prefix `input.foo` is indexed     |
+| `x := input; x.foo[i].bar == "a"`             | no      | variable is not the last element         |
+| `x := {"a": 1}; x.a == 1`                     | no      | head does not resolve to a reference     |
+| `x := some_rule; x.foo == "a"`                | no      | resolved reference is a virtual document |
+| `f(x) if x.foo == "a"`                        | no      | head is a function argument              |
 
 ### Early Exit in Rule Evaluation
 

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -1177,6 +1177,16 @@ func (i *refindices) eqOperandsToRefAndValue(rule *Rule, args []*Term, a, b Valu
 		}
 
 	case Ref:
+		// A ref rooted at a local -- `x := input; x.foo == "bar"` -- indexes the
+		// same as the ref that local aliases, so long as the local resolves.
+		if head, isVar := v[0].Value.(Var); isVar && !RootDocumentNames.Contains(v[0]) {
+			resolved := resolveVarToRef(i.resolvable(rule), args, head)
+			if resolved == nil {
+				return false
+			}
+			v = resolved.Concat(v[1:])
+		}
+
 		if !i.isValidIndexRef(v) {
 			return false
 		}

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -141,6 +141,20 @@ func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int,
 					values = append(values, ri)
 				}
 			}
+
+			// A var value records "this ref can be anything", which a concrete value
+			// for the same ref supersedes: everything on one path has to hold, so the
+			// concrete value is the stronger of the two constraints. A chain of
+			// assignments, `x := input.a; y := x`, leaves one var entry per local
+			// behind, and only the first of them is replaced when the concrete value
+			// is inserted. Keeping the rest would index the rule under anyValue below
+			// and give up all the discrimination the concrete value buys us.
+			if len(values) > 1 {
+				if concrete := slices.DeleteFunc(slices.Clone(values), (*refindex).isVar); len(concrete) > 0 {
+					values = concrete
+				}
+			}
+
 			if len(values) == 0 {
 				node = node.Insert(ref, nil, nil)
 			} else if len(values) == 1 {

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -594,6 +594,11 @@ func (i *refindices) tryIndexWildcardRef(rule *Rule, a, b Value, constants map[V
 		return false
 	}
 
+	ref = i.resolveRefHead(rule, rule.Head.Args, ref)
+	if ref == nil {
+		return false
+	}
+
 	groundPrefix := ref.GroundPrefix()
 	if len(groundPrefix) != len(ref)-1 || !i.isValidIndexRef(groundPrefix) {
 		return false
@@ -725,6 +730,28 @@ func (i *refindices) resolveAndValidateRef(rule *Rule, args []*Term, term *Term)
 	}
 
 	return ref
+}
+
+// resolveRefHead resolves a ref rooted at a local variable -- what
+//
+//	x := input
+//	x.foo == "bar"
+//
+// gets compiled to -- into the ref that local aliases, splicing the remainder of
+// the ref onto it: `input.foo`. Refs that are already rooted at a root document
+// are returned unchanged; a head that does not resolve yields nil.
+func (i *refindices) resolveRefHead(rule *Rule, args []*Term, ref Ref) Ref {
+	head, isVar := ref[0].Value.(Var)
+	if !isVar || RootDocumentNames.Contains(ref[0]) {
+		return ref
+	}
+
+	resolved := resolveVarToRef(i.resolvable(rule), args, head)
+	if resolved == nil {
+		return nil
+	}
+
+	return resolved.Concat(ref[1:])
 }
 
 // resolveVarToRef checks the previously prepared `*refindex` slice for
@@ -1179,15 +1206,8 @@ func (i *refindices) eqOperandsToRefAndValue(rule *Rule, args []*Term, a, b Valu
 	case Ref:
 		// A ref rooted at a local -- `x := input; x.foo == "bar"` -- indexes the
 		// same as the ref that local aliases, so long as the local resolves.
-		if head, isVar := v[0].Value.(Var); isVar && !RootDocumentNames.Contains(v[0]) {
-			resolved := resolveVarToRef(i.resolvable(rule), args, head)
-			if resolved == nil {
-				return false
-			}
-			v = resolved.Concat(v[1:])
-		}
-
-		if !i.isValidIndexRef(v) {
+		v = i.resolveRefHead(rule, args, v)
+		if v == nil || !i.isValidIndexRef(v) {
 			return false
 		}
 

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -13,6 +13,7 @@ import (
 
 type testResolver struct {
 	input       *Term
+	data        *Term
 	failRef     Ref
 	unknownRefs Set
 	args        []Value
@@ -34,6 +35,13 @@ func (r testResolver) Resolve(ref Ref) (Value, error) {
 	}
 	if ref.HasPrefix(InputRootRef) {
 		v, err := r.input.Value.Find(ref[1:])
+		if err != nil {
+			return nil, nil
+		}
+		return v, nil
+	}
+	if r.data != nil && ref.HasPrefix(DefaultRootRef) {
+		v, err := r.data.Value.Find(ref[1:])
 		if err != nil {
 			return nil, nil
 		}
@@ -71,6 +79,80 @@ func TestBaseDocEqIndexing(t *testing.T) {
 	} {
 		input.b = 1
 	}`, opts)
+
+	// NOTE(sr): pseudo-compiled, as with everyModWithDomain above. These are what
+	//
+	//   p if { x := input; x.foo == "a" }
+	//
+	// and friends get rewritten to -- the ref ends up rooted at a local rather
+	// than at input, and the indexer has to resolve that head to index at all.
+	//
+	// Note that `in` and glob.match never receive a ref operand directly: their
+	// operands are always hoisted to a variable first, so those two benefit only
+	// via the assignment that does the hoisting. The cases below are written the
+	// way the compiler actually emits them.
+	localHeadMod := MustParseModuleWithOpts(`package test
+
+	whole if { __local0__ = input; __local0__.foo = "a" }
+	whole if { __local1__ = input; __local1__.foo = "b" }
+
+	intermediate if { __local2__ = input.a.b; __local2__.c = "a" }
+	intermediate if { __local3__ = input.a.b; __local3__.c = "b" }
+
+	member if { __local4__ = input; __local5__ = __local4__.foo; "a" in __local5__ }
+	member if { __local6__ = input; __local7__ = __local6__.foo; "b" in __local7__ }
+
+	globmatch if { __local8__ = input; __local9__ = __local8__.foo; glob.match("a/*", ["/"], __local9__) }
+	globmatch if { __local10__ = input; __local11__ = __local10__.foo; glob.match("b/*", ["/"], __local11__) }
+
+	# The head resolves to a composite rather than a ref, so there is nothing to
+	# index and both rules have to be evaluated.
+	unresolvable if { __local12__ = [1, 2, 3]; __local12__[0] = 1 }
+	unresolvable if { __local13__ = [1, 2, 3]; __local13__[0] = 2 }
+
+	# Bare refs run through the equality path, too, so their heads resolve as well.
+	naked_local if { __local14__ = input; __local14__.foo }
+	naked_local if { __local15__ = input; __local15__.bar }
+
+	# The assignment __local17__ = __local16__ records "input.a = __local17__" next
+	# to "input.a = __local16__", so a head reached through a chain of assignments
+	# resolves just as well as one assigned the ref directly.
+	chained if { __local16__ = input.a; __local17__ = __local16__; __local17__.b = "a" }
+	chained if { __local18__ = input.a; __local19__ = __local18__; __local19__.b = "b" }
+
+	# Nothing sets input apart from data here.
+	from_data if { __local20__ = data.roles; __local20__.a = 1 }
+	from_data if { __local21__ = data.roles; __local21__.a = 2 }
+
+	# The ref spliced onto the resolved head still has to be ground,
+	nonground if { __local22__ = input; __local22__.foo[__local23__] = "a" }
+	nonground if { __local24__ = input; __local24__.foo[__local25__] = "b" }
+
+	# and a wildcard is no exception -- even though "input.foo[_] = value" is indexed,
+	# since the ground-prefix path (updateEqWildcardRef) gives up on a locally-rooted
+	# ref before the head gets a chance to resolve.
+	wildcard if { __local26__ = input; __local26__.foo[_] = "a" }
+	wildcard if { __local27__ = input; __local27__.foo[_] = "b" }
+
+	# The head resolves to a ref, but a virtual one, which the indexer cannot look up.
+	virtual if { __local28__ = data.test.vd; __local28__.foo = "a" }
+	virtual if { __local29__ = data.test.vd; __local29__.foo = "b" }`, opts)
+
+	// The operand body of an `and`/`or` is its own scope, so the local assigned in
+	// the enclosing body has to be resolved through refindices.resolvable (see
+	// operandAlternatives) rather than the rule's own indices alone.
+	logicalOpts := ParserOptions{
+		Capabilities:   CapabilitiesForThisVersion(CapabilitiesExperimentalKeywords(true)),
+		FutureKeywords: []string{"and", "or", "not"},
+	}
+
+	logicalHeadMod := MustParseModuleWithOpts(`package test
+
+	conj if { __local0__ = input; __local0__.foo = "a" and __local0__.bar = "a" }
+	conj if { __local1__ = input; __local1__.foo = "b" and __local1__.bar = "b" }
+
+	disj if { __local2__ = input; __local2__.foo = "a" or __local2__.foo = "aa" }
+	disj if { __local3__ = input; __local3__.foo = "b" or __local3__.foo = "bb" }`, logicalOpts)
 
 	refMod := MustParseModuleWithOpts(`package test
 
@@ -244,6 +326,8 @@ func TestBaseDocEqIndexing(t *testing.T) {
 		ruleset     string
 		ruleRef     Ref
 		input       string
+		data        string
+		isVirtual   func(Ref) bool
 		unknowns    []string
 		args        []Value
 		expectedRS  any
@@ -704,6 +788,112 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			ruleset:    "p",
 			input:      `{"a": [1]}`,
 			expectedRS: RuleSet([]*Rule{everyModWithDomain.Rules[0]}),
+		},
+		{
+			note:       "local ref head: whole input document",
+			module:     localHeadMod,
+			ruleset:    "whole",
+			input:      `{"foo": "a"}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[0]}),
+		},
+		{
+			note:       "local ref head: inside an `and` operand",
+			module:     logicalHeadMod,
+			ruleset:    "conj",
+			input:      `{"foo": "a", "bar": "a"}`,
+			expectedRS: RuleSet([]*Rule{logicalHeadMod.Rules[0]}),
+		},
+		{
+			note:       "local ref head: inside an `or` operand",
+			module:     logicalHeadMod,
+			ruleset:    "disj",
+			input:      `{"foo": "aa"}`,
+			expectedRS: RuleSet([]*Rule{logicalHeadMod.Rules[2]}),
+		},
+		{
+			note:       "local ref head: intermediate ref",
+			module:     localHeadMod,
+			ruleset:    "intermediate",
+			input:      `{"a": {"b": {"c": "a"}}}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[2]}),
+		},
+		{
+			note:       "local ref head: membership, via the hoisting assignment",
+			module:     localHeadMod,
+			ruleset:    "member",
+			input:      `{"foo": ["a"]}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[4]}),
+		},
+		{
+			note:       "local ref head: glob.match, via the hoisting assignment",
+			module:     localHeadMod,
+			ruleset:    "globmatch",
+			input:      `{"foo": "a/b"}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[6]}),
+		},
+		{
+			note:       "local ref head: unresolvable head is not indexed",
+			module:     localHeadMod,
+			ruleset:    "unresolvable",
+			input:      `{}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[8], localHeadMod.Rules[9]}),
+		},
+		{
+			note:       "local ref head: bare ref",
+			module:     localHeadMod,
+			ruleset:    "naked_local",
+			input:      `{"foo": true}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[10]}),
+		},
+		{
+			note:       "local ref head: chain of assignments",
+			module:     localHeadMod,
+			ruleset:    "chained",
+			input:      `{"a": {"b": "a"}}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[12]}),
+		},
+		{
+			note:       "local ref head: rooted at data",
+			module:     localHeadMod,
+			ruleset:    "from_data",
+			data:       `{"roles": {"a": 1}}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[14]}),
+		},
+		{
+			note:       "local ref head: non-ground remainder is not indexed",
+			module:     localHeadMod,
+			ruleset:    "nonground",
+			input:      `{"foo": ["a"]}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[16], localHeadMod.Rules[17]}),
+		},
+		{
+			note:       "local ref head: wildcard remainder is not indexed",
+			module:     localHeadMod,
+			ruleset:    "wildcard",
+			input:      `{"foo": ["a"]}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[18], localHeadMod.Rules[19]}),
+		},
+		{
+			note:       "local ref head: virtual document is not indexed",
+			module:     localHeadMod,
+			ruleset:    "virtual",
+			isVirtual:  func(ref Ref) bool { return ref.HasPrefix(MustParseRef("data.test.vd")) },
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[20], localHeadMod.Rules[21]}),
+		},
+		{
+			// Deliberate: resolveVarToRef maps a formal to an `args[i]` ref, which
+			// isValidIndexRef rejects -- indexing bare formals works by bypassing that
+			// validation, and sub-paths of args would need the resolver to know about them.
+			note: "local ref head: function argument is not indexed",
+			module: module(`package test
+			f(x) = 1 if { x.foo = "a" }
+			f(x) = 2 if { x.foo = "b" }`),
+			ruleset: "f",
+			args:    []Value{MustParseTerm(`{"foo": "a"}`).Value},
+			expectedRS: []string{
+				`f(x) = 1 if { x.foo = "a" }`,
+				`f(x) = 2 if { x.foo = "b" }`,
+			},
 		},
 		{
 			note:        "ref: single value, ground ref",
@@ -1356,6 +1546,11 @@ func TestBaseDocEqIndexing(t *testing.T) {
 				input = MustParseTerm(tc.input)
 			}
 
+			var data *Term
+			if tc.data != "" {
+				data = MustParseTerm(tc.data)
+			}
+
 			var expectedRS RuleSet
 
 			switch e := tc.expectedRS.(type) {
@@ -1369,9 +1564,12 @@ func TestBaseDocEqIndexing(t *testing.T) {
 				panic("Unexpected test case: expected value")
 			}
 
-			index := newBaseDocEqIndex(func(Ref) bool {
-				return false
-			})
+			isVirtual := tc.isVirtual
+			if isVirtual == nil {
+				isVirtual = func(Ref) bool { return false }
+			}
+
+			index := newBaseDocEqIndex(isVirtual)
 
 			if !index.Build(rules) {
 				t.Fatalf("Expected index build to succeed")
@@ -1387,7 +1585,7 @@ func TestBaseDocEqIndexing(t *testing.T) {
 				}
 			}
 
-			result, err := index.Lookup(testResolver{input: input, unknownRefs: unknownRefs, args: tc.args})
+			result, err := index.Lookup(testResolver{input: input, data: data, unknownRefs: unknownRefs, args: tc.args})
 			if err != nil {
 				t.Fatalf("Unexpected error during index lookup: %v", err)
 			}

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -154,6 +154,17 @@ func TestBaseDocEqIndexing(t *testing.T) {
 	disj if { __local2__ = input; __local2__.foo = "a" or __local2__.foo = "aa" }
 	disj if { __local3__ = input; __local3__.foo = "b" or __local3__.foo = "bb" }`, logicalOpts)
 
+	// NOTE(sr): pseudo-compiled once more -- this is
+	//
+	//   p if { x := input.role; y := x; y == "a" }
+	//
+	// The chain of assignments records "input.role can be anything" once per local,
+	// and the concrete value from the comparison replaces only the first of them.
+	chainedValueMod := MustParseModuleWithOpts(`package test
+
+	p if { __local0__ = input.role; __local1__ = __local0__; __local1__ = "a" }
+	p if { __local2__ = input.role; __local3__ = __local2__; __local3__ = "b" }`, opts)
+
 	refMod := MustParseModuleWithOpts(`package test
 
 	ref.single.value.ground = x if x := input.x
@@ -879,6 +890,13 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			ruleset:    "virtual",
 			isVirtual:  func(ref Ref) bool { return ref.HasPrefix(MustParseRef("data.test.vd")) },
 			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[20], localHeadMod.Rules[21]}),
+		},
+		{
+			note:       "chained assignment: concrete value supersedes the leftover any-entry",
+			module:     chainedValueMod,
+			ruleset:    "p",
+			input:      `{"role": "a"}`,
+			expectedRS: RuleSet([]*Rule{chainedValueMod.Rules[0]}),
 		},
 		{
 			// Deliberate: resolveVarToRef maps a formal to an `args[i]` ref, which

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -124,19 +124,19 @@ func TestBaseDocEqIndexing(t *testing.T) {
 	from_data if { __local20__ = data.roles; __local20__.a = 1 }
 	from_data if { __local21__ = data.roles; __local21__.a = 2 }
 
-	# The ref spliced onto the resolved head still has to be ground,
-	nonground if { __local22__ = input; __local22__.foo[__local23__] = "a" }
-	nonground if { __local24__ = input; __local24__.foo[__local25__] = "b" }
+	# The ref spliced onto the resolved head is subject to the same conditions as one
+	# written out: a single trailing variable is fine, wildcard or not -- only the
+	# ground prefix gets indexed, exactly as for "input.foo[_] = value" --
+	trailingvar if { __local22__ = input; __local22__.foo[__local23__] = "a" }
+	trailingvar if { __local24__ = input; __local24__.foo[_] = "b" }
 
-	# and a wildcard is no exception -- even though "input.foo[_] = value" is indexed,
-	# since the ground-prefix path (updateEqWildcardRef) gives up on a locally-rooted
-	# ref before the head gets a chance to resolve.
-	wildcard if { __local26__ = input; __local26__.foo[_] = "a" }
-	wildcard if { __local27__ = input; __local27__.foo[_] = "b" }
+	# but a variable anywhere else leaves nothing indexable.
+	nonground if { __local25__ = input; __local25__.foo[__local26__].bar = "a" }
+	nonground if { __local27__ = input; __local27__.foo[__local28__].bar = "b" }
 
 	# The head resolves to a ref, but a virtual one, which the indexer cannot look up.
-	virtual if { __local28__ = data.test.vd; __local28__.foo = "a" }
-	virtual if { __local29__ = data.test.vd; __local29__.foo = "b" }`, opts)
+	virtual if { __local29__ = data.test.vd; __local29__.foo = "a" }
+	virtual if { __local30__ = data.test.vd; __local30__.foo = "b" }`, opts)
 
 	// The operand body of an `and`/`or` is its own scope, so the local assigned in
 	// the enclosing body has to be resolved through refindices.resolvable (see
@@ -860,17 +860,17 @@ func TestBaseDocEqIndexing(t *testing.T) {
 			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[14]}),
 		},
 		{
+			note:       "local ref head: trailing variable, ground prefix is indexed",
+			module:     localHeadMod,
+			ruleset:    "trailingvar",
+			input:      `{"foo": ["a"]}`,
+			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[16]}),
+		},
+		{
 			note:       "local ref head: non-ground remainder is not indexed",
 			module:     localHeadMod,
 			ruleset:    "nonground",
-			input:      `{"foo": ["a"]}`,
-			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[16], localHeadMod.Rules[17]}),
-		},
-		{
-			note:       "local ref head: wildcard remainder is not indexed",
-			module:     localHeadMod,
-			ruleset:    "wildcard",
-			input:      `{"foo": ["a"]}`,
+			input:      `{"foo": [{"bar": "a"}]}`,
 			expectedRS: RuleSet([]*Rule{localHeadMod.Rules[18], localHeadMod.Rules[19]}),
 		},
 		{


### PR DESCRIPTION
### Why?

Indexability depends on how the reference is spelled:

```rego
# indexed                              # not indexed
allow if {                             allow if {
    input.method == "GET"                  req := input
    input.path == "/v1/resource42"         req.method == "GET"
}                                          req.path == "/v1/resource42"
                                       }
```
----
🥼 **Full disclosure:** This is a preliminary step to something else: inlining simple expressions. My goal is to have the indexer cover things like

```rego
is_foo(s) if input.foo == s

allow if {
  is_foo(input.bar)
  input.resource == "B"
}
```

and since the compiler turns `is_foo` into something like SSA, we need these steps here to get to that point.

------

Example measurement: 100 rules of each shape, matching input: 4.9 µs, one rule evaluated, against
50.6 µs, all 100 evaluated.

`isValidIndexRef` requires a reference rooted at `input` or `data`. The second
rule compiles to `__local0__ = input; __local0__.method = "GET"`, rooted at
neither, so nothing about the rule is indexed. `resolveVarToRef` already resolves
a local in the value position — `x := input.role; x in {"admin", "user"}` is
indexed — so what is missing is the same resolution for a local at the head of a
reference.

### What are the changes in this PR?

1. **ast: index refs rooted at a local variable** — resolve the head in the
   equality path, splice the remainder onto the resolved reference. Covers bare
   references and `in`/`glob.match` operands, which `RewriteDynamicTerms` hoists
   to a local first.
2. **ast: resolve local ref heads in the ground-prefix path too** — same
   resolution in `tryIndexWildcardRef`, which indexes a reference whose last
   element is a variable (`req := input; req.roles[_] == r`) on its ground prefix.
   Moves the resolution into a shared `resolveRefHead`.
3. **ast: let concrete index values supersede leftover "any" entries** — `insert`
   replaces only the first `ref = var` entry for a reference, so a chain of
   assignments leaves one behind and the rule is indexed under `anyValue`. Drop
   those at trie-build time when a concrete value for the same reference exists.
4. **docs: document indexing of refs rooted at a local variable** — new
   subsection, plus two corrections noted below.

### Notes to assist PR review:

<details><summary>benchmark noise</summary>

 `opa bench`, 100 `allow` rules, input matching the last rule:

| Spelling | before | after | allocs/op |
| --- | --- | --- | --- |
| `input.path == …` (baseline) | 4.93 µs | 5.00 µs | 64 → 64 |
| `req := input; req.path == …` | 50.6 µs | 5.14 µs | 1157 → 66 |
| `http := input.attributes.request.http; http.path == …` | 64.7 µs | 5.58 µs | 1157 → 66 |
| `role := input.role; r := role; r == …` | 44.2 µs | 4.86 µs | 1157 → 66 |
| `req := input; req.roles[_] == …` | 46.5 µs | 5.17 µs | 1057 → 66 |

Aliased spelling, N=100, by position of the matching rule:

| match at | before | after |
| --- | --- | --- |
| first rule | 10.4 µs | 5.04 µs |
| middle | 31.1 µs | 5.15 µs |
| last rule | 51.2 µs | 5.25 µs |
| no match | 50.0 µs | 4.57 µs |

Aliased spelling, no match, by rule count:

| rules | before | after |
| --- | --- | --- |
| 10 | 9.3 µs | 4.47 µs |
| 100 | 50.4 µs | 4.55 µs |
| 500 | 207.8 µs | 4.67 µs |

Resolution runs at index-build time; there is no eval-time cost.
`timer_rego_module_compile_ns` on a 500-rule policy over 20 runs: 7.910 ms before,
7.900 ms after.

☝️ Take this with a grain of salt. If we care for the performance of this, we should add a benchmark.

</details>

Correctness:

- The index selects which rules are evaluated; the bodies still run. Selection
  here only gets tighter, so a mistaken resolution costs performance, not
  correctness.
- The resolution maps a local to the reference it aliases, using only bindings
  recorded from earlier expressions of the same body. `reorderBodyForSafety` moves
  the binding ahead of the use or compilation fails, so a body cannot reach the
  indexer using a local it has not bound.

Notable exceptions, each with a test in `v1/ast/index_test.go`:

- A head resolving to a **virtual document is not indexed**; the indexer looks up base
  documents only.
- Function args are untouched. `resolveVarToRef` maps a formal to an `args[i]`
  reference, which `isValidIndexRef` rejects; bare-formal indexing works by
  bypassing that validation, and `args[i].foo` would need the resolver to resolve
  sub-paths of `args`.
- A head resolving to a composite rather than a reference is not indexed, nor is a
  remainder with a variable in a non-final position. (See doc additions)

`and`/`or` operands: indexing for the logical keywords landed in v1.20.0 (#9063),
where an operand body is its own scope and `refindices.resolvable` lets a var
inside it resolve against the enclosing body's indices. `resolveRefHead` goes
through the same helper, so `req := input; req.method == "GET" and req.path == "/v1/resource42"`
is indexed on both conditions. Two cases cover it, one per keyword.

Two corrections in the docs commit predate this PR: the equality table claimed
`input.x[i] == "foo"` and `input.x[input.y] == "foo"` are not indexed. Both are
indexed via the ground-prefix path, which a note in `index_test.go` dates to
1.14.0. Verified against a build without this PR's changes.

### Further comments:

Out of scope: the package-level alias rule. They look like variables, but they are stub rules 😬 

```rego
http := input.attributes.request.http

allow if { http.path == "/v1/resource42" }
```

But see #9073.