### PR TITLE
fix: `runner.CapturePrintOutput` setting never read

### DIFF
--- a/v1/plugins/logs/eventBuffer.go
+++ b/v1/plugins/logs/eventBuffer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/plugins"
 	"github.com/open-policy-agent/opa/v1/plugins/rest"
-	"github.com/open-policy-agent/opa/v1/util"
+	"github.com/open-policy-agent/opa/v1/util/channel"
 	"golang.org/x/time/rate"
 )
 
@@ -167,7 +167,7 @@ func (b *eventBuffer) push(event *bufferItem) {
 		return
 	}
 
-	util.PushFIFO(b.buffer, event, b.metrics, logBufferEventDropCounterName)
+	channel.PushFIFO(b.buffer, event, b.metrics, logBufferEventDropCounterName)
 }
 
 func (b *eventBuffer) processBufferItem(item *bufferItem) [][]byte {

--- a/v1/plugins/status/plugin.go
+++ b/v1/plugins/status/plugin.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 
 	lstat "github.com/open-policy-agent/opa/v1/plugins/logs/status"
+	"github.com/open-policy-agent/opa/v1/util/channel"
 
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/metrics"
@@ -296,12 +297,12 @@ func (p *Plugin) flush(ctx context.Context) {
 //
 // Deprecated: Use BulkUpdateBundleStatus instead.
 func (p *Plugin) UpdateBundleStatus(status bundle.Status) {
-	util.PushFIFO(p.bundleCh, status, p.metrics, statusBufferDropCounterName)
+	channel.PushFIFO(p.bundleCh, status, p.metrics, statusBufferDropCounterName)
 }
 
 // BulkUpdateBundleStatus notifies the plugin that the policy bundle was updated.
 func (p *Plugin) BulkUpdateBundleStatus(status map[string]*bundle.Status) {
-	util.PushFIFO(p.bulkBundleCh, status, p.metrics, statusBufferDropCounterName)
+	channel.PushFIFO(p.bulkBundleCh, status, p.metrics, statusBufferDropCounterName)
 }
 
 // UpdateDiscoveryStatus notifies the plugin that the discovery bundle was updated.

--- a/v1/tester/reporter.go
+++ b/v1/tester/reporter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/cover"
 	"github.com/open-policy-agent/opa/v1/topdown"
+	"github.com/open-policy-agent/opa/v1/util/channel"
 )
 
 // Reporter defines the interface for reporting test results.
@@ -46,7 +47,6 @@ func (r PrettyReporter) println(a ...any) {
 // printed immediately, and the FAILURES detail section and summary are
 // printed after all results have been received.
 func (r PrettyReporter) Report(ch chan *Result) error {
-
 	dirty := false
 	var pass, fail, skip, errs int
 	var failures []*Result
@@ -267,23 +267,15 @@ type JSONReporter struct {
 
 // Report prints the test report to the reporter's output.
 func (r JSONReporter) Report(ch chan *Result) error {
-	report := make([]*Result, 0, len(ch))
-	for tr := range ch {
-		report = append(report, tr)
-	}
-
-	switch r.Sort {
-	case formats.SortDuration:
-		slices.SortFunc(report, func(i, j *Result) int {
-			return cmp.Compare(j.Duration, i.Duration)
-		})
+	report := channel.Collect(ch)
+	if r.Sort == formats.SortDuration {
+		slices.SortFunc(report, byDuration)
 	}
 
 	bs, err := json.MarshalIndent(report, "", "  ")
-	if err != nil {
-		return err
+	if err == nil {
+		_, err = r.Output.Write(append(bs, '\n'))
 	}
-	_, err = fmt.Fprintln(r.Output, string(bs))
 	return err
 }
 
@@ -385,4 +377,8 @@ func (w indentingWriter) Write(bs []byte) (int, error) {
 		indent = b == '\n'
 	}
 	return written, nil
+}
+
+func byDuration(a, b *Result) int {
+	return cmp.Compare(b.Duration, a.Duration)
 }

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -34,6 +34,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 	"github.com/open-policy-agent/opa/v1/util"
+	"github.com/open-policy-agent/opa/v1/util/channel"
 )
 
 // TestPrefix declares the prefix for all test rules.
@@ -58,11 +59,7 @@ func RunWithFilter(ctx context.Context, _ loader.Filter, paths ...string) ([]*Re
 	if err != nil {
 		return nil, err
 	}
-	result := []*Result{}
-	for r := range ch {
-		result = append(result, r)
-	}
-	return result, nil
+	return channel.Collect(ch), nil
 }
 
 type SubResult struct {
@@ -75,9 +72,10 @@ type SubResult struct {
 type SubResultMap map[string]*SubResult
 
 func (srm SubResultMap) Update(path ast.Array, trace []*topdown.Event) bool {
+	buf := new(bytes.Buffer)
 	strPath := make([]string, path.Len())
 	for i := range path.Len() {
-		strPath[i] = termToString(path.Elem(i))
+		strPath[i] = termToString(buf, path.Elem(i))
 	}
 	return srm.update(strPath, 0, trace)
 }
@@ -104,7 +102,6 @@ func (srm SubResultMap) update(path []string, i int, trace []*topdown.Event) boo
 	}
 
 	fail := entry.SubResults.update(path, i+1, trace)
-
 	if fail {
 		entry.Fail = true
 	}
@@ -132,22 +129,17 @@ func (pm prefixMatchers) AnyPrefixMatcher(prefix ast.Ref) bool {
 	})
 }
 
-func termToString(t *ast.Term) string {
-	ti, err := ast.ValueToInterface(t.Value, unknownResolver{})
-	if err != nil {
-		return "INVALID"
-	}
-	var str string
-	var ok bool
-	if str, ok = ti.(string); !ok {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(ti); err != nil {
-			return "INVALID"
+func termToString(buf *bytes.Buffer, t *ast.Term) string {
+	if ti, err := ast.ValueToInterface(t.Value, unknownResolver{}); err == nil {
+		if str, ok := ti.(string); ok {
+			return str
 		}
-		str = strings.TrimSpace(buf.String())
+		buf.Reset()
+		if err := json.NewEncoder(buf).Encode(ti); err == nil {
+			return strings.TrimSpace(buf.String())
+		}
 	}
-
-	return str
+	return "INVALID"
 }
 
 // Result represents a single test case result.
@@ -349,10 +341,11 @@ type Runner struct {
 // NewRunner returns a new runner.
 func NewRunner() *Runner {
 	return &Runner{
-		timeout:            5 * time.Second,
-		defaultRegoVersion: ast.DefaultRegoVersion,
-		parallel:           runtime.NumCPU(),
-		coverageRuns:       []cover.Kind{cover.KindIndexExcluded, cover.KindEarlyExit},
+		enablePrintStatements: true,
+		timeout:               5 * time.Second,
+		defaultRegoVersion:    ast.DefaultRegoVersion,
+		parallel:              runtime.NumCPU(),
+		coverageRuns:          []cover.Kind{cover.KindIndexExcluded, cover.KindEarlyExit},
 	}
 }
 
@@ -440,7 +433,8 @@ func (r *Runner) SetCoverageRuns(kinds []cover.Kind) *Runner {
 }
 
 // CapturePrintOutput captures print() call outputs during evaluation and
-// includes the output in test results.
+// includes the output in test results. If not set, defaults to true. Print
+// output is always disabled in benchmarks.
 func (r *Runner) CapturePrintOutput(yes bool) *Runner {
 	r.enablePrintStatements = yes
 	return r
@@ -522,7 +516,7 @@ func (r *Runner) Run(ctx context.Context, modules map[string]*ast.Module) (chan 
 // RunTests executes tests found in either modules or bundles loaded on the runner.
 // Test results are sent as they complete and may arrive in any order.
 func (r *Runner) RunTests(ctx context.Context, txn storage.Transaction) (chan *Result, error) {
-	return r.runTests(ctx, txn, true, r.runTest, r.parallel)
+	return r.runTests(ctx, txn, r.enablePrintStatements, r.runTest, r.parallel)
 }
 
 // RunBenchmarks executes tests similar to tester.Runner#RunTests but will repeat
@@ -585,7 +579,7 @@ func (r *Runner) setupTestRun(ctx context.Context, txn storage.Transaction, enab
 
 		// Activate the bundle(s) to get their info and policies into the store
 		// the actual compiled policies will be overwritten later.
-		opts := &bundle.ActivateOpts{
+		err := bundle.Activate(&bundle.ActivateOpts{
 			Ctx:           ctx,
 			Store:         r.store,
 			Txn:           txn,
@@ -593,8 +587,7 @@ func (r *Runner) setupTestRun(ctx context.Context, txn storage.Transaction, enab
 			Metrics:       metrics.New(),
 			Bundles:       r.bundles,
 			ParserOptions: ast.ParserOptions{RegoVersion: r.defaultRegoVersion},
-		}
-		err := bundle.Activate(opts)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -1219,11 +1212,13 @@ func subResult(n string, v any) *SubResult {
 }
 
 func (r *Runner) runBenchmark(ctx context.Context, txn storage.Transaction, mod *ast.Module, rule *ast.Rule, options BenchmarkOptions) (*Result, bool) {
-	_, rf := ruleName(rule.Head)
+	ruleName, rf := ruleName(rule.Head)
+
 	tr := &Result{
 		Location: rule.Loc(),
 		Package:  mod.Package.Path.String(),
 		Name:     rf.String(), // TODO(sr): test
+		Skip:     strings.HasPrefix(ruleName, SkipTestPrefix),
 	}
 
 	var stop bool

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/open-policy-agent/opa/v1/types"
 	"github.com/open-policy-agent/opa/v1/util"
+	"github.com/open-policy-agent/opa/v1/util/channel"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 
@@ -158,26 +159,21 @@ func testRun(t *testing.T, conf testRunConfig) map[string]*ast.Module {
 		}},
 	}
 
-	var modules map[string]*ast.Module
-	test.WithTempFS(files, func(d string) {
-		var rs []*tester.Result
-		rs, modules = doTestRunWithTmpDir(t, d, conf)
-		validateTestResults(t, tests, rs, conf)
-	})
+	rs, modules := doTestRunWithTmpDir(t, test.TempDir(t, files), conf)
+	validateTestResults(t, tests, rs, conf)
+
 	return modules
 }
 
 func doTestRunWithTmpDir(t *testing.T, dir string, conf testRunConfig) ([]*tester.Result, map[string]*ast.Module) {
 	t.Helper()
 
-	ctx := t.Context()
-
-	paths := []string{dir}
-	modules, store, err := tester.Load(paths, nil)
+	modules, store, err := tester.Load([]string{dir}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	ctx := t.Context()
 	txn := storage.NewTransactionOrDie(ctx, store)
 	defer store.Abort(ctx, txn)
 
@@ -198,12 +194,8 @@ func doTestRunWithTmpDir(t *testing.T, dir string, conf testRunConfig) ([]*teste
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	var rs []*tester.Result
-	for r := range ch {
-		rs = append(rs, r)
-	}
 
-	return rs, modules
+	return channel.Collect(ch), modules
 }
 
 func validateTestResults(t *testing.T, tests expectedTestResults, rs []*tester.Result, conf testRunConfig) {
@@ -216,6 +208,8 @@ func validateTestResults(t *testing.T, tests expectedTestResults, rs []*tester.R
 		if !ok {
 			t.Errorf("Unexpected result for %v", k)
 			continue
+		} else if exp.wantSkip != r.Skip {
+			t.Errorf("Expected %+v for %v but got: %v", exp, k, r)
 		} else if exp.wantErr != (r.Error != nil) || exp.wantFail != r.Fail {
 			t.Errorf("Expected %+v for %v but got: %v", exp, k, r)
 		} else {
@@ -361,16 +355,47 @@ func TestRunWithPrefixMatchers(t *testing.T) {
 		},
 	}
 
-	test.WithTempFS(files, func(d string) {
-		for _, tc := range cases {
-			t.Run(tc.note, func(t *testing.T) {
+	d := test.TempDir(t, files)
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			conf := testRunConfig{prefixMatchers: tc.prefixes}
+			rs, _ := doTestRunWithTmpDir(t, d, conf)
+			validateTestResults(t, tc.tests, rs, conf)
+		})
+	}
 
-				conf := testRunConfig{prefixMatchers: tc.prefixes}
-				rs, _ := doTestRunWithTmpDir(t, d, conf)
-				validateTestResults(t, tc.tests, rs, conf)
-			})
+}
+
+func TestRunTestWithAndWithoutPrintCapture(t *testing.T) {
+	paths := []string{test.TempDirOf(t, "/a_test.rego", `package print_test
+		test_print if {
+			x := 2 + 2
+			print(x)
+			x == 4
+		}`),
+	}
+	modules, store, err := tester.Load(paths, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn := storage.NewTransactionOrDie(t.Context(), store)
+	defer store.Abort(t.Context(), txn)
+
+	for capture, expected := range map[bool]string{true: "4\n", false: ""} {
+		ch, err := tester.NewRunner().
+			SetStore(store).
+			SetModules(modules).
+			CapturePrintOutput(capture).
+			RunTests(t.Context(), txn)
+
+		if err != nil {
+			t.Fatal(err)
 		}
-	})
+		if result := <-ch; string(result.Output) != expected {
+			t.Fatalf("Expected print output to be %q, got: %q", expected, result.Output)
+		}
+	}
 }
 
 func TestRunWithFilterRegex(t *testing.T) {
@@ -541,15 +566,14 @@ func TestRunWithFilterRegex(t *testing.T) {
 		},
 	}
 
-	test.WithTempFS(files, func(d string) {
-		for _, tc := range cases {
-			t.Run(tc.note, func(t *testing.T) {
-				conf := testRunConfig{filter: tc.regex}
-				rs, _ := doTestRunWithTmpDir(t, d, conf)
-				validateTestResults(t, tc.tests, rs, conf)
-			})
-		}
-	})
+	d := test.TempDir(t, files)
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			conf := testRunConfig{filter: tc.regex}
+			rs, _ := doTestRunWithTmpDir(t, d, conf)
+			validateTestResults(t, tc.tests, rs, conf)
+		})
+	}
 }
 
 func TestRunnerCancel(t *testing.T) {
@@ -561,7 +585,6 @@ func TestRunnerCancelBenchmark(t *testing.T) {
 }
 
 func testCancel(t *testing.T, bench bool) {
-
 	registerSleepBuiltin()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -572,41 +595,32 @@ func testCancel(t *testing.T, bench bool) {
 	test_1 if { test.sleep("100ms") }
 	test_2 if { true }`
 
-	files := map[string]string{
-		"/a_test.rego": module,
+	paths := []string{test.TempDirOf(t, "/a_test.rego", module)}
+	modules, store, err := tester.Load(paths, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	test.WithTempFS(files, func(d string) {
-		paths := []string{d}
-		modules, store, err := tester.Load(paths, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+	txn := storage.NewTransactionOrDie(ctx, store)
+	runner := tester.NewRunner().SetStore(store).SetModules(modules)
 
-		txn := storage.NewTransactionOrDie(ctx, store)
-		runner := tester.NewRunner().SetStore(store).SetModules(modules)
+	// Everything below uses a canceled context..
+	cancel()
 
-		// Everything below uses a canceled context..
-		cancel()
+	var ch chan *tester.Result
+	if bench {
+		ch, err = runner.RunBenchmarks(ctx, txn, tester.BenchmarkOptions{})
+	} else {
+		ch, err = runner.RunTests(ctx, txn)
+	}
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 
-		var ch chan *tester.Result
-		if bench {
-			ch, err = runner.RunBenchmarks(ctx, txn, tester.BenchmarkOptions{})
-		} else {
-			ch, err = runner.RunTests(ctx, txn)
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-		var results []*tester.Result
-		for r := range ch {
-			results = append(results, r)
-		}
-
-		if len(results) != 0 {
-			t.Fatalf("Expected no tests to be run but, got: %d", len(results))
-		}
-	})
+	results := channel.Collect(ch)
+	if len(results) != 0 {
+		t.Fatalf("Expected no tests to be run but, got: %d", len(results))
+	}
 }
 
 func TestRunnerTimeout(t *testing.T) {
@@ -621,8 +635,6 @@ func TestRunnerTimeoutBenchmark(t *testing.T) {
 func testTimeout(t *testing.T, bench bool) {
 	registerSleepBuiltin()
 
-	ctx := t.Context()
-
 	files := map[string]string{
 		"/a_test.rego": `package foo
 		import rego.v1
@@ -634,48 +646,43 @@ func testTimeout(t *testing.T, bench bool) {
 		test_2 if { test.sleep("1ms") }`,
 	}
 
-	test.WithTempFS(files, func(d string) {
-		paths := []string{d}
-		modules, store, err := tester.Load(paths, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		duration, err := time.ParseDuration("15ms")
-		if err != nil {
-			t.Fatal(err)
-		}
+	paths := []string{test.TempDir(t, files)}
+	modules, store, err := tester.Load(paths, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duration, err := time.ParseDuration("15ms")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		txn := storage.NewTransactionOrDie(ctx, store)
-		runner := tester.NewRunner().SetTimeout(duration).SetStore(store).SetModules(modules)
+	ctx := t.Context()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	runner := tester.NewRunner().SetTimeout(duration).SetStore(store).SetModules(modules)
 
-		var ch chan *tester.Result
-		if bench {
-			ch, err = runner.RunBenchmarks(ctx, txn, tester.BenchmarkOptions{})
-		} else {
-			ch, err = runner.RunTests(ctx, txn)
-		}
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-		var results []*tester.Result
-		for r := range ch {
-			results = append(results, r)
-		}
+	var ch chan *tester.Result
+	if bench {
+		ch, err = runner.RunBenchmarks(ctx, txn, tester.BenchmarkOptions{})
+	} else {
+		ch, err = runner.RunTests(ctx, txn)
+	}
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 
-		if bench {
-			if !topdown.IsCancel(results[1].Error) {
-				t.Fatalf("Expected cancel error for second test but got: %v", results[1].Error)
-			}
-		} else {
-			if !topdown.IsCancel(results[1].Error) {
-				t.Fatalf("Expected test to have timed out")
-			}
+	results := channel.Collect(ch)
+	if bench {
+		if !topdown.IsCancel(results[1].Error) {
+			t.Fatalf("Expected cancel error for second test but got: %v", results[1].Error)
 		}
-	})
+	} else {
+		if !topdown.IsCancel(results[1].Error) {
+			t.Fatalf("Expected test to have timed out")
+		}
+	}
 }
 
 func TestRunnerPrintOutput(t *testing.T) {
-
 	files := map[string]string{
 		"/test.rego": `package test
 		import rego.v1
@@ -700,62 +707,58 @@ func TestRunnerPrintOutput(t *testing.T) {
 		p.q.r.test_k if { print("K") }`,
 	}
 
+	modules, store, err := tester.Load([]string{test.TempDir(t, files)}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx := t.Context()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	runner := tester.NewRunner().SetStore(store).SetModules(modules).CapturePrintOutput(true)
+	ch, err := runner.RunTests(ctx, txn)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	test.WithTempFS(files, func(d string) {
-		paths := []string{d}
-		modules, store, err := tester.Load(paths, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+	exp := map[string]map[string]string{
+		"test.rego": {
+			"test_a":       "A\n",
+			"test_b":       "",
+			"test_c":       "C\n",
+			"p.q.r.test_d": "D\n",
+		},
+		"test2.rego": {
+			"test_d":       "D\n",
+			"test_e":       "",
+			"test_f":       "F\n",
+			"p.q.r.test_g": "G\n",
+		},
+		"test3.rego": {
+			"test_h":       "H\n",
+			"test_i":       "",
+			"test_j":       "J\n",
+			"p.q.r.test_k": "K\n",
+		},
+	}
 
-		txn := storage.NewTransactionOrDie(ctx, store)
-		runner := tester.NewRunner().SetStore(store).SetModules(modules).CapturePrintOutput(true)
-		ch, err := runner.RunTests(ctx, txn)
-		if err != nil {
-			t.Fatal(err)
+	got := map[string]map[string]string{}
+	for r := range ch {
+		file := filepath.Base(r.Location.File)
+		if got[file] == nil {
+			got[file] = map[string]string{}
 		}
+		got[file][r.Name] = string(r.Output)
+	}
 
-		exp := map[string]map[string]string{
-			"test.rego": {
-				"test_a":       "A\n",
-				"test_b":       "",
-				"test_c":       "C\n",
-				"p.q.r.test_d": "D\n",
-			},
-			"test2.rego": {
-				"test_d":       "D\n",
-				"test_e":       "",
-				"test_f":       "F\n",
-				"p.q.r.test_g": "G\n",
-			},
-			"test3.rego": {
-				"test_h":       "H\n",
-				"test_i":       "",
-				"test_j":       "J\n",
-				"p.q.r.test_k": "K\n",
-			},
-		}
-
-		got := map[string]map[string]string{}
-		for r := range ch {
-			file := filepath.Base(r.Location.File)
-			if got[file] == nil {
-				got[file] = map[string]string{}
-			}
-			got[file][r.Name] = string(r.Output)
-		}
-
-		if !maps.Equal(exp["test.rego"], got["test.rego"]) {
-			t.Fatal("test.rego expected:", exp["test.rego"], "got:", got["test.rego"])
-		}
-		if !maps.Equal(exp["test2.rego"], got["test2.rego"]) {
-			t.Fatal("test2.rego expected:", exp["test2.rego"], "got:", got["test2.rego"])
-		}
-		if !maps.Equal(exp["test3.rego"], got["test3.rego"]) {
-			t.Fatal("test3.rego expected:", exp["test3.rego"], "got:", got["test3.rego"])
-		}
-	})
+	if !maps.Equal(exp["test.rego"], got["test.rego"]) {
+		t.Fatal("test.rego expected:", exp["test.rego"], "got:", got["test.rego"])
+	}
+	if !maps.Equal(exp["test2.rego"], got["test2.rego"]) {
+		t.Fatal("test2.rego expected:", exp["test2.rego"], "got:", got["test2.rego"])
+	}
+	if !maps.Equal(exp["test3.rego"], got["test3.rego"]) {
+		t.Fatal("test3.rego expected:", exp["test3.rego"], "got:", got["test3.rego"])
+	}
 }
 
 // TestRunnerPrintOutputWithCoverage guards against a regression where the
@@ -768,54 +771,35 @@ func TestRunnerPrintOutputWithCoverage(t *testing.T) {
 		test_a if { print("A") }`,
 	}
 
+	modules, store, err := tester.Load([]string{test.TempDir(t, files)}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx := t.Context()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	runner := tester.NewRunner().
+		SetStore(store).
+		SetModules(modules).
+		CapturePrintOutput(true).
+		SetCoverageQueryTracer(cover.New())
 
-	test.WithTempFS(files, func(d string) {
-		modules, store, err := tester.Load([]string{d}, nil)
-		if err != nil {
-			t.Fatal(err)
+	ch, err := runner.RunTests(ctx, txn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for r := range ch {
+		if r.Name != "test_a" {
+			continue
 		}
-
-		txn := storage.NewTransactionOrDie(ctx, store)
-		runner := tester.NewRunner().
-			SetStore(store).
-			SetModules(modules).
-			CapturePrintOutput(true).
-			SetCoverageQueryTracer(cover.New())
-		ch, err := runner.RunTests(ctx, txn)
-		if err != nil {
-			t.Fatal(err)
+		if got := string(r.Output); got != "A\n" {
+			t.Fatalf("expected print output %q, got %q (supplementary coverage passes may be duplicating it)", "A\n", got)
 		}
-
-		for r := range ch {
-			if r.Name != "test_a" {
-				continue
-			}
-			if got := string(r.Output); got != "A\n" {
-				t.Fatalf("expected print output %q, got %q (supplementary coverage passes may be duplicating it)", "A\n", got)
-			}
-		}
-	})
-}
-
-func registerSleepBuiltin() {
-	ast.RegisterBuiltin(&ast.Builtin{
-		Name: "test.sleep",
-		Decl: types.NewFunction(
-			types.Args(types.S),
-			types.Nl,
-		),
-	})
-
-	topdown.RegisterBuiltinFunc("test.sleep", func(_ topdown.BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-		d, _ := time.ParseDuration(string(operands[0].Value.(ast.String)))
-		time.Sleep(d)
-		return iter(ast.NullTerm())
-	})
+	}
 }
 
 func TestRunnerWithCustomBuiltin(t *testing.T) {
-
 	var myBuiltinDecl = &ast.Builtin{
 		Name: "my_sum",
 		Decl: types.NewFunction(
@@ -856,43 +840,34 @@ func TestRunnerWithCustomBuiltin(t *testing.T) {
 		test_c if { my_sum(4,1.0) == 5 }`,
 	}
 
+	modules, store, err := tester.Load([]string{test.TempDir(t, files)}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx := t.Context()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	runner := tester.NewRunner().SetStore(store).SetModules(modules).AddCustomBuiltins([]*tester.Builtin{myBuiltin})
+	ch, err := runner.RunTests(ctx, txn)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	test.WithTempFS(files, func(d string) {
-		paths := []string{d}
-		modules, store, err := tester.Load(paths, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		txn := storage.NewTransactionOrDie(ctx, store)
-		runner := tester.NewRunner().SetStore(store).SetModules(modules).AddCustomBuiltins([]*tester.Builtin{myBuiltin})
-		ch, err := runner.RunTests(ctx, txn)
-		if err != nil {
-			t.Fatal(err)
-		}
+	exp := map[string]bool{
+		"test_a": true,
+		"test_b": false,
+		"test_c": false,
+	}
 
-		results := make([]*tester.Result, 0, 10)
+	got := map[string]bool{}
 
-		for r := range ch {
-			results = append(results, r)
-		}
+	for tr := range ch {
+		got[tr.Name] = tr.Pass()
+	}
 
-		exp := map[string]bool{
-			"test_a": true,
-			"test_b": false,
-			"test_c": false,
-		}
-
-		got := map[string]bool{}
-
-		for _, tr := range results {
-			got[tr.Name] = tr.Pass()
-		}
-
-		if !maps.Equal(exp, got) {
-			t.Fatal("expected:", exp, "got:", got)
-		}
-	})
+	if !maps.Equal(exp, got) {
+		t.Fatal("expected:", exp, "got:", got)
+	}
 }
 
 func TestRunnerWithBuiltinErrors(t *testing.T) {
@@ -927,37 +902,32 @@ func TestRunnerWithBuiltinErrors(t *testing.T) {
 		},
 	}
 
-	ctx := t.Context()
-
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			files := map[string]string{
-				"builtin_error_test.rego": fmt.Sprintf(ruleTemplate, tc.json),
+			d := test.TempDirOf(t, "builtin_error_test.rego", fmt.Sprintf(ruleTemplate, tc.json))
+			paths := []string{d}
+			modules, store, err := tester.Load(paths, nil)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			test.WithTempFS(files, func(d string) {
-				paths := []string{d}
-				modules, store, err := tester.Load(paths, nil)
-				if err != nil {
-					t.Fatal(err)
-				}
-				txn := storage.NewTransactionOrDie(ctx, store)
-				runner := tester.
-					NewRunner().
-					SetStore(store).
-					SetModules(modules).
-					RaiseBuiltinErrors(tc.builtinErrors)
+			ctx := t.Context()
+			txn := storage.NewTransactionOrDie(ctx, store)
+			runner := tester.
+				NewRunner().
+				SetStore(store).
+				SetModules(modules).
+				RaiseBuiltinErrors(tc.builtinErrors)
 
-				ch, err := runner.RunTests(ctx, txn)
-				if err != nil {
-					t.Fatal(err)
+			ch, err := runner.RunTests(ctx, txn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for result := range ch {
+				if gotErr := result.Error != nil; gotErr != tc.wantErr {
+					t.Errorf("wantErr = %v, gotErr = %v", tc.wantErr, gotErr)
 				}
-				for result := range ch {
-					if gotErr := result.Error != nil; gotErr != tc.wantErr {
-						t.Errorf("wantErr = %v, gotErr = %v", tc.wantErr, gotErr)
-					}
-				}
-			})
+			}
 		})
 	}
 }
@@ -1014,36 +984,28 @@ test_p if {
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-			files := map[string]string{
-				"test.rego": tc.module,
-			}
+			root := test.TempDirOf(t, "test.rego", tc.module)
+			modules, store, err := tester.Load([]string{root}, nil)
+			if len(tc.expErrs) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error but got nil")
+				}
 
-			test.WithTempFS(files, func(root string) {
-				modules, store, err := tester.Load([]string{root}, nil)
-				if len(tc.expErrs) > 0 {
-					if err == nil {
-						t.Fatalf("Expected error but got nil")
-					}
-
-					for _, expErr := range tc.expErrs {
-						if !strings.Contains(err.Error(), expErr) {
-							t.Fatalf("Expected error to contain:\n\n%q\n\nbut got:\n\n%v", expErr, err)
-						}
-					}
-				} else {
-					if err != nil {
-						t.Fatalf("Unexpected error: %v", err)
-					}
-
-					if modules == nil {
-						t.Fatalf("Expected modules to be non-nil")
-					}
-
-					if store == nil {
-						t.Fatalf("Expected store to be non-nil")
+				for _, expErr := range tc.expErrs {
+					if !strings.Contains(err.Error(), expErr) {
+						t.Fatalf("Expected error to contain:\n\n%q\n\nbut got:\n\n%v", expErr, err)
 					}
 				}
-			})
+			} else {
+				switch {
+				case err != nil:
+					t.Fatalf("Unexpected error: %v", err)
+				case modules == nil:
+					t.Fatalf("Expected modules to be non-nil")
+				case store == nil:
+					t.Fatalf("Expected store to be non-nil")
+				}
+			}
 		})
 	}
 }
@@ -1085,23 +1047,17 @@ func TestRun_DefaultRegoVersion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-			ctx := t.Context()
-
-			modules := map[string]*ast.Module{
-				"test": &tc.module,
-			}
-
 			store := inmem.New()
+			ctx := t.Context()
 			txn := storage.NewTransactionOrDie(ctx, store)
 			defer store.Abort(ctx, txn)
 
 			runner := tester.NewRunner().
 				SetStore(store).
-				SetModules(modules).
+				SetModules(map[string]*ast.Module{"test": &tc.module}).
 				SetTimeout(10 * time.Second)
 
 			ch, err := runner.RunTests(ctx, txn)
-
 			if len(tc.expErrs) > 0 {
 				if err == nil {
 					t.Fatalf("Expected error but got nil")
@@ -1115,18 +1071,9 @@ func TestRun_DefaultRegoVersion(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
-				}
-
-				var rs []*tester.Result
-				for r := range ch {
-					rs = append(rs, r)
-				}
-
-				if len(rs) != 1 {
+				} else if rs := channel.Collect(ch); len(rs) != 1 {
 					t.Fatalf("Expected exactly one result but got: %v", rs)
-				}
-
-				if rs[0].Fail {
+				} else if rs[0].Fail {
 					t.Fatalf("Expected test to pass but it failed")
 				}
 			}
@@ -1207,34 +1154,25 @@ func TestReporterFormatsWithExplicitParallel(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.note, func(t *testing.T) {
-			ctx := t.Context()
+			paths := []string{test.TempDir(t, files)}
+			modules, store, err := tester.Load(paths, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-			test.WithTempFS(files, func(d string) {
-				paths := []string{d}
-				modules, store, err := tester.Load(paths, nil)
-				if err != nil {
-					t.Fatal(err)
-				}
+			txn := storage.NewTransactionOrDie(t.Context(), store)
+			runner := tester.NewRunner().SetStore(store).SetModules(modules).CapturePrintOutput(true)
+			ch, err := runner.RunTests(t.Context(), txn)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-				txn := storage.NewTransactionOrDie(ctx, store)
-				runner := tester.NewRunner().SetStore(store).SetModules(modules).CapturePrintOutput(true)
-				ch, err := runner.RunTests(ctx, txn)
-				if err != nil {
-					t.Fatal(err)
-				}
+			buf := new(bytes.Buffer)
+			if err := tc.r(buf).Report(ch); err != nil {
+				t.Fatal(err)
+			}
 
-				var buf bytes.Buffer
-
-				r := tc.r(&buf)
-
-				if err := r.Report(ch); err != nil {
-					t.Fatal(err)
-				}
-
-				str := buf.String()
-
-				tc.exp(str)
-			})
+			tc.exp(buf.String())
 		})
 	}
 }
@@ -1325,16 +1263,14 @@ func TestResultUnmarshalJSONEvalError(t *testing.T) {
 }
 
 func TestRunTestsDoesNotMutateInternedTestCaseRef(t *testing.T) {
-	ctx := t.Context()
-
 	before := ast.Interned.Refs.InternalTestCase[0]
-
 	modules := map[string]*ast.Module{
 		"test.rego": ast.MustParseModule(`package test
 			test_cases[x] if { some x in ["foo", "bar"] }`),
 	}
 
 	store := inmem.New()
+	ctx := t.Context()
 	txn := storage.NewTransactionOrDie(ctx, store)
 	defer store.Abort(ctx, txn)
 
@@ -1351,4 +1287,20 @@ func TestRunTestsDoesNotMutateInternedTestCaseRef(t *testing.T) {
 	if act := ast.Interned.Refs.InternalTestCase[0]; act != before {
 		t.Errorf("ast.Interned.Refs.InternalTestCase was mutated: %p -> %p", before, act)
 	}
+}
+
+func registerSleepBuiltin() {
+	ast.RegisterBuiltin(&ast.Builtin{
+		Name: "test.sleep",
+		Decl: types.NewFunction(
+			types.Args(types.S),
+			types.Nl,
+		),
+	})
+
+	topdown.RegisterBuiltinFunc("test.sleep", func(_ topdown.BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+		d, _ := time.ParseDuration(string(operands[0].Value.(ast.String)))
+		time.Sleep(d)
+		return iter(ast.NullTerm())
+	})
 }

--- a/v1/util/channel/channel.go
+++ b/v1/util/channel/channel.go
@@ -1,4 +1,4 @@
-package util
+package channel
 
 import (
 	"github.com/open-policy-agent/opa/v1/metrics"
@@ -11,7 +11,6 @@ const maxEventRetry = 1000
 // PushFIFO pushes data into a buffered channel without blocking when full, making room by dropping the oldest data.
 // An optional metric can be recorded when data is dropped.
 func PushFIFO[T any](buffer chan T, data T, metrics metrics.Metrics, metricName string) {
-
 	for range maxEventRetry {
 		// non-blocking send to the buffer, to prevent blocking if buffer is full so room can be made.
 		select {
@@ -29,4 +28,13 @@ func PushFIFO[T any](buffer chan T, data T, metrics metrics.Metrics, metricName 
 		default:
 		}
 	}
+}
+
+// CollectChan reads all values from a channel and returns them as a slice.
+func Collect[T any](ch <-chan T) []T {
+	out := make([]T, 0, len(ch))
+	for v := range ch {
+		out = append(out, v)
+	}
+	return out
 }


### PR DESCRIPTION
Setting `field-writes-are-uses: false` in the `unused` linter revealed quite a few locations where we either have dead code, or code that doesn't do what we intended. This fixes one of those issues.

While the runner API exposes a `CapturePrintOutput` this value was never read, but would be hardcoded to `true` for tests and `false` for benchmarks. This fixes that so that the setting is honored by the test runner (but still defaulting to `true) when running regular tests. The value remains hardcoded to `false` for benchmarks as it's unlikely to help anyone getting thousands of lines printed running those.

Also a few improvements in related code.
