### PR TITLE
ast: Mark JSON schema builtins nondeterministic

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -2404,7 +2404,8 @@
           "type": "array"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "json.patch",
@@ -2575,7 +2576,8 @@
           "type": "array"
         },
         "type": "function"
-      }
+      },
+      "nondeterministic": true
     },
     {
       "name": "lower",

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -3126,6 +3126,8 @@ var JSONSchemaVerify = &Builtin{
 			Description("`output` is of the form `[valid, error]`. If the schema is valid, then `valid` is `true`, and `error` is `null`. Otherwise, `valid` is `false` and `error` is a string describing the error."),
 	),
 	Categories: objectCat,
+	// `$ref`s are dereferenced at evaluation time, so the result depends on what those URLs serve.
+	Nondeterministic: true,
 	// Needs the BuiltinContext to read the allow_net capability, which
 	// restricts the hosts that remote `$ref`s may be fetched from.
 	CanSkipBctx: false,
@@ -3159,8 +3161,10 @@ var JSONMatchSchema = &Builtin{
 		}, nil)).
 			Description("`output` is of the form `[match, errors]`. If the document is valid given the schema, then `match` is `true`, and `errors` is an empty array. Otherwise, `match` is `false` and `errors` is an array of objects describing the error(s)."),
 	),
-	Categories:  objectCat,
-	CanSkipBctx: false,
+	Categories: objectCat,
+	// `$ref`s are dereferenced at evaluation time, so the result depends on what those URLs serve.
+	Nondeterministic: true,
+	CanSkipBctx:      false,
 }
 
 /**

--- a/v1/topdown/topdown_partial_test.go
+++ b/v1/topdown/topdown_partial_test.go
@@ -3470,6 +3470,21 @@ func TestTopDownPartialEval(t *testing.T) {
 			},
 			wantQueries: []string{""}, // unconditional true
 		},
+		{
+			// $ref is dereferenced at evaluation time, so folding this during PE
+			// would bake a remote answer into the residual. The URL is the local
+			// test server so a regression fails here instead of hitting the network.
+			note:     "nondeterministic builtin json.match_schema saved during PE",
+			query:    "data.test.p",
+			unknowns: []string{"input.x"},
+			modules: []string{fmt.Sprintf(`package test
+			p if {
+				input.x == 1
+				json.match_schema({"user": "jsmith"}, {"$ref": "%s"})
+			}`, testserver.URL),
+			},
+			wantQueries: []string{fmt.Sprintf(`input.x = 1; json.match_schema({"user": "jsmith"}, {"$ref": "%s"})`, testserver.URL)},
+		},
 
 		{
 			note:  "default function, result not collected (non-false default value)",


### PR DESCRIPTION
### Why the changes in this PR are needed?

`json.match_schema` and `json.verify_schema` dereference `$ref` at evaluation time, including remote and `file://` URLs, so their results depend on what those locations serve. Neither is declared `Nondeterministic`.

Reported in #8998, where the reporter walks the builtin list and disallows nondeterministic builtins when running sandboxed code. These two pass that filter silently.

There is also a concrete consequence in partial evaluation. `ignoreDuringPartial()` keys off the same flag, so partial eval folds these calls when their arguments are known, fetching over the network at partial-eval time and baking the answer into the residual policy. A residual built today can encode whatever a remote server happened to serve at build time.

### What are the changes in this PR?

`Nondeterministic: true` on both builtins in `v1/ast/builtins.go`, and `capabilities.json` regenerated with `./build/gen-run-go.sh`. The regenerated file changes exactly those two entries.

A partial evaluation case in `v1/topdown/topdown_partial_test.go` asserts the call is left in the residual. It fails without the flags, where the residual collapses to `input.x = 1` because the call was folded away.

`CanSkipBctx` is unchanged: both builtins need the `BuiltinContext` to read the `allow_net` capability.

### Notes to assist PR review:

Measured on this branch against `main`, same query, with a local HTTP server counting requests:

| | requests | residual |
| --- | --- | --- |
| `main` | 1 | `input.unrelated = "x"`, the schema call folded away |
| this branch | 0 | the `json.match_schema` call retained |

One correction to the issue: `allow_net` is not bypassed. Running the same policy with `allow_net: []` makes zero requests, so remote `$ref` fetching is already gated. Worth stating so this is not read as an unbounded SSRF.

The test's `$ref` points at the file's existing local test server rather than a public URL, so if the flags are ever removed the resulting fetch stays on loopback instead of leaving CI.

Worth weighing before merge: this changes partial-eval residuals for anyone using these builtins, since calls that were folded are now retained. That is the intended fix, but it is a behaviour change beyond the capabilities metadata.

`capabilities/v1.20.0.json` already shipped with the old values and is left untouched, so this lands in v1.21.0.

### Further comments:

Fixes #8998. The reporter confirmed on the issue that marking them plus updating capabilities covers his case, and noted he does not use partial eval directly, so the partial-eval half has not had a maintainer's view yet.

That is the open question I would most like input on: is marking both builtins the change you want, or would you rather treat the partial-eval folding separately?
