### PR TITLE
format: Honor line breaks before explicit `and`/`or` operand bodies

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -1308,11 +1308,19 @@ type logicalStep struct {
 	lhsEndRow int
 }
 
-// breaksLine reports whether the rhs operand is written on a line of its own.
-// Explicit operands always open their brace on the operator's line, so only an
-// implicit operand starting on a later row than the operator breaks.
+// breaksLine reports whether the rhs operand is written on a line of its own,
+// i.e. starts on a later row than the end of everything left of the operator.
+// An explicit operand starts at its opening brace, an implicit one at its sole
+// expression; a missing location leaves the row unknown, so no break.
 func (s logicalStep) breaksLine() bool {
-	return !s.rhs.explicit && s.rhs.body[0].Location.Row > s.lhsEndRow
+	var start *ast.Location
+	if s.rhs.explicit {
+		start = s.rhs.brace
+	} else if len(s.rhs.body) > 0 {
+		start = s.rhs.body[0].Location
+	}
+
+	return start != nil && start.Row > s.lhsEndRow
 }
 
 func (w *writer) writeLogical(expr *ast.Expr, comments []*ast.Comment) ([]*ast.Comment, error) {

--- a/v1/format/testfiles/v1/test_logical_multiline.rego
+++ b/v1/format/testfiles/v1/test_logical_multiline.rego
@@ -41,3 +41,43 @@ already_formatted if {
 		input.b or
 		input.c
 }
+
+# An explicit `{...}` operand on a line of its own stays there
+broken_body_chain if {
+	{input.foo.bar.baz.a} or
+	{input.foo.bar.baz.b} or
+	{input.foo.bar.baz.c} or
+	{input.foo.bar.baz.d} or
+	{input.foo.bar.baz.e} or
+	{input.foo.bar.baz.f} or
+	{input.foo.bar.baz.g}
+}
+
+broken_mixed_operands if {
+	{input.a} or
+	input.b or
+	{input.c}
+}
+
+broken_multi_expr_body_rhs if {
+	{input.a} or
+	{
+		input.b
+		input.c
+	}
+}
+
+broken_after_multi_expr_body_lhs if {
+	{
+		input.a
+		input.b
+	} or
+	{input.c}
+}
+
+# A brace opening on the operator's line is not a break
+body_opens_on_operator_line if {
+	{input.a} or {
+		input.b
+	} or {input.c}
+}

--- a/v1/format/testfiles/v1/test_logical_multiline.rego.formatted
+++ b/v1/format/testfiles/v1/test_logical_multiline.rego.formatted
@@ -41,3 +41,43 @@ already_formatted if {
 		input.b or
 		input.c
 }
+
+# An explicit `{...}` operand on a line of its own stays there
+broken_body_chain if {
+	{ input.foo.bar.baz.a } or
+		{ input.foo.bar.baz.b } or
+		{ input.foo.bar.baz.c } or
+		{ input.foo.bar.baz.d } or
+		{ input.foo.bar.baz.e } or
+		{ input.foo.bar.baz.f } or
+		{ input.foo.bar.baz.g }
+}
+
+broken_mixed_operands if {
+	{ input.a } or
+		input.b or
+		{ input.c }
+}
+
+broken_multi_expr_body_rhs if {
+	{ input.a } or
+		{
+			input.b
+			input.c
+		}
+}
+
+broken_after_multi_expr_body_lhs if {
+	{
+		input.a
+		input.b
+	} or
+		{ input.c }
+}
+
+# A brace opening on the operator's line is not a break
+body_opens_on_operator_line if {
+	{ input.a } or {
+		input.b
+	} or { input.c }
+}


### PR DESCRIPTION
fix:  #9053

A chain of `{...}` operands written one per line was collapsed onto a single, unreadably long line; trailing operands are now indented, following existing behavior introduced in https://github.com/open-policy-agent/opa/pull/9006.