### PR TITLE
compile: validate plan-addons exist

### DIFF
--- a/v1/compile/compile.go
+++ b/v1/compile/compile.go
@@ -60,6 +60,13 @@ const (
 // PlanFormats contains the list of plan output formats supported by the compiler.
 var PlanFormats = []string{PlanFormatJSON, PlanFormatProto}
 
+// PlanAddonUnplannedRules is a plan addon that also includes a list of locations for
+// unplanned rules for coverage reporting.
+const PlanAddonUnplannedRules = "unplanned_rules"
+
+// PlanAddons contains the list of plan addons supported by the compiler.
+var PlanAddons = []string{PlanAddonUnplannedRules}
+
 // Targets contains the list of targets supported by the compiler.
 var Targets = []string{
 	TargetRego,
@@ -346,6 +353,15 @@ func (c *Compiler) Build(ctx context.Context) error {
 	}
 	if c.planFormat != PlanFormatJSON && c.target != TargetPlan {
 		return fmt.Errorf("plan format %q is only valid with target %q", c.planFormat, TargetPlan)
+	}
+
+	for _, addon := range c.planAddons {
+		if !slices.Contains(PlanAddons, addon) {
+			return fmt.Errorf("unsupported plan addon %q (want one of %v)", addon, PlanAddons)
+		}
+	}
+	if len(c.planAddons) > 0 && c.target != TargetPlan {
+		return fmt.Errorf("plan addons are only valid with target %q", TargetPlan)
 	}
 
 	if err := c.init(); err != nil {
@@ -720,7 +736,7 @@ func (c *Compiler) compilePlan(context.Context) error {
 		WithModules(modules).
 		WithBuiltinDecls(builtins).
 		WithDebug(c.debug.Writer()).
-		WithUnplannedRules(slices.Contains(c.planAddons, "unplanned_rules"))
+		WithUnplannedRules(slices.Contains(c.planAddons, PlanAddonUnplannedRules))
 	policy, err := p.Plan()
 	if err != nil {
 		return err


### PR DESCRIPTION
Failing silently caught me out this morning, so better to avoid having the issue where you write unplaned_rules or other typos.
