### PR TITLE
github: Drop python from the CodeQL language matrix

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript', 'python' ]
+        language: [ 'go', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed


### PR DESCRIPTION
CodeQL has been failing on every push to main since a3953de6a3 ("build/release: Create new release tool (#8959)"), which replaced build/changelog.py with a Go release tool and left no Python source in the repository. The python matrix job now dies during database finalization:

```
    CodeQL detected code written in GitHub Actions, Go, C/C++ and
    JavaScript/TypeScript, but not any written in Python. Confirm that
    there is some source code for Python in the project.

    Error: Encountered a fatal error while running "codeql database
    finalize --finalize-dataset [...] /codeql_databases/python".
    Exit code was 32
```

Because the extractor finds nothing to build a database from, this is a hard error rather than an empty result, so the job cannot pass while the language stays in the matrix. Drop python; go and javascript continue to cover the whole remaining surface.