### PR TITLE
perf: heap allocation hunting

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -835,8 +835,7 @@ func (c *Compiler) GetRulesWithPrefix(ref Ref) (rules []*Rule) {
 //	GetRules("data.a.b.c.q")	=> [rule2]
 //	GetRules("data.a.b.c")		=> [rule1, rule2]
 //	GetRules("data.a.b.d")		=> nil
-func (c *Compiler) GetRules(ref Ref) (rules []*Rule) {
-
+func (c *Compiler) GetRules(ref Ref) []*Rule {
 	set := map[*Rule]struct{}{}
 
 	for _, rule := range c.GetRulesForVirtualDocument(ref) {
@@ -847,11 +846,7 @@ func (c *Compiler) GetRules(ref Ref) (rules []*Rule) {
 		set[rule] = struct{}{}
 	}
 
-	for rule := range set {
-		rules = append(rules, rule)
-	}
-
-	return rules
+	return util.Keys(set)
 }
 
 // GetRulesDynamic returns a slice of rules that could be referred to by a ref.
@@ -945,11 +940,7 @@ func (c *Compiler) GetRulesDynamicWithOpts(ref Ref, opts RulesOptions) []*Rule {
 	}
 
 	walk(node, 0)
-	rules := make([]*Rule, 0, len(set))
-	for rule := range set {
-		rules = append(rules, rule)
-	}
-	return rules
+	return util.Keys(set)
 }
 
 // Utility: add all rule values to the set.

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/opa/v1/ast/internal/tokens"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 const (
@@ -10606,11 +10607,7 @@ func assertExplicitBodiesEqualInBody(t *testing.T, exp, act Body) {
 }
 
 func describeExprs(b Body) string {
-	parts := make([]string, 0, len(b))
-	for _, e := range b {
-		parts = append(parts, describeExpr(e))
-	}
-	return strings.Join(parts, "; ")
+	return strings.Join(util.Map(b, describeExpr), "; ")
 }
 
 func describeExpr(e *Expr) string {

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -1853,11 +1853,7 @@ func (rs RuleSet) Merge(other RuleSet) RuleSet {
 }
 
 func (rs RuleSet) String() string {
-	buf := make([]string, 0, len(rs))
-	for _, rule := range rs {
-		buf = append(buf, rule.String())
-	}
-	return "{" + strings.Join(buf, ", ") + "}"
+	return "{" + strings.Join(util.Map(rs, (*Rule).String), ", ") + "}"
 }
 
 // Returns true if the equality or assignment expression referred to by expr

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1813,9 +1813,11 @@ func (s *set) Find(path Ref) (Value, error) {
 }
 
 // Diff returns elements in s that are not in other.
+// A returned empty set will be an interned representation that
+// should not be modified without copying.
 func (s *set) Diff(other Set) Set {
 	if s.Compare(other) == 0 {
-		return NewSet()
+		return InternedEmptySetValue.(Set)
 	}
 
 	result := newset(len(s.keys))
@@ -2197,11 +2199,10 @@ func (lob *lazyObj) Keys() []*Term {
 	}
 	ret := make([]*Term, 0, len(lob.native))
 	for k := range lob.native {
-		ret = append(ret, StringTerm(k))
+		ret = append(ret, InternedTerm(k))
 	}
-	slices.SortFunc(ret, TermValueCompare)
 
-	return ret
+	return util.SortedFunc(ret, TermValueCompare)
 }
 
 func (lob *lazyObj) KeysIterator() ObjectKeysIterator {

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -201,10 +202,7 @@ func BenchmarkObjectFind(b *testing.B) {
 }
 
 func BenchmarkObjectInsert(b *testing.B) {
-	nums := make([]*Term, 0, 100)
-	for i := range 100 {
-		nums = append(nums, InternedTerm(i))
-	}
+	nums := slices.Collect(InternedIntRange(0, 100))
 
 	b.Run("existing key and value", func(b *testing.B) {
 		obj := newobject(0)
@@ -275,13 +273,10 @@ func BenchmarkObjectCreationAndLookup(b *testing.B) {
 }
 
 // insert           38148     30049 ns/op   58912 B/op     528 allocs/op
-// terms_array      65698     17079 ns/op   34680 B/op     506 allocs/op
+// terms_array      106726    11183 ns/op	34968 B/op       7 allocs/op
 func BenchmarkObjectCreateWithInsertVsTermsArray(b *testing.B) {
 	n := 500
-	interned := make([]*Term, n)
-	for i := range n {
-		interned[i] = InternedTerm(i)
-	}
+	interned := slices.Collect(InternedIntRange(0, n))
 
 	b.Run("insert", func(b *testing.B) {
 		for b.Loop() {

--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -759,14 +759,14 @@ func TestRefConcat(t *testing.T) {
 	if !a.Concat(terms).Equal(a) {
 		t.Fatal("Expected no change")
 	}
-	terms = append(terms, StringTerm("qux"))
+	terms = append(terms, InternedTerm("qux"))
 	exp := MustParseTerm("foo.bar.baz.qux")
 	result := a.Concat(terms)
 	if !result.Equal(exp.Value) {
 		t.Fatalf("Expected %v but got %v", exp, result)
 	}
 	exp = MustParseTerm("foo.bar.baz.qux[0]")
-	terms = append(terms, IntNumberTerm(0))
+	terms = append(terms, InternedTerm(0))
 	result = a.Concat(terms)
 	if !result.Equal(exp.Value) {
 		t.Fatalf("Expected %v but got %v", exp, result)
@@ -1161,11 +1161,7 @@ func TestArrayOperations(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
 			arr := MustParseTerm(tc.input).Value.(*Array)
-
-			var expected []*Term
-			for _, e := range tc.expected {
-				expected = append(expected, MustParseTerm(e))
-			}
+			expected := util.Map(tc.expected, MustParseTerm)
 
 			results = nil
 			tc.iterator(arr)

--- a/v1/ast/varset.go
+++ b/v1/ast/varset.go
@@ -6,7 +6,6 @@ package ast
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -111,12 +110,7 @@ func (s VarSet) Intersect(vs VarSet) VarSet {
 
 // Sorted returns a new sorted slice of vars from s.
 func (s VarSet) Sorted() []Var {
-	sorted := make([]Var, 0, len(s))
-	for v := range s {
-		sorted = append(sorted, v)
-	}
-	slices.SortFunc(sorted, VarCompare)
-	return sorted
+	return util.SortedFunc(util.Keys(s), VarCompare)
 }
 
 // Update merges the other VarSet into this VarSet.

--- a/v1/cover/range.go
+++ b/v1/cover/range.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // Position represents a file location.
@@ -111,8 +112,7 @@ func (s rangeSet) Slice() []Range {
 	for _, r := range s {
 		rs = append(rs, r)
 	}
-	slices.SortFunc(rs, Range.Compare)
-	return rs
+	return util.SortedFunc(rs, Range.Compare)
 }
 
 // fileRangeSets maps a file to the set of ranges recorded for it.

--- a/v1/topdown/aggregates.go
+++ b/v1/topdown/aggregates.go
@@ -101,14 +101,14 @@ func builtinSum(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 			return iter(ast.NewTerm(n))
 		}
 
-		sum := big.NewFloat(0)
+		sum := new(big.Float)
 		tmp := new(big.Float)
 		err := a.Iter(func(x *ast.Term) error {
 			n, ok := x.Value.(ast.Number)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			sum = new(big.Float).Add(sum, builtins.NumberToFloatInto(tmp, n))
+			sum = sum.Add(sum, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {
@@ -118,17 +118,19 @@ func builtinSum(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 	case ast.Set:
 		// Fast path for sets of integers
 		is := 0
-		bail := a.Until(func(x *ast.Term) bool {
-			if n, ok := x.Value.(ast.Number); ok {
+		bail := false
+		for _, term := range a.Slice() {
+			if n, ok := term.Value.(ast.Number); ok {
 				if i, ok := n.Int(); ok {
 					if s, ok := addInt(is, i); ok {
 						is = s
-						return false
+						continue
 					}
 				}
 			}
-			return true
-		})
+			bail = true
+			break
+		}
 		if !bail {
 			return iter(ast.InternedTerm(is))
 		}
@@ -137,18 +139,15 @@ func builtinSum(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) err
 			return iter(ast.NewTerm(n))
 		}
 
-		sum := big.NewFloat(0)
+		sum := new(big.Float)
 		tmp := new(big.Float)
-		err := a.Iter(func(x *ast.Term) error {
-			n, ok := x.Value.(ast.Number)
+
+		for _, term := range a.Slice() {
+			n, ok := term.Value.(ast.Number)
 			if !ok {
-				return builtins.NewOperandElementErr(1, a, x.Value, "number")
+				return builtins.NewOperandElementErr(1, a, term.Value, "number")
 			}
-			sum = new(big.Float).Add(sum, builtins.NumberToFloatInto(tmp, n))
-			return nil
-		})
-		if err != nil {
-			return err
+			sum = sum.Add(sum, builtins.NumberToFloatInto(tmp, n))
 		}
 		return iter(ast.NewTerm(builtins.FloatToNumber(sum)))
 	}
@@ -169,7 +168,7 @@ func builtinProduct(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			product = new(big.Float).Mul(product, builtins.NumberToFloatInto(tmp, n))
+			product = product.Mul(product, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {
@@ -188,7 +187,7 @@ func builtinProduct(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 			if !ok {
 				return builtins.NewOperandElementErr(1, a, x.Value, "number")
 			}
-			product = new(big.Float).Mul(product, builtins.NumberToFloatInto(tmp, n))
+			product = product.Mul(product, builtins.NumberToFloatInto(tmp, n))
 			return nil
 		})
 		if err != nil {

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -330,7 +330,7 @@ func (s *functionMocksStack) PopPairs() {
 }
 
 func (s *functionMocksStack) PutPairs(mocks [][2]*ast.Term) {
-	el := frame{}
+	el := make(frame, len(mocks))
 	for i := range mocks {
 		el[mocks[i][0].Value.String()] = mocks[i][1]
 	}

--- a/v1/topdown/comparison.go
+++ b/v1/topdown/comparison.go
@@ -6,43 +6,35 @@ package topdown
 
 import "github.com/open-policy-agent/opa/v1/ast"
 
-type compareFunc func(a, b ast.Value) bool
-
-func compareGreaterThan(a, b ast.Value) bool {
-	return a.Compare(b) > 0
+func builtinGreaterThan(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(operands[0].Value.Compare(operands[1].Value) > 0))
 }
 
-func compareGreaterThanEq(a, b ast.Value) bool {
-	return a.Compare(b) >= 0
+func builtinGreaterThanEq(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(operands[0].Value.Compare(operands[1].Value) >= 0))
 }
 
-func compareLessThan(a, b ast.Value) bool {
-	return a.Compare(b) < 0
+func builtinLessThan(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(operands[0].Value.Compare(operands[1].Value) < 0))
 }
 
-func compareLessThanEq(a, b ast.Value) bool {
-	return a.Compare(b) <= 0
+func builtinLessThanEq(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(operands[0].Value.Compare(operands[1].Value) <= 0))
 }
 
-func compareNotEq(a, b ast.Value) bool {
-	return a.Compare(b) != 0
+func builtinNotEqual(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(!operands[0].Equal(operands[1])))
 }
 
-func compareEq(a, b ast.Value) bool {
-	return a.Compare(b) == 0
-}
-
-func builtinCompare(cmp compareFunc) BuiltinFunc {
-	return func(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-		return iter(ast.InternedTerm(cmp(operands[0].Value, operands[1].Value)))
-	}
+func builtinEqual(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	return iter(ast.InternedTerm(operands[0].Equal(operands[1])))
 }
 
 func init() {
-	RegisterBuiltinFunc(ast.GreaterThan.Name, builtinCompare(compareGreaterThan))
-	RegisterBuiltinFunc(ast.GreaterThanEq.Name, builtinCompare(compareGreaterThanEq))
-	RegisterBuiltinFunc(ast.LessThan.Name, builtinCompare(compareLessThan))
-	RegisterBuiltinFunc(ast.LessThanEq.Name, builtinCompare(compareLessThanEq))
-	RegisterBuiltinFunc(ast.NotEqual.Name, builtinCompare(compareNotEq))
-	RegisterBuiltinFunc(ast.Equal.Name, builtinCompare(compareEq))
+	RegisterBuiltinFunc(ast.GreaterThan.Name, builtinGreaterThan)
+	RegisterBuiltinFunc(ast.GreaterThanEq.Name, builtinGreaterThanEq)
+	RegisterBuiltinFunc(ast.LessThan.Name, builtinLessThan)
+	RegisterBuiltinFunc(ast.LessThanEq.Name, builtinLessThanEq)
+	RegisterBuiltinFunc(ast.NotEqual.Name, builtinNotEqual)
+	RegisterBuiltinFunc(ast.Equal.Name, builtinEqual)
 }

--- a/v1/topdown/copypropagation/copypropagation.go
+++ b/v1/topdown/copypropagation/copypropagation.go
@@ -373,11 +373,10 @@ func (p *CopyPropagator) placeholderRef(b *binding) *ast.Expr {
 	if !ok || !p.placeholders.Contains(k) {
 		return nil
 	}
-	ref, ok := b.v.(ast.Ref)
-	if !ok {
+	if _, ok = b.v.(ast.Ref); !ok {
 		return nil
 	}
-	return ast.NewExpr(ast.NewTerm(ref))
+	return ast.NewExpr(ast.NewTerm(b.v))
 }
 
 func (p *CopyPropagator) updateBindingsEq(a, b *ast.Term) (ast.Var, ast.Value, bool) {
@@ -495,24 +494,22 @@ func makeDisjointSets(livevars ast.VarSet, query ast.Body) (*unionFind, bool) {
 	for _, expr := range query {
 		if expr.IsEquality() && !expr.Negated && len(expr.With) == 0 {
 			a, b := expr.Operand(0), expr.Operand(1)
-			varA, ok1 := a.Value.(ast.Var)
-			varB, ok2 := b.Value.(ast.Var)
+			_, aIsVar := a.Value.(ast.Var)
+			_, bIsVar := b.Value.(ast.Var)
 
 			switch {
-			case ok1 && ok2:
-				if _, ok := uf.Merge(varA, varB); !ok {
+			case aIsVar && bIsVar:
+				if _, ok := uf.Merge(a.Value, b.Value); !ok {
 					return nil, false
 				}
-
-			case ok1 && ast.IsConstant(b.Value):
-				root := uf.MakeSet(varA)
+			case aIsVar && ast.IsConstant(b.Value):
+				root := uf.MakeSet(a.Value)
 				if root.constant != nil && !root.constant.Equal(b) {
 					return nil, false
 				}
 				root.constant = b
-
-			case ok2 && ast.IsConstant(a.Value):
-				root := uf.MakeSet(varB)
+			case bIsVar && ast.IsConstant(a.Value):
+				root := uf.MakeSet(b.Value)
 				if root.constant != nil && !root.constant.Equal(a) {
 					return nil, false
 				}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -984,7 +984,8 @@ func (e *eval) evalCall(terms []*ast.Term, iter unifyIterator) error {
 	mock, mocked := e.functionMocks.Get(ref)
 	if mocked {
 		if m, ok := mock.Value.(ast.Ref); ok && isFunction(e.compiler.TypeEnv, m) { // builtin or data function
-			mockCall := append([]*ast.Term{mock}, terms[1:]...)
+			mockCall := make([]*ast.Term, 0, len(terms))
+			mockCall = append(append(mockCall, mock), terms[1:]...)
 
 			e.functionMocks.Push()
 			err := e.evalCall(mockCall, func() error {
@@ -4661,8 +4662,7 @@ func getSavePairsFromExpr(declArgsLen int, x *ast.Expr, b *bindings, result []sa
 
 func getSavePairsFromTerm(x *ast.Term, b *bindings, result []savePair) []savePair {
 	if _, ok := x.Value.(ast.Var); ok {
-		result = append(result, savePair{x, b})
-		return result
+		return append(result, savePair{x, b})
 	}
 	vis := ast.NewVarVisitor().WithParams(ast.VarVisitorParams{
 		SkipClosures: true,

--- a/v1/topdown/reachable.go
+++ b/v1/topdown/reachable.go
@@ -40,10 +40,12 @@ func builtinReachable(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Ter
 
 	var queue []*ast.Term
 	switch initial := operands[1].Value.(type) {
-	case *ast.Array, ast.Set:
+	case *ast.Array:
 		foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
 			queue = append(queue, t)
 		})
+	case ast.Set:
+		queue = append(queue, initial.Slice()...)
 	default:
 		return builtins.NewOperandTypeErr(2, initial, "{array, set}")
 	}
@@ -113,10 +115,12 @@ func builtinReachablePaths(_ BuiltinContext, operands []*ast.Term, iter func(*as
 	// initialised to the initial set of nodes we start out with.
 	var queue []*ast.Term
 	switch initial := operands[1].Value.(type) {
-	case *ast.Array, ast.Set:
+	case *ast.Array:
 		foreachVertex(ast.NewTerm(initial), func(t *ast.Term) {
 			queue = append(queue, t)
 		})
+	case ast.Set:
+		queue = append(queue, initial.Slice()...)
 	default:
 		return builtins.NewOperandTypeErr(2, initial, "{array, set}")
 	}

--- a/v1/topdown/sets.go
+++ b/v1/topdown/sets.go
@@ -11,7 +11,6 @@ import (
 
 // Deprecated: deprecated in v0.4.2 in favour of minus/infix "-" operation.
 func builtinSetDiff(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	s1, err := builtins.SetOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
@@ -27,7 +26,6 @@ func builtinSetDiff(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 
 // builtinSetIntersection returns the intersection of the given input sets
 func builtinSetIntersection(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	inputSet, err := builtins.SetOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
@@ -40,8 +38,8 @@ func builtinSetIntersection(_ BuiltinContext, operands []*ast.Term, iter func(*a
 
 	var result ast.Set
 
-	err = inputSet.Iter(func(x *ast.Term) error {
-		n, err := builtins.SetOperand(x.Value, 1)
+	for _, term := range inputSet.Slice() {
+		n, err := builtins.SetOperand(term.Value, 1)
 		if err != nil {
 			return err
 		}
@@ -51,10 +49,6 @@ func builtinSetIntersection(_ BuiltinContext, operands []*ast.Term, iter func(*a
 		} else {
 			result = result.Intersect(n)
 		}
-		return nil
-	})
-	if err != nil {
-		return err
 	}
 	return iter(ast.NewTerm(result))
 }
@@ -72,31 +66,22 @@ func builtinSetUnion(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 
 	// First pass: count total elements for pre-allocation
 	totalSize := 0
-	err = inputSet.Iter(func(x *ast.Term) error {
-		item, err := builtins.SetOperand(x.Value, 1)
+	for _, term := range inputSet.Slice() {
+		item, err := builtins.SetOperand(term.Value, 1)
 		if err != nil {
 			return err
 		}
 		totalSize += item.Len()
-		return nil
-	})
-	if err != nil {
-		return err
 	}
 
 	// Pre-allocate result set with estimated capacity
-	result := ast.NewSetWithCapacity(totalSize)
-
-	err = inputSet.Iter(func(x *ast.Term) error {
-		item, _ := builtins.SetOperand(x.Value, 1) // error checked above
-		item.Foreach(result.Add)
-		return nil
-	})
-	if err != nil {
-		return err
+	terms := make([]*ast.Term, 0, totalSize)
+	for _, term := range inputSet.Slice() {
+		item, _ := builtins.SetOperand(term.Value, 1) // error checked above
+		terms = append(terms, item.Slice()...)
 	}
 
-	return iter(ast.NewTerm(result))
+	return iter(ast.SetTerm(terms...))
 }
 
 func init() {

--- a/v1/topdown/sets_bench_test.go
+++ b/v1/topdown/sets_bench_test.go
@@ -5,12 +5,12 @@
 package topdown
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage"
 	inmem "github.com/open-policy-agent/opa/v1/storage/inmem/test"
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 func genNxMSetBenchmarkData(n, m int) ast.Value {
@@ -18,7 +18,7 @@ func genNxMSetBenchmarkData(n, m int) ast.Value {
 	for i := range n {
 		v := ast.NewSet()
 		for j := range m {
-			v.Add(ast.StringTerm(fmt.Sprintf("%d,%d", i, j)))
+			v.Add(ast.StringTerm(fmtInts(i, j, ',')))
 		}
 		setOfSets.Add(ast.NewTerm(v))
 	}
@@ -26,38 +26,15 @@ func genNxMSetBenchmarkData(n, m int) ast.Value {
 }
 
 func BenchmarkSetIntersection(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 1000}
 
 	for _, n := range sizes {
 		for _, m := range sizes {
-			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
-				store := inmem.NewFromObject(map[string]any{"sets": genNxMSetBenchmarkData(n, m)})
-
-				module := `package test
-
-				combined := intersection({s | s := data.sets[_]})`
-
-				query := ast.MustParseBody("data.test.combined")
-				compiler := ast.MustCompileModules(map[string]string{
-					"test.rego": module,
-				})
-
-				b.ResetTimer()
+			b.Run(fmtInts(n, m, 'x'), func(b *testing.B) {
+				ops := []*ast.Term{ast.NewTerm(genNxMSetBenchmarkData(n, m))}
 
 				for b.Loop() {
-					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-						_, err := NewQuery(query).
-							WithCompiler(compiler).
-							WithStore(store).
-							WithTransaction(txn).
-							Run(ctx)
-
-						return err
-					})
-
-					if err != nil {
+					if err := builtinSetIntersection(BuiltinContext{}, ops, noOpIter); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -67,13 +44,11 @@ func BenchmarkSetIntersection(b *testing.B) {
 }
 
 func BenchmarkSetIntersectionSlow(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 50, 100}
 
 	for _, n := range sizes {
 		for _, m := range sizes {
-			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
+			b.Run(fmtInts(n, m, 'x'), func(b *testing.B) {
 				store := inmem.NewFromObject(map[string]any{"sets": genNxMSetBenchmarkData(n, m)})
 
 				module := `package test
@@ -91,6 +66,7 @@ func BenchmarkSetIntersectionSlow(b *testing.B) {
 				})
 
 				b.ResetTimer()
+				ctx := b.Context()
 
 				for b.Loop() {
 					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
@@ -113,41 +89,15 @@ func BenchmarkSetIntersectionSlow(b *testing.B) {
 }
 
 func BenchmarkSetUnion(b *testing.B) {
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 250}
 
 	for _, n := range sizes {
 		for _, m := range sizes {
-			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
-				store := inmem.NewFromObject(map[string]any{"sets": genNxMSetBenchmarkData(n, m)})
-
-				// Code is lifted from here:
-				// https://github.com/open-policy-agent/opa/issues/4979#issue-1332019382
-
-				module := `package test
-
-				combined := union({s | s := data.sets[_]})`
-
-				query := ast.MustParseBody("data.test.combined")
-				compiler := ast.MustCompileModules(map[string]string{
-					"test.rego": module,
-				})
-
-				b.ResetTimer()
+			b.Run(fmtInts(n, m, 'x'), func(b *testing.B) {
+				ops := []*ast.Term{ast.NewTerm(genNxMSetBenchmarkData(n, m))}
 
 				for b.Loop() {
-					err := storage.Txn(ctx, store, storage.TransactionParams{}, func(txn storage.Transaction) error {
-						_, err := NewQuery(query).
-							WithCompiler(compiler).
-							WithStore(store).
-							WithTransaction(txn).
-							Run(ctx)
-
-						return err
-					})
-
-					if err != nil {
+					if err := builtinSetUnion(BuiltinContext{}, ops, noOpIter); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -160,13 +110,12 @@ func BenchmarkSetUnionSlow(b *testing.B) {
 	// This benchmarks the suggested means to implement union
 	// without using the builtin, to give us an idea of whether or not
 	// the builtin is actually making things any faster.
-	ctx := b.Context()
-
 	sizes := []int{10, 100, 250}
 
 	for _, n := range sizes {
 		for _, m := range sizes {
-			b.Run(fmt.Sprintf("%dx%d", n, m), func(b *testing.B) {
+			b.Run(fmtInts(n, m, 'x'), func(b *testing.B) {
+				ctx := b.Context()
 				store := inmem.NewFromObject(map[string]any{"sets": genNxMSetBenchmarkData(n, m)})
 
 				// Code is lifted from here:
@@ -201,4 +150,8 @@ func BenchmarkSetUnionSlow(b *testing.B) {
 			})
 		}
 	}
+}
+
+func fmtInts(n, m int, sep byte) string {
+	return util.ByteSliceToString(util.AppendInt(append(util.AppendInt(make([]byte, 0, 32), n), sep), m))
 }

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -20,6 +20,11 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
+var (
+	trueAny                 any = true
+	errEmptySearchCharacter     = errors.New("empty search character")
+)
+
 func builtinAnyPrefixMatch(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	a, b := operands[0].Value, operands[1].Value
 
@@ -104,11 +109,11 @@ func anyStartsWithAny(strs []string, prefixes []string) bool {
 
 	trie := patricia.NewTrie()
 	for i := range strs {
-		trie.Insert([]byte(strs[i]), true)
+		trie.Insert(util.StringToByteSlice(strs[i]), trueAny)
 	}
 
 	for i := range prefixes {
-		if trie.MatchSubtree([]byte(prefixes[i])) {
+		if trie.MatchSubtree(util.StringToByteSlice(prefixes[i])) {
 			return true
 		}
 	}
@@ -312,7 +317,7 @@ func builtinIndexOf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 		return err
 	}
 	if len(string(search)) == 0 {
-		return errors.New("empty search character")
+		return errEmptySearchCharacter
 	}
 
 	if isASCII(string(base)) && isASCII(string(search)) {
@@ -350,7 +355,7 @@ func builtinIndexOfN(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 		return err
 	}
 	if len(string(search)) == 0 {
-		return errors.New("empty search character")
+		return errEmptySearchCharacter
 	}
 
 	baseRunes := []rune(string(base))
@@ -372,7 +377,6 @@ func builtinIndexOfN(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term
 }
 
 func builtinSubstring(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-
 	base, err := builtins.StringOperand(operands[0].Value, 1)
 	if err != nil {
 		return err
@@ -590,10 +594,7 @@ func builtinSplitN(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) 
 	} else {
 		parts := strings.Split(text, delim)
 		start := max(len(parts)+n, 0)
-		result = make([]*ast.Term, len(parts)-start)
-		for i, p := range parts[start:] {
-			result[i] = ast.InternedTerm(p)
-		}
+		result = util.Map(parts[start:], ast.InternedTerm)
 	}
 
 	return iter(ast.ArrayTerm(result...))
@@ -857,7 +858,7 @@ func reverseString(str string) string {
 		utf8.EncodeRune(buf[size-start:], r)
 	}
 
-	return string(buf)
+	return util.ByteSliceToString(buf)
 }
 
 func init() {

--- a/v1/topdown/strings_bench_test.go
+++ b/v1/topdown/strings_bench_test.go
@@ -2,6 +2,7 @@ package topdown
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -372,11 +373,7 @@ func BenchmarkLongSprintf(b *testing.B) {
 }
 
 func repeatTerm(t *ast.Term, n int) *ast.Term {
-	terms := make([]*ast.Term, 0, n)
-	for range n {
-		terms = append(terms, t)
-	}
-	return ast.ArrayTerm(terms...)
+	return ast.ArrayTerm(slices.Repeat([]*ast.Term{t}, n)...)
 }
 
 func BenchmarkSplitLenVsStringsCount(b *testing.B) {

--- a/v1/topdown/trace.go
+++ b/v1/topdown/trace.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 
@@ -857,15 +858,9 @@ func printPrettyVars(w *bytes.Buffer, exprVars map[string]varInfo) {
 	if containsTabs && len(varRows) > 1 {
 		// We can't (currently) reliably point to var locations when they are on different rows that contain tabs.
 		// So we'll just print them in alphabetical order instead.
-		byName := make([]varInfo, 0, len(exprVars))
-		for _, info := range exprVars {
-			byName = append(byName, info)
-		}
-		slices.SortStableFunc(byName, func(a, b varInfo) int {
-			return strings.Compare(a.Title(), b.Title())
-		})
-
 		w.WriteString("\n\nWhere:\n")
+
+		byName := slices.SortedStableFunc(maps.Values(exprVars), cmpVarInfoTitle)
 		for _, info := range byName {
 			fmt.Fprintf(w, "\n%s: %s", info.Title(), iStrs.Truncate(info.Value(), maxPrettyExprVarWidth))
 		}
@@ -898,6 +893,10 @@ func printPrettyVars(w *bytes.Buffer, exprVars map[string]varInfo) {
 		w.WriteByte('\n')
 		printArrows(w, byCol, i)
 	}
+}
+
+func cmpVarInfoTitle(a, b varInfo) int {
+	return strings.Compare(a.Title(), b.Title())
 }
 
 func printArrows(w *bytes.Buffer, l []varInfo, printValueAt int) {

--- a/v1/util/maps.go
+++ b/v1/util/maps.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"cmp"
-	"slices"
 )
 
 // Keys returns a slice of keys from any map.
@@ -16,12 +15,7 @@ func Keys[M ~map[K]V, K comparable, V any](m M) []K {
 
 // KeysSorted returns a slice of keys from any map, sorted in ascending order.
 func KeysSorted[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
-	r := make([]K, 0, len(m))
-	for k := range m {
-		r = append(r, k)
-	}
-	slices.Sort(r)
-	return r
+	return Sorted(Keys(m))
 }
 
 // Values returns a slice of values from any map. Copied from golang.org/x/exp/maps.

--- a/v1/util/slices.go
+++ b/v1/util/slices.go
@@ -20,9 +20,11 @@ func Map[T any, U any](s []T, f func(T) U) []U {
 
 // MapAppend applies f to each element of src and appends the results to dst, returning the resulting slice.
 func MapAppend[T any, U any](dst []U, src []T, f func(T) U) []U {
-	dst = slices.Grow(dst, len(src))
-	for _, v := range src {
-		dst = append(dst, f(v))
+	if len(src) > 0 {
+		dst = slices.Grow(dst, len(src))
+		for _, v := range src {
+			dst = append(dst, f(v))
+		}
 	}
 	return dst
 }


### PR DESCRIPTION
Nothing that stands out here, just various changes to reduce heap allocations here and there:

- Register and call the comparison built-in functions without a redundant proxy function (that also ends up on the heap).
- Avoid `Set.Iter` and `Set.Foreach` when we can simply iterate over its `Slice` without function literals and/or closure variables escaping to the heap.
- Avoid creating new big.Float's in each iteration in the `sum` and `product` built-in functions.
- Use `util.StringToByteSlice` in more places where it's safe to do so.
- Clean up the Set intersection/union benchmarks and make sure they only benchmark the builtin functions, not the whole topdown machinery
- Avoid `Var` -> `Value` in copy propagation

Also replacing some code with more modern alternatives, from the stdlib or our own utils.