### PR TITLE
format: write added imports before rules

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -477,8 +477,26 @@ func (w *writer) writeModule(module *ast.Module) error {
 
 	comments = trimTrailingWhitespaceInComments(comments)
 
+	// Imports added by the formatter get an assigned line number, which can sort
+	// after a rule's. An import written after a rule has no effect.
+	var added []*ast.Import
+	if addedImportFollowsRule(others) {
+		others = slices.DeleteFunc(others, func(x any) bool {
+			imp, ok := x.(*ast.Import)
+			if !ok || !isAddedImport(imp) {
+				return false
+			}
+			added = append(added, imp)
+			return true
+		})
+	}
+
 	var err error
 	comments, err = w.writePackage(pkg, comments)
+	if err != nil {
+		return err
+	}
+	comments, err = w.writeImports(added, comments)
 	if err != nil {
 		return err
 	}
@@ -2937,6 +2955,32 @@ func nextImportLoc(imps []*ast.Import, node ast.Node) *ast.Location {
 func isFutureKeywordsImport(imp *ast.Import) bool {
 	path := imp.Path.Value.(ast.Ref)
 	return len(path) >= 2 && ast.FutureRootDocument.Equal(path[0])
+}
+
+func isAddedImport(imp *ast.Import) bool {
+	return imp.Loc() != nil && imp.Loc().File == defaultLocationFile
+}
+
+// addedImportFollowsRule reports whether an import added by the formatter would
+// be written at or after the first rule.
+func addedImportFollowsRule(others []any) bool {
+	firstRule := -1
+	for _, x := range others {
+		if r, ok := x.(*ast.Rule); ok && r.Loc() != nil {
+			if firstRule < 0 || r.Loc().Row < firstRule {
+				firstRule = r.Loc().Row
+			}
+		}
+	}
+	if firstRule < 0 {
+		return false
+	}
+	for _, x := range others {
+		if imp, ok := x.(*ast.Import); ok && isAddedImport(imp) && imp.Loc().Row >= firstRule {
+			return true
+		}
+	}
+	return false
 }
 
 func ensureRegoV1Import(imps []*ast.Import) []*ast.Import {

--- a/v1/format/format_test.go
+++ b/v1/format/format_test.go
@@ -1094,6 +1094,47 @@ func TestFormatAST_Error(t *testing.T) {
 	}
 }
 
+func TestFormatAddedImportsPrecedeRules(t *testing.T) {
+	// Partial evaluation drops the imports and emits rules at line 1, so the
+	// formatter has to add an import for every keyword the rules use.
+	cases := []struct {
+		note   string
+		module string
+	}{
+		{
+			note:   "and and or",
+			module: "package t\n\nimport future.keywords.and\nimport future.keywords.or\n\nallow if input.a and input.b or input.c\n",
+		},
+		{
+			note:   "and and not",
+			module: "package t\n\nimport future.keywords.and\nimport future.keywords.not\n\nallow if not (input.a) and input.b\n",
+		},
+		{
+			note:   "or and not",
+			module: "package t\n\nimport future.keywords.not\nimport future.keywords.or\n\nallow if not (input.a) or input.b\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			module := ast.MustParseModule(tc.module)
+			module.Imports = nil
+			for _, rule := range module.Rules {
+				rule.SetLoc(ast.NewLocation(rule.Loc().Text, "", 1, 1))
+			}
+
+			formatted, err := Ast(module)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if _, err := ast.ParseModule("formatted.rego", string(formatted)); err != nil {
+				t.Fatalf("Expected formatted module to parse, got %s:\n\n%s", err, formatted)
+			}
+		})
+	}
+}
+
 func TestFormatDeepCopy(t *testing.T) {
 
 	original := ast.Body{


### PR DESCRIPTION
`opa build --optimize` put a `future.keywords` import after the rules when a policy needed two or more of them, producing a bundle OPA could not load.