### PR TITLE
util: don't return a nil slice from StringToByteSlice("")

### DIFF
--- a/v1/test/cases/testdata/v0/strings/test-anyprefixmatch.yaml
+++ b/v1/test/cases/testdata/v0/strings/test-anyprefixmatch.yaml
@@ -339,3 +339,58 @@ cases:
     query: data.test.p = x
     strict_error: true
     want_error: "test-0.rego:4: eval_type_error: strings.any_prefix_match: operand 2 must be one of {string, set, array} but got number"
+  - input:
+      strings: ["a/b/c", "", "e/f/g"]
+      prefixes: ["z/"]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    note: strings/any_prefix_match/empty_string_in_strings_nomatch
+    query: data.test.p = x
+    want_result: []
+  - input:
+      strings: ["a/b/c", "", "e/f/g"]
+      prefixes: ["z/", "e/f"]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    note: strings/any_prefix_match/empty_string_in_strings_match
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - input:
+      strings: ["a/b/c", "a/b/d", "e/f/g"]
+      prefixes: ["z/", ""]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    note: strings/any_prefix_match/empty_prefix_match
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - input:
+      strings: ["", "a/b/c"]
+      prefixes: ["z/", ""]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    note: strings/any_prefix_match/empty_string_and_empty_prefix_match
+    query: data.test.p = x
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v0/strings/test-anysuffixmatch.yaml
+++ b/v1/test/cases/testdata/v0/strings/test-anysuffixmatch.yaml
@@ -339,3 +339,58 @@ cases:
     query: data.test.p = x
     strict_error: true
     want_error: "test-0.rego:4: eval_type_error: strings.any_suffix_match: operand 2 must be one of {string, set, array} but got number"
+  - input:
+      strings: ["a/b/c", "", "e/f/g"]
+      suffixes: ["/z"]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    note: strings/any_suffix_match/empty_string_in_strings_nomatch
+    query: data.test.p = x
+    want_result: []
+  - input:
+      strings: ["a/b/c", "", "e/f/g"]
+      suffixes: ["/z", "f/g"]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    note: strings/any_suffix_match/empty_string_in_strings_match
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - input:
+      strings: ["a/b/c", "a/b/d", "e/f/g"]
+      suffixes: ["/z", ""]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    note: strings/any_suffix_match/empty_suffix_match
+    query: data.test.p = x
+    want_result:
+      - x: true
+  - input:
+      strings: ["", "a/b/c"]
+      suffixes: ["/z", ""]
+    modules:
+      - |
+        package test
+
+        p {
+          strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    note: strings/any_suffix_match/empty_string_and_empty_suffix_match
+    query: data.test.p = x
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/strings/test-anyprefixmatch.yaml
+++ b/v1/test/cases/testdata/v1/strings/test-anyprefixmatch.yaml
@@ -428,3 +428,76 @@ cases:
         - e/f/g
     want_error: "test-0.rego:4: eval_type_error: strings.any_prefix_match: operand 2 must be one of {string, set, array} but got number"
     strict_error: true
+  - note: strings/any_prefix_match/empty_string_in_strings_nomatch
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    input:
+      prefixes:
+        - z/
+      strings:
+        - a/b/c
+        - ""
+        - e/f/g
+    want_result: []
+  - note: strings/any_prefix_match/empty_string_in_strings_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    input:
+      prefixes:
+        - z/
+        - e/f
+      strings:
+        - a/b/c
+        - ""
+        - e/f/g
+    want_result:
+      - x: true
+  - note: strings/any_prefix_match/empty_prefix_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    input:
+      prefixes:
+        - z/
+        - ""
+      strings:
+        - a/b/c
+        - a/b/d
+        - e/f/g
+    want_result:
+      - x: true
+  - note: strings/any_prefix_match/empty_string_and_empty_prefix_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_prefix_match(input.strings, input.prefixes)
+        }
+    input:
+      prefixes:
+        - z/
+        - ""
+      strings:
+        - ""
+        - a/b/c
+    want_result:
+      - x: true

--- a/v1/test/cases/testdata/v1/strings/test-anysuffixmatch.yaml
+++ b/v1/test/cases/testdata/v1/strings/test-anysuffixmatch.yaml
@@ -428,3 +428,76 @@ cases:
         - e/f/g
     want_error: "test-0.rego:4: eval_type_error: strings.any_suffix_match: operand 2 must be one of {string, set, array} but got number"
     strict_error: true
+  - note: strings/any_suffix_match/empty_string_in_strings_nomatch
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    input:
+      suffixes:
+        - /z
+      strings:
+        - a/b/c
+        - ""
+        - e/f/g
+    want_result: []
+  - note: strings/any_suffix_match/empty_string_in_strings_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    input:
+      suffixes:
+        - /z
+        - f/g
+      strings:
+        - a/b/c
+        - ""
+        - e/f/g
+    want_result:
+      - x: true
+  - note: strings/any_suffix_match/empty_suffix_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    input:
+      suffixes:
+        - /z
+        - ""
+      strings:
+        - a/b/c
+        - a/b/d
+        - e/f/g
+    want_result:
+      - x: true
+  - note: strings/any_suffix_match/empty_string_and_empty_suffix_match
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p if {
+        	strings.any_suffix_match(input.strings, input.suffixes)
+        }
+    input:
+      suffixes:
+        - /z
+        - ""
+      strings:
+        - ""
+        - a/b/c
+    want_result:
+      - x: true

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -107,6 +107,10 @@ func anyStartsWithAny(strs []string, prefixes []string) bool {
 		return strings.HasPrefix(strs[0], prefixes[0])
 	}
 
+	// The trie is local, and only ever inserted into and searched, so it's safe
+	// to hand it byte slices aliasing the operand strings' memory. Note that
+	// patricia's compact() writes through the key slices it retains, so Delete
+	// and DeleteSubtree must not be used here: they'd corrupt those strings.
 	trie := patricia.NewTrie()
 	for i := range strs {
 		trie.Insert(util.StringToByteSlice(strs[i]), trueAny)

--- a/v1/util/performance.go
+++ b/v1/util/performance.go
@@ -105,8 +105,15 @@ func ByteSliceToString(bs []byte) string {
 }
 
 // Allocation free conversion from ~string to []byte (unsafe)
-// Note that the byte slice must not be modified after conversion
+// Note that the byte slice must not be modified after conversion, and that it
+// aliases the string's memory: it is a view of s, not a copy like []byte(s).
 func StringToByteSlice[T ~string](s T) []byte {
+	if len(s) == 0 {
+		// unsafe.StringData's return value is unspecified for the empty string,
+		// so don't build a slice on top of it. Doing so currently yields a nil
+		// slice, which callers may treat differently from an empty one.
+		return []byte{}
+	}
 	return unsafe.Slice(unsafe.StringData(string(s)), len(s))
 }
 

--- a/v1/util/performance_test.go
+++ b/v1/util/performance_test.go
@@ -185,3 +185,17 @@ func mustAtoi(s string) int {
 	v, _ := Atoi(s)
 	return v
 }
+
+func TestStringToByteSlice(t *testing.T) {
+	for _, s := range []string{"", "a", "foo/bar"} {
+		bs := StringToByteSlice(s)
+
+		// must be equivalent to []byte(s), including being non-nil for ""
+		if bs == nil {
+			t.Errorf("StringToByteSlice(%q): expected non-nil slice", s)
+		}
+		if string(bs) != s {
+			t.Errorf("StringToByteSlice(%q): got %q", s, string(bs))
+		}
+	}
+}


### PR DESCRIPTION
unsafe.StringData's return value is unspecified for the empty string, so building a slice on top of it yielded a nil slice rather than an empty one. Since #9082 anyStartsWithAny feeds the result to a patricia trie, which panics on nil keys, so strings.any_prefix_match and strings.any_suffix_match crashed on any input containing an empty string (unless both operands were single strings, which short-circuits). Regal hit this via 'not strings.any_prefix_match(input.regal.file.lines, ...)', as good as every document has a blank line.

Also record why aliasing the operand strings is safe in anyStartsWithAny: patricia's compact() writes through the keys it retains, so the trie must not be Deleted from.
