### PR TITLE
More modernization

### DIFF
--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -107,10 +107,10 @@ func Compare(a, b any) int {
 	case Var:
 		return VarCompare(a, b.(Var))
 	case Ref:
-		return termSliceCompare(a, b.(Ref))
+		return slices.CompareFunc(a, b.(Ref), TermValueCompare)
 	case *Array:
 		b := b.(*Array)
-		return termSliceCompare(a.elems, b.elems)
+		return slices.CompareFunc(a.elems, b.elems, TermValueCompare)
 	case *lazyObj:
 		return Compare(a.force(), b)
 	case *object:
@@ -130,7 +130,7 @@ func Compare(a, b any) int {
 		b := b.(*SetComprehension)
 		return a.Compare(b)
 	case Call:
-		return termSliceCompare(a, b.(Call))
+		return slices.CompareFunc(a, b.(Call), TermValueCompare)
 	case *Expr:
 		return a.Compare(b.(*Expr))
 	case *SomeDecl:
@@ -150,7 +150,7 @@ func Compare(a, b any) int {
 	case *Rule:
 		return a.Compare(b.(*Rule))
 	case Args:
-		return termSliceCompare(a, b.(Args))
+		return slices.CompareFunc(a, b.(Args), TermValueCompare)
 	case *Import:
 		return a.Compare(b.(*Import))
 	case *Package:
@@ -247,52 +247,6 @@ func sortOrder(x any) int {
 	panic(fmt.Sprintf("illegal value: %T", x))
 }
 
-func rulesCompare(a, b []*Rule) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Compare(b[i]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	}
-	if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
-func termSliceCompare(a, b []*Term) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Value.Compare(b[i].Value); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	} else if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
-func withSliceCompare(a, b []*With) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Compare(b[i]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	} else if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
 func VarCompare(a, b Var) int {
 	if a == b {
 		return 0
@@ -329,7 +283,7 @@ func ValueEqual(a, b Value) bool {
 }
 
 func RefCompare(a, b Ref) int {
-	return termSliceCompare(a, b)
+	return slices.CompareFunc(a, b, TermValueCompare)
 }
 
 func RefEqual(a, b Ref) bool {

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2118,18 +2118,6 @@ func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
 	return rules
 }
 
-func refSliceEqual(a, b []Ref) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !a[i].Equal(b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 func hashMapAdd(rules *util.HasherMap[Ref, []Ref], pkg, rule Ref) {
 	prev, ok := rules.Get(pkg)
 	if !ok {
@@ -2640,15 +2628,12 @@ func rewriteTemplateString(tsr *templateStringRewriter, safe VarSet, loc *Locati
 				// Note: we don't care about not exprs here
 				vis = ClearOrNewVarVisitor(vis).WithParams(SafetyCheckVisitorParams)
 				vis.Walk(t)
-				vars := vis.Vars()
-				if vars.DiffCount(safe) > 0 {
-					unsafe := vars.Diff(safe)
-					for _, v := range unsafe.Sorted() {
-						if w, ok := tsr.rewritten[v]; ok {
-							v = w
-						}
-						errs = append(errs, NewError(CompileErr, t.Loc(), "var %v is undeclared", v))
+				unsafe := vis.Vars().DeleteFunc(safe.Contains)
+				for _, v := range unsafe.Sorted() {
+					if w, ok := tsr.rewritten[v]; ok {
+						v = w
 					}
+					errs = append(errs, NewError(CompileErr, t.Loc(), "var %v is undeclared", v))
 				}
 
 				loc := t.Loc()
@@ -2829,15 +2814,12 @@ func rewritePrintCalls(gen *localVarGenerator, getArity func(Ref) int, globals V
 			// Note: we don't care about not exprs here
 			vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
 			vis.Walk(args[j])
-			vars := vis.Vars()
-			if vars.DiffCount(safe) > 0 {
-				unsafe := vars.Diff(safe)
-				for _, v := range unsafe.Sorted() {
-					if w, ok := rewritten[v]; ok {
-						v = w
-					}
-					errs = append(errs, NewError(CompileErr, args[j].Loc(), "var %v is undeclared", v))
+			unsafe := vis.Vars().DeleteFunc(safe.Contains)
+			for _, v := range unsafe.Sorted() {
+				if w, ok := rewritten[v]; ok {
+					v = w
 				}
+				errs = append(errs, NewError(CompileErr, args[j].Loc(), "var %v is undeclared", v))
 			}
 		}
 
@@ -3356,11 +3338,7 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 		if rule.Head.Value != nil && !IsScalar(rule.Head.Value.Value) {
 			valueVars := rule.Head.Value.Vars()
 			vis.vars.Update(valueVars)
-			for arg := range unusedArgs {
-				if valueVars.Contains(arg) {
-					delete(unusedArgs, arg)
-				}
-			}
+			unusedArgs.DeleteFunc(valueVars.Contains)
 		}
 
 		used = vis.Vars()
@@ -4063,7 +4041,9 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 	}
 
 	outputs := outputVarsForBody(body, arity, ReservedVars, nil)
-	unsafe := body.Vars(SafetyCheckVisitorParams).Diff(outputs).Diff(ReservedVars)
+	unsafe := body.Vars(SafetyCheckVisitorParams).
+		DeleteFunc(outputs.Contains).
+		DeleteFunc(ReservedVars.Contains)
 
 	if len(unsafe) > 0 {
 		dbg.Printf("%s: comprehension index: unsafe vars: %v", expr.Location, unsafe)
@@ -4100,12 +4080,7 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 		return nil
 	}
 
-	result := make([]*Term, 0, len(indexVars))
-	for v := range indexVars {
-		result = append(result, NewTerm(v))
-	}
-	slices.SortFunc(result, TermValueCompare)
-
+	result := util.SortedFunc(util.MapKeys(indexVars, ToTerm), TermValueCompare)
 	debugRes := make([]*Term, len(result))
 	for i, r := range result {
 		if o, ok := rwVars[r.Value.(Var)]; ok {
@@ -4796,10 +4771,7 @@ func (g *Graph) Sort() (sorted []util.T, ok bool) {
 		temp:   map[util.T]struct{}{},
 	}
 
-	nodesList := make([]util.T, 0, len(g.nodes))
-	for node := range g.nodes {
-		nodesList = append(nodesList, node)
-	}
+	nodesList := util.Keys(g.nodes)
 	sortGraphNodes(nodesList)
 	for _, node := range nodesList {
 		if !sorter.Visit(node) {
@@ -5010,10 +4982,8 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 	for _, e := range body {
 		vis = vis.Clear().WithParams(SafetyCheckVisitorParamsWithArity(arity))
 		vis.Walk(e)
-		for v := range vis.Vars() {
-			if _, ok := safe[v]; !ok {
-				unsafe.Add(e, v)
-			}
+		for v := range vis.Vars().DeleteFunc(safe.Contains) {
+			unsafe.Add(e, v)
 		}
 	}
 
@@ -5034,13 +5004,13 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 			// check closures: is this expression closing over variables that
 			// haven't been made safe by what's already included in `reordered`?
 			unsafeVarsInClosures(e, unsVis)
-			cv := unsVis.Vars().Intersect(bodyVars).Diff(globals)
+			cv := unsVis.Vars().Intersect(bodyVars).DeleteFunc(globals.Contains)
 			unsVis.Clear()
 
 			ob := outputVarsForBody(reordered, arity, safe, vis)
 
 			if cv.DiffCount(ob) > 0 {
-				uv := cv.Diff(ob)
+				uv := cv.DeleteFunc(ob.Contains)
 				if uv.Equal(ovs) { // special case "closure-self"
 					continue
 				}
@@ -5300,8 +5270,7 @@ func (xform *bodySafetyTransformer) reorderComprehensionSafety(tv VarSet, body B
 	bv.Update(xform.globals)
 
 	if tv.DiffCount(bv) > 0 {
-		uv := tv.Diff(bv)
-		for v := range uv {
+		for v := range tv.Diff(bv) {
 			xform.unsafe.Add(xform.current, v)
 		}
 	}
@@ -5361,11 +5330,10 @@ func outputVarsForBody(body Body, arity func(Ref) int, safe VarSet, vis *VarVisi
 	output := VarSet{}
 
 	vis = ClearOrNewVarVisitor(vis)
-
 	for _, e := range body {
 		o.Update(outputVarsForExpr(e, arity, o, output, vis))
 	}
-	return o.Diff(safe)
+	return o.DeleteFunc(safe.Contains)
 }
 
 // OutputVarsFromExpr returns all variables which are the "output" for
@@ -5473,7 +5441,7 @@ func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vi
 	vis = ClearOrNewVarVisitor(vis).WithParams(params)
 	vis.WalkArgs(Args(terms[:numInputTerms]))
 
-	unsafe := vis.Vars().Diff(output).DiffCount(safe)
+	unsafe := vis.Vars().DeleteFunc(output.Contains).DiffCount(safe)
 	if unsafe > 0 {
 		return VarSet{}
 	}
@@ -5574,9 +5542,9 @@ func newLocalVarGeneratorForModuleSet(sorted []string, modules map[string]*Modul
 	return &localVarGenerator{exclude: vis.vars, suffix: LocalVarPrefix}
 }
 
-func newLocalVarGenerator(suffix string, node any) *localVarGenerator {
+func newLocalVarGenerator(suffix string, body Body) *localVarGenerator {
 	vis := NewVarVisitor()
-	vis.Walk(node)
+	vis.WalkBody(body)
 	return &localVarGenerator{exclude: vis.vars, suffix: LocalVarPrefix + suffix}
 }
 
@@ -5599,7 +5567,7 @@ func getGlobals(pkg *Package, rules []Ref, imports []*Import) map[Var]*usedRef {
 
 	for _, ref := range rules {
 		v := ref[0].Value.(Var)
-		globals[v] = &usedRef{ref: pkg.Path.Append(StringTerm(string(v)))}
+		globals[v] = &usedRef{ref: pkg.Path.Append(InternedTerm(string(v)))}
 	}
 
 	for _, imp := range imports {
@@ -6810,13 +6778,12 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 
 	for v := range used {
 		if gv, ok := stack.Declared(v); ok {
-			bodyvars.Add(gv)
-		} else {
-			bodyvars.Add(v)
+			v = gv
 		}
+		bodyvars.Add(v)
 	}
 
-	dbv := declared.Diff(bodyvars)
+	dbv := declared.DeleteFunc(bodyvars.Contains)
 	if dbv.DiffCount(used) == 0 {
 		return errs
 	}
@@ -6826,7 +6793,7 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 		reversed[v] = k
 	}
 
-	for _, gv := range dbv.Diff(used).Sorted() {
+	for _, gv := range dbv.DeleteFunc(used.Contains).Sorted() {
 		rv := reversed[gv]
 		if !rv.IsGenerated() {
 			// Scan through body exprs, looking for a match between the
@@ -7301,7 +7268,7 @@ func validateWith(c *Compiler, unsafeBuiltinsMap map[string]struct{}, expr *Expr
 	// Ensure that values that are built-ins are rewritten to Ref (not Var)
 	if v, ok := value.Value.(Var); ok {
 		if _, ok := c.builtins[v.String()]; ok {
-			value.Value = Ref([]*Term{NewTerm(v)})
+			value.Value = Ref([]*Term{NewTerm(value.Value)})
 		}
 	}
 	isBuiltinRefOrVar, err := isBuiltinRefOrVar(c.builtins, unsafeBuiltinsMap, target)
@@ -7362,8 +7329,8 @@ func validateWith(c *Compiler, unsafeBuiltinsMap map[string]struct{}, expr *Expr
 	case isBuiltinRefOrVar:
 		// NOTE(sr): first we ensure that parsed Var builtins (`count`, `concat`, etc)
 		// are rewritten to their proper Ref convention
-		if v, ok := target.Value.(Var); ok {
-			target.Value = Ref([]*Term{NewTerm(v)})
+		if _, ok := target.Value.(Var); ok {
+			target.Value = Ref([]*Term{NewTerm(target.Value)})
 		}
 
 		targetRef := target.Value.(Ref)

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -444,10 +444,7 @@ func refMapEqual(a, b *util.HasherMap[Ref, []Ref]) bool {
 		if !ok {
 			return true
 		}
-		if !refSliceEqual(v, v2) {
-			return true
-		}
-		return false
+		return !slices.EqualFunc(v, v2, RefEqual)
 	})
 }
 
@@ -2982,7 +2979,7 @@ func TestCompilerExprExpansion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-			gen := newLocalVarGenerator("", NullTerm())
+			gen := newLocalVarGenerator("", Body{})
 			expr := MustParseExpr(tc.input)
 			result := expandExpr(gen, expr.Copy())
 			if len(result) != len(tc.expected) {

--- a/v1/ast/parser_ext.go
+++ b/v1/ast/parser_ext.go
@@ -301,7 +301,7 @@ func ParseCompleteDocRuleWithDotsFromTerm(module *Module, term *Term) (*Rule, er
 	}
 
 	if _, ok := ref[0].Value.(Var); !ok {
-		return nil, fmt.Errorf("invalid rule head: %v", ref)
+		return nil, fmt.Errorf("invalid rule head: %v", term.Value)
 	}
 	head := RefHead(ref, BooleanTerm(true).SetLocation(term.Location))
 	head.generatedValue = true
@@ -326,7 +326,7 @@ func ParsePartialObjectDocRuleFromEqExpr(module *Module, lhs, rhs *Term) (*Rule,
 	}
 
 	if _, ok := ref[0].Value.(Var); !ok {
-		return nil, fmt.Errorf("invalid rule head: %v", ref)
+		return nil, fmt.Errorf("invalid rule head: %v", lhs.Value)
 	}
 
 	head := RefHead(ref, rhs)
@@ -352,13 +352,12 @@ func ParsePartialObjectDocRuleFromEqExpr(module *Module, lhs, rhs *Term) (*Rule,
 // ParsePartialSetDocRuleFromTerm returns a rule if the term can be interpreted
 // as a partial set document definition.
 func ParsePartialSetDocRuleFromTerm(module *Module, term *Term) (*Rule, error) {
-
 	ref, ok := term.Value.(Ref)
 	if !ok || len(ref) == 1 {
 		return nil, fmt.Errorf("%vs cannot be used for rule head", ValueName(term.Value))
 	}
 	if _, ok := ref[0].Value.(Var); !ok {
-		return nil, fmt.Errorf("invalid rule head: %v", ref)
+		return nil, fmt.Errorf("invalid rule head: %v", term.Value)
 	}
 
 	head := RefHead(ref)
@@ -388,7 +387,6 @@ func ParsePartialSetDocRuleFromTerm(module *Module, term *Term) (*Rule, error) {
 // ParseRuleFromCallEqExpr returns a rule if the term can be interpreted as a
 // function definition (e.g., f(x) = y => f(x) = y { true }).
 func ParseRuleFromCallEqExpr(module *Module, lhs, rhs *Term) (*Rule, error) {
-
 	call, ok := lhs.Value.(Call)
 	if !ok {
 		return nil, errors.New("must be call")
@@ -399,7 +397,7 @@ func ParseRuleFromCallEqExpr(module *Module, lhs, rhs *Term) (*Rule, error) {
 		return nil, fmt.Errorf("%vs cannot be used in function signature", ValueName(call[0].Value))
 	}
 	if _, ok := ref[0].Value.(Var); !ok {
-		return nil, fmt.Errorf("invalid rule head: %v", ref)
+		return nil, fmt.Errorf("invalid rule head: %v", call[0].Value)
 	}
 
 	head := RefHead(ref, rhs)
@@ -421,7 +419,6 @@ func ParseRuleFromCallEqExpr(module *Module, lhs, rhs *Term) (*Rule, error) {
 // ParseRuleFromCallExpr returns a rule if the terms can be interpreted as a
 // function returning true or some value (e.g., f(x) => f(x) = true { true }).
 func ParseRuleFromCallExpr(module *Module, terms []*Term) (*Rule, error) {
-
 	if len(terms) <= 1 {
 		return nil, errors.New("rule argument list must take at least one argument")
 	}
@@ -429,7 +426,7 @@ func ParseRuleFromCallExpr(module *Module, terms []*Term) (*Rule, error) {
 	loc := terms[0].Location
 	ref := terms[0].Value.(Ref)
 	if _, ok := ref[0].Value.(Var); !ok {
-		return nil, fmt.Errorf("invalid rule head: %v", ref)
+		return nil, fmt.Errorf("invalid rule head: %v", terms[0].Value)
 	}
 	head := RefHead(ref, BooleanTerm(true).SetLocation(loc))
 	head.Location = loc

--- a/v1/ast/performance.go
+++ b/v1/ast/performance.go
@@ -62,10 +62,11 @@ func BuiltinNameFromRef(ref Ref) (string, bool) {
 
 	totalLen := len(varName)
 	for _, term := range ref[1:] {
-		if _, ok = term.Value.(String); !ok {
+		tvs, ok := term.Value.(String)
+		if !ok {
 			return "", false
 		}
-		totalLen += 1 + len(term.Value.(String)) // account for dot
+		totalLen += 1 + len(tvs) // account for dot
 	}
 
 	matched, ok := builtinNamesByShape()[builtinNameShape(reflen, totalLen)]
@@ -99,12 +100,16 @@ func BuiltinNameFromRef(ref Ref) (string, bool) {
 }
 
 func AppendDelimeted[T encoding.TextAppender](buf []byte, appenders []T, delim string) ([]byte, error) {
-	for i, item := range appenders {
-		if i > 0 {
-			buf = append(buf, delim...)
-		}
-		var err error
-		if buf, err = item.AppendText(buf); err != nil {
+	if len(appenders) == 0 {
+		return buf, nil
+	}
+	var err error
+	if buf, err = appenders[0].AppendText(buf); err != nil {
+		return nil, err
+	}
+
+	for _, item := range appenders[1:] {
+		if buf, err = item.AppendText(append(buf, delim...)); err != nil {
 			return nil, err
 		}
 	}

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -345,7 +345,7 @@ func (mod *Module) Compare(other *Module) int {
 	if cmp := slices.CompareFunc(mod.Annotations, other.Annotations, (*Annotations).Compare); cmp != 0 {
 		return cmp
 	}
-	return rulesCompare(mod.Rules, other.Rules)
+	return slices.CompareFunc(mod.Rules, other.Rules, (*Rule).Compare)
 }
 
 // Copy returns a deep copy of mod.
@@ -466,7 +466,7 @@ func (c *Comment) Equal(other *Comment) bool {
 // Compare returns an integer indicating whether pkg is less than, equal to,
 // or greater than other.
 func (pkg *Package) Compare(other *Package) int {
-	return termSliceCompare(pkg.Path, other.Path)
+	return slices.CompareFunc(pkg.Path, other.Path, TermValueCompare)
 }
 
 // Copy returns a deep copy of pkg.
@@ -823,10 +823,10 @@ func (head *Head) Compare(other *Head) int {
 	} else if !head.Assign && other.Assign {
 		return 1
 	}
-	if cmp := termSliceCompare(head.Args, other.Args); cmp != 0 {
+	if cmp := slices.CompareFunc(head.Args, other.Args, TermValueCompare); cmp != 0 {
 		return cmp
 	}
-	if cmp := termSliceCompare(head.Reference, other.Reference); cmp != 0 {
+	if cmp := slices.CompareFunc(head.Reference, other.Reference, TermValueCompare); cmp != 0 {
 		return cmp
 	}
 	if cmp := VarCompare(head.Name, other.Name); cmp != 0 {
@@ -1115,7 +1115,7 @@ func (expr *Expr) Compare(other *Expr) int {
 			return cmp
 		}
 	case []*Term:
-		if cmp := termSliceCompare(t, other.Terms.([]*Term)); cmp != 0 {
+		if cmp := slices.CompareFunc(t, other.Terms.([]*Term), TermValueCompare); cmp != 0 {
 			return cmp
 		}
 	case *SomeDecl:
@@ -1140,7 +1140,7 @@ func (expr *Expr) Compare(other *Expr) int {
 		}
 	}
 
-	return withSliceCompare(expr.With, other.With)
+	return slices.CompareFunc(expr.With, other.With, (*With).Compare)
 }
 
 func (expr *Expr) sortOrder() int {
@@ -1471,7 +1471,7 @@ func (d *SomeDecl) Copy() *SomeDecl {
 // Compare returns an integer indicating whether d is less than, equal to, or
 // greater than other.
 func (d *SomeDecl) Compare(other *SomeDecl) int {
-	return termSliceCompare(d.Symbols, other.Symbols)
+	return slices.CompareFunc(d.Symbols, other.Symbols, TermValueCompare)
 }
 
 // Hash returns a hash code of d.
@@ -1820,12 +1820,7 @@ func (rs *RuleSet) Add(rule *Rule) {
 
 // Contains returns true if rs contains rule.
 func (rs RuleSet) Contains(rule *Rule) bool {
-	for i := range rs {
-		if rs[i].Equal(rule) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(rs, rule.Equal)
 }
 
 // Diff returns a new RuleSet containing rules in rs that are not in other.

--- a/v1/ast/rego_v1.go
+++ b/v1/ast/rego_v1.go
@@ -23,9 +23,7 @@ func checkDuplicateImports(modules []*Module) (errors Errors) {
 	return
 }
 
-func checkRootDocumentOverrides(node any) Errors {
-	errors := Errors{}
-
+func checkRootDocumentOverrides(node any) (errors Errors) {
 	WalkRules(node, func(rule *Rule) bool {
 		name := rule.Head.Name
 		if len(rule.Head.Reference) > 0 {
@@ -74,7 +72,10 @@ func walkCalls(node any, f func(any) bool) {
 			}
 		case *Head:
 			// GenericVisitor doesn't walk the rule head ref
-			walkCalls(y.Reference, f)
+			// (Ref -> any escapes to heap, so walk terms instead)
+			for _, term := range y.Reference {
+				walkCalls(term, f)
+			}
 		}
 		return false
 	})

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -441,6 +441,12 @@ func TermValueIs[T Value](term *Term) (ok bool) {
 	return ok
 }
 
+// ToTerm exists solely to be able to map concrete Value
+// implementations to *Term in util.Map, util.MapKeys, etc.
+func ToTerm[T Value](v T) *Term {
+	return NewTerm(v)
+}
+
 // IsConstant returns true if the AST value is constant.
 // Note that this is only a shallow check as we currently don't have a real
 // notion of constant "vars" in the AST implementation. Meaning that while we could
@@ -1255,7 +1261,7 @@ func (ref Ref) Equal(other Value) bool {
 // or greater than other.
 func (ref Ref) Compare(other Value) int {
 	if o, ok := other.(Ref); ok {
-		return termSliceCompare(ref, o)
+		return slices.CompareFunc(ref, o, TermValueCompare)
 	}
 	return valueTypeCompare(ref, other)
 }
@@ -1515,7 +1521,7 @@ func (arr *Array) Equal(other Value) bool {
 // or greater than other.
 func (arr *Array) Compare(other Value) int {
 	if b, ok := other.(*Array); ok {
-		return termSliceCompare(arr.elems, b.elems)
+		return slices.CompareFunc(arr.elems, b.elems, TermValueCompare)
 	}
 
 	return valueTypeCompare(arr, other)
@@ -2197,12 +2203,7 @@ func (lob *lazyObj) Keys() []*Term {
 	if lob.strict != nil {
 		return lob.strict.Keys()
 	}
-	ret := make([]*Term, 0, len(lob.native))
-	for k := range lob.native {
-		ret = append(ret, InternedTerm(k))
-	}
-
-	return util.SortedFunc(ret, TermValueCompare)
+	return util.SortedFunc(util.MapKeys(lob.native, InternedTerm), TermValueCompare)
 }
 
 func (lob *lazyObj) KeysIterator() ObjectKeysIterator {
@@ -2986,7 +2987,7 @@ func (c Call) Copy() Call {
 // or greater than other.
 func (c Call) Compare(other Value) int {
 	if oc, ok := other.(Call); ok {
-		return termSliceCompare(c, oc)
+		return slices.CompareFunc(c, oc, TermValueCompare)
 	}
 	return valueTypeCompare(c, other)
 }

--- a/v1/ast/unify.go
+++ b/v1/ast/unify.go
@@ -226,7 +226,10 @@ func (u *unifier) unifyAll(a Var, b Value) {
 			SkipClosures:   true,
 		})
 		vis.Walk(b)
-		unsafe := vis.Vars().Diff(u.safe).Diff(u.unified)
+		unsafe := vis.Vars().
+			DeleteFunc(u.safe.Contains).
+			DeleteFunc(u.unified.Contains)
+
 		if len(unsafe) == 0 {
 			u.markSafe(a)
 		} else {

--- a/v1/ast/varset.go
+++ b/v1/ast/varset.go
@@ -120,6 +120,17 @@ func (s VarSet) Update(vs VarSet) {
 	}
 }
 
+// DeleteFunc removes all variables from the set for which the provided predicate f is true.
+// The delete operation is performed *in place* and the modified VarSet is returned for convenience.
+func (s VarSet) DeleteFunc(f func(Var) bool) VarSet {
+	for v := range s {
+		if f(v) {
+			delete(s, v)
+		}
+	}
+	return s
+}
+
 func (s VarSet) String() string {
 	return fmt.Sprintf("%v", util.KeysSorted(s))
 }

--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -328,15 +328,7 @@ func (wr *WasmResolver) Equal(other *WasmResolver) bool {
 type stringSet map[string]struct{}
 
 func (ss stringSet) Equal(other stringSet) bool {
-	if len(ss) != len(other) {
-		return false
-	}
-	for k := range other {
-		if _, ok := ss[k]; !ok {
-			return false
-		}
-	}
-	return true
+	return maps.Equal(ss, other)
 }
 
 func (m *Manifest) validateAndInjectDefaults(b Bundle) error {

--- a/v1/bundle/filefs.go
+++ b/v1/bundle/filefs.go
@@ -35,13 +35,11 @@ func NewFSLoader(filesystem fs.FS) (DirectoryLoader, error) {
 // NewFSLoaderWithRoot returns a basic DirectoryLoader implementation
 // that will load files from a fs.FS interface at the supplied root
 func NewFSLoaderWithRoot(filesystem fs.FS, root string) DirectoryLoader {
-	d := dirLoaderFS{
+	return &dirLoaderFS{
 		filesystem: filesystem,
 		root:       normalizeRootDirectory(root),
 		pathFormat: Chrooted,
 	}
-
-	return &d
 }
 
 func (d *dirLoaderFS) walkDir(path string, dirEntry fs.DirEntry, err error) error {
@@ -135,6 +133,5 @@ func (d *dirLoaderFS) NextFile() (*Descriptor, error) {
 	}
 
 	cleanedPath := formatPath(fileName, d.root, d.pathFormat)
-	f := NewDescriptor(cleanedPath, cleanedPath, fh).WithCloser(fh)
-	return f, nil
+	return NewDescriptor(cleanedPath, cleanedPath, fh).WithCloser(fh), nil
 }

--- a/v1/dependencies/deps.go
+++ b/v1/dependencies/deps.go
@@ -31,21 +31,15 @@ func All(x any) (resolved []ast.Ref, err error) {
 			return true
 		case ast.Body:
 			vars := ast.NewVarVisitor()
-			vars.Walk(x)
-
-			arr := ast.NewArray()
-			for v := range vars.Vars() {
-				if v.IsWildcard() {
-					continue
-				}
-				arr = arr.Append(ast.NewTerm(v))
-			}
-
+			vars.WalkBody(x)
 			// The analysis will discard variables that are not used in
 			// direct comparisons or in the output. Since lone Bodies are
 			// often queries, we want all the variables to be in the output.
 			r := &ast.Rule{
-				Head: &ast.Head{Name: ast.Var("_"), Value: ast.NewTerm(arr)},
+				Head: &ast.Head{
+					Name:  ast.Var("_"),
+					Value: ast.ArrayTerm(util.MapKeys(vars.Vars().DeleteFunc(ast.Var.IsWildcard), ast.ToTerm)...),
+				},
 				Body: x,
 			}
 			rawResolved = append(rawResolved, ruleDeps(r)...)
@@ -274,15 +268,18 @@ func ruleDeps(rule *ast.Rule) (resolved []ast.Ref) {
 
 	usedVars := varVisitor.Vars()
 
-	// Vars included in refs must be counted as used.
-	ast.WalkRefs(rule.Body, func(r ast.Ref) bool {
-		for i := 1; i < len(r); i++ {
-			if v, ok := r[i].Value.(ast.Var); ok {
-				usedVars.Add(v)
+	// Walk each expression to avoid Body -> any boxing (heap allocation).
+	for _, expr := range rule.Body {
+		// Vars included in refs must be counted as used.
+		ast.WalkRefs(expr, func(r ast.Ref) bool {
+			for _, t := range r[1:] {
+				if v, ok := t.Value.(ast.Var); ok {
+					usedVars.Add(v)
+				}
 			}
-		}
-		return false
-	})
+			return false
+		})
+	}
 
 	resolveRemainingVars(joined, visitor, usedVars, headVars)
 	return resolved

--- a/v1/topdown/copypropagation/copypropagation.go
+++ b/v1/topdown/copypropagation/copypropagation.go
@@ -175,7 +175,7 @@ func (p *CopyPropagator) Apply(query ast.Body) ast.Body {
 	safe.Update(ast.ReservedVars)
 	safe.Update(p.livevars)
 	safe.Update(ast.OutputVarsFromBody(p.compiler, result, safe))
-	unsafe := result.Vars(ast.SafetyCheckVisitorParamsWithArity(p.compiler.GetArity)).Diff(safe)
+	unsafe := result.Vars(ast.SafetyCheckVisitorParamsWithArity(p.compiler.GetArity)).DeleteFunc(safe.Contains)
 
 	for _, b := range sortbindings(removedEqs) {
 		removedEq := ast.Equality.Expr(ast.NewTerm(b.k), ast.NewTerm(b.v))

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -925,7 +925,6 @@ func (e *eval) evalNotPartial(expr *ast.Expr, unNegateFn unNegateFn, complementF
 }
 
 func (e *eval) evalNotPartialSupport(negationID uint64, expr *ast.Expr, supportTermsFn supportTermsFn, unknowns ast.VarSet, queries []ast.Body, iter evalIterator) error {
-
 	// Prepare support rule head.
 	supportName := fmt.Sprintf("__not%d_%d_%d__", e.queryID, e.index, negationID)
 	term := ast.RefTerm(ast.DefaultRootDocument, e.saveNamespace, ast.StringTerm(supportName))
@@ -938,27 +937,15 @@ func (e *eval) evalNotPartialSupport(negationID uint64, expr *ast.Expr, supportT
 		bodyVars.Update(q.Vars(ast.VarVisitorParams{}))
 	}
 
-	unknowns = unknowns.Intersect(bodyVars)
-
 	// Make rule args. Sort them to ensure order is deterministic.
-	args := make([]*ast.Term, 0, len(unknowns))
-
-	for v := range unknowns {
-		args = append(args, ast.NewTerm(v))
-	}
-
-	slices.SortFunc(args, ast.TermValueCompare)
-
+	args := util.SortedFunc(util.MapKeys(unknowns.Intersect(bodyVars), ast.ToTerm), ast.TermValueCompare)
 	if len(args) > 0 {
 		head.Args = args
 	}
 
 	// Save support rules.
 	for _, query := range queries {
-		e.saveSupport.Insert(path, &ast.Rule{
-			Head: head,
-			Body: query,
-		})
+		e.saveSupport.Insert(path, &ast.Rule{Head: head, Body: query})
 	}
 
 	// Save expression that refers to support rule set.
@@ -1369,13 +1356,11 @@ func (e *eval) biunifyRef(a, b *ast.Term, b1, b2 *bindings, iter unifyIterator) 
 }
 
 func (e *eval) biunifyComprehension(a, b *ast.Term, b1, b2 *bindings, swap bool, iter unifyIterator) error {
-
 	if e.unknown(a, b1) {
 		return e.biunifyComprehensionPartial(a, b, b1, b2, swap, iter)
 	}
 
 	value, err := e.buildComprehensionCache(a)
-
 	if err != nil {
 		return err
 	} else if value != nil {
@@ -3025,8 +3010,7 @@ func (h *evalVirtualPartialCacheHint) keyWithoutScope() ast.Ref {
 }
 
 func (e evalVirtualPartial) eval(iter unifyIterator) error {
-	unknown := e.e.unknown(e.ref[:e.pos+1], e.bindings)
-
+	unknown := e.e.unknownRef(e.ref[:e.pos+1], e.bindings)
 	if len(e.ref) == e.pos+1 {
 		if unknown {
 			return e.partialEvalSupport(iter)
@@ -3065,7 +3049,7 @@ func (e evalVirtualPartial) evalEachRule(iter unifyIterator, unknown bool) error
 
 	if e.e.partial() {
 		m := maxRefLength(e.ir.Rules, len(e.ref))
-		if e.e.unknown(e.ref[e.pos+1:m], e.bindings) {
+		if e.e.unknownRef(e.ref[e.pos+1:m], e.bindings) {
 			for _, rule := range e.ir.Rules {
 				if err := e.evalOneRulePostUnify(iter, rule); err != nil {
 					return err
@@ -3431,11 +3415,8 @@ func (e evalVirtualPartial) evalTerm(iter unifyIterator, pos int, term *ast.Term
 	return eval.eval(iter)
 }
 
-func (e evalVirtualPartial) evalCache(iter unifyIterator) (evalVirtualPartialCacheHint, error) {
-
-	var hint evalVirtualPartialCacheHint
-
-	if e.e.unknown(e.ref[:e.pos+1], e.bindings) {
+func (e evalVirtualPartial) evalCache(iter unifyIterator) (hint evalVirtualPartialCacheHint, err error) {
+	if e.e.unknownRef(e.ref[:e.pos+1], e.bindings) {
 		// FIXME: Return empty hint if unknowns in any e.ref elem overlapping with applicable rule refs?
 		return hint, nil
 	}

--- a/v1/util/maps.go
+++ b/v1/util/maps.go
@@ -18,6 +18,15 @@ func KeysSorted[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
 	return Sorted(Keys(m))
 }
 
+// MapKeys returns a slice of keys from m, transformed by f.
+func MapKeys[M ~map[K]V, K comparable, V, R any](m M, f func(K) R) []R {
+	r := make([]R, 0, len(m))
+	for k := range m {
+		r = append(r, f(k))
+	}
+	return r
+}
+
 // Values returns a slice of values from any map. Copied from golang.org/x/exp/maps.
 func Values[M ~map[K]V, K comparable, V any](m M) []V {
 	r := make([]V, 0, len(m))


### PR DESCRIPTION
And allocation Pokémons caught. Gotta catch 'em all!

- Add `VarSet.DeleteFunc` which largerly replaces the `VarSet.Diff` function, just diffing in place rather than by creating a new `VarSet` — one which we almost never used more than temporarily
- Use `unknownRef` in eval over `unknown` where possible as `Ref` -> `any` boxing always allocates
- Get rid of a few more custom comparison functions in favor of those in the stdlib..
- ..and some more code replaced with stdlib/our helpers to reduce lines of code and help with readability
- Fixed a few random heap allocations
