### PR TITLE
ast: fix panic comparing a decimal zero with a non-integral number

### DIFF
--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -354,18 +354,23 @@ func NumberCompare(x, y Number) int {
 	var xf, yf float64
 	var xIsF, yIsF bool
 
-	// Treat "1" and "1.0", "1.00", etc as "1"
+	// Treat "1" and "1.0", "1.00", etc as "1" for the purpose of deciding
+	// whether each side is a non-integral value.
+	//
+	// The trimmed forms must not be assigned back over xs and ys. TrimRight
+	// takes a cutset rather than a suffix, so ".0" strips every trailing '.'
+	// and '0' character: "0.0" trims to the empty string and "-0.0" to "-".
+	// Those are then handed to big.Float.SetString below, which fails, and the
+	// failure path is a panic.
 	if strings.IndexByte(xs, '.') != -1 {
 		if tx := strings.TrimRight(xs, ".0"); tx != xs {
 			// Still a float after trimming?
 			xIsF = strings.IndexByte(tx, '.') != -1
-			xs = tx
 		}
 	}
 	if strings.IndexByte(ys, '.') != -1 {
 		if ty := strings.TrimRight(ys, ".0"); ty != ys {
 			yIsF = strings.IndexByte(ty, '.') != -1
-			ys = ty
 		}
 	}
 

--- a/v1/ast/compare_test.go
+++ b/v1/ast/compare_test.go
@@ -38,6 +38,21 @@ func TestCompare(t *testing.T) {
 		{"1.10", "1.11", -1},
 		{"0", "1.5", -1},
 		{"1.5", "0", 1},
+
+		// A zero written with a decimal point, compared against a non-integral
+		// value. These panicked with "illegal value": the float detection above
+		// trims with a cutset rather than a suffix, so "0.0" becomes "" and
+		// "-0.0" becomes "-", and the trimmed form was then handed to
+		// big.Float.SetString.
+		{"0.0", "0.7", -1},
+		{"0.7", "0.0", 1},
+		{"0.0", "-0.7", 1},
+		{"-0.7", "0.0", -1},
+		{"0.00", "1.5", -1},
+		{"-0.0", "0.5", -1},
+		{"0.0e0", "0.5", -1},
+		{"0.0", "0.0", 0},
+		{"0.0", "-0.0", 0},
 		{"100000", "100", 1},
 		{"123456789123456789123", "123456789123456789123", 0},
 		{"123456789123456789123", "123456789123456789122", 1},


### PR DESCRIPTION
Fixes #9098.

## The bug

`0.0 >= 0.7` panics with `illegal value` on v1.20.0:

```rego
package repro

g if 0.0 >= 0.7
```

```console
$ opa eval -d repro.rego 'data.repro.g'
panic: illegal value
```

So does any comparison where one side is a zero written with a decimal point —
`0.0`, `0.00`, `-0.0`, `0.0e0` — and the other is non-integral. Either operand
order, and any operator including `==`.

## Cause

`NumberCompare` decides whether each side is non-integral by trimming trailing
zeros:

```go
if tx := strings.TrimRight(xs, ".0"); tx != xs {
	xIsF = strings.IndexByte(tx, '.') != -1
	xs = tx
}
```

`strings.TrimRight` takes a **cutset, not a suffix**, so `".0"` strips every
trailing `'.'` and `'0'`:

| input | result |
| --- | --- |
| `"1.0"` | `"1"` — intended |
| `"0.70"` | `"0.7"` — fine |
| `"0.0"` | `""` |
| `"-0.0"` | `"-"` |
| `"0.0e0"` | `"0.0e"` |

The trimmed value is assigned back over `xs`, and `xs` is what reaches:

```go
fa, ok := new(big.Float).SetString(xs)
if !ok {
	panic("illegal value")
}
```

**Why it is new in v1.20.0.** The cutset is in v1.19.1 too, so the latent flaw is
older. What changed is the operand at the four `big.Float`/`big.Rat` parse sites:

```diff
-	fa, ok := new(big.Float).SetString(string(x))
+	fa, ok := new(big.Float).SetString(xs)
```

v1.19.1 parsed the original text, so the corrupted trim only ever affected the
`xIsF`/`yIsF` flags.

**Why the other side has to be non-integral.** When both sides are integral,
`util.Atoi64` succeeds on the untrimmed strings and the function returns from the
`cmp.Compare(xi, yi)` fast path before reaching the trim. `0.0` vs `1.0` is
therefore fine; `0.0` vs `0.7` is not.

## The fix

Drop the two assignments. The trim exists only to set `xIsF`/`yIsF`, and the parse
sites want the original text — which is what v1.19.1 passed them. All four now
receive `string(x)`/`string(y)` again, as they did before v1.20.0.

I also considered fixing the trimming itself — `TrimRight(xs, "0")` then removing
a single trailing `'.'` keeps a normalised form and never empties the string.
Happy to switch if you prefer that; I went with the smaller change because it
restores behaviour that shipped correctly for many releases rather than
introducing new normalisation.

## Verification

- Every ordered pair from `0.0 0.1 0.5 0.7 0.9 1.0 2.0 0 1 -0.0 -1.5 3.14`
  compared with `>=` — **144 comparisons** — now matches v1.19.1 **exactly**, and
  goes from **24 panics to 0**.
- `go test -count=1 ./v1/ast/ ./v1/topdown/ ./v1/rego/` passes; `go vet ./v1/ast/`
  clean; `gofmt` clean.
- Nine cases added to `TestCompare`, covering both operand orders, `0.00`, `-0.0`,
  `0.0e0`, negative right-hand sides, and `0.0` vs `-0.0`. They **panic without
  this change** and pass with it.

## Why it may be worth a patch release

`net/http` recovers the panic per connection, so the server survives — but the
caller gets no response at all:

```
2026/08/28 07:07:14 http: panic serving 127.0.0.1:60716: illegal value
```

```console
$ curl -sv -X POST localhost:8181/v1/data/srv/deny -d '{"input":{"threshold":0.7}}'
* Empty reply from server
$ curl -s -o /dev/null -w '%{http_code}' localhost:8181/health
200
```

So a policy decision silently stops being returned while `/health` stays green,
and `opa check` passes. Using `0.0` as a numeric fallback and comparing it to a
threshold is a common shape — it is how we hit this, across a 98-policy library
where `opa test` began aborting with exit code 2 rather than failing any test.