### PR TITLE
Update remaining `errors.As` call sites to use `errors.AsType`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,6 +36,8 @@ linters:
         - (*encoding/json/jsontext.Encoder).WriteValue
     forbidigo:
       forbid:
+        - pattern: '^errors\.As$'
+          message: "Prefer to use errors.AsType instead"
         - pattern: '^sort\.[A-Z][a-zA-Z]+$'
           message: "Prefer the more performant sort/search functions in the slices package"
     gocritic:

--- a/build/release/go.mod
+++ b/build/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-policy-agent/opa/build/release
 
-go 1.25.0
+go 1.26.0
 
 require github.com/google/go-github/v76 v76.0.0
 

--- a/build/release/internal/gh/client.go
+++ b/build/release/internal/gh/client.go
@@ -87,11 +87,8 @@ func (c *realClient) IssueURL(number int) string {
 // isCommitNotFound matches GitHub's 422 "No commit found for SHA", i.e. an
 // unpushed commit. Matching on status alone survives message rewording.
 func isCommitNotFound(err error) bool {
-	var gerr *github.ErrorResponse
-	if errors.As(err, &gerr) && gerr.Response != nil {
-		return gerr.Response.StatusCode == http.StatusUnprocessableEntity
-	}
-	return false
+	gerr, ok := errors.AsType[*github.ErrorResponse](err)
+	return ok && gerr.Response != nil && gerr.Response.StatusCode == http.StatusUnprocessableEntity
 }
 
 func (c *realClient) Commit(ctx context.Context, sha string) (*Commit, error) {

--- a/build/release/internal/gh/retry.go
+++ b/build/release/internal/gh/retry.go
@@ -147,12 +147,9 @@ func isRetryableErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return true
-	}
+	_, isNetErr := errors.AsType[net.Error](err)
 	// A reset or EOF mid-response arrives wrapped in *url.Error, not as net.Error.
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed)
+	return isNetErr || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed)
 }
 
 // retryAfter retries 5xx, 429, and 403-with-exhausted-rate-limit (GitHub's

--- a/internal/wasm/sdk/internal/wasm/bindings.go
+++ b/internal/wasm/sdk/internal/wasm/bindings.go
@@ -196,9 +196,8 @@ func (d *builtinDispatcher) dispatch(ctx context.Context, id int32, argAddrs ...
 		return nil
 	})
 	if err != nil {
-		if errors.As(err, &topdown.Halt{}) {
-			var e *topdown.Error
-			if errors.As(err, &e) && e.Code == topdown.CancelErr {
+		if _, ok := errors.AsType[topdown.Halt](err); ok {
+			if e, ok := errors.AsType[*topdown.Error](err); ok && e.Code == topdown.CancelErr {
 				panic(cancelledError{message: e.Message})
 			}
 			panic(builtinError{err: err})

--- a/v1/ast/annotations.go
+++ b/v1/ast/annotations.go
@@ -95,6 +95,14 @@ func (a *Annotations) String() string {
 	return string(bs)
 }
 
+func (a *Annotations) AppendText(buf []byte) ([]byte, error) {
+	bs, err := a.MarshalJSON()
+	if err == nil {
+		buf = append(buf, bs...)
+	}
+	return buf, err
+}
+
 // Loc returns the location of this annotation.
 func (a *Annotations) Loc() *Location {
 	return a.Location

--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -1211,12 +1211,11 @@ type RefErrUnsupportedDetail struct {
 
 // Lines returns the string representation of the detail.
 func (r *RefErrUnsupportedDetail) Lines() []string {
-	lines := []string{
+	return []string{
 		r.Ref.String(),
 		strings.Repeat("^", len(r.Ref[:r.Pos+1].String())),
 		fmt.Sprintf("have: %v", r.Have),
 	}
-	return lines
 }
 
 // RefErrInvalidDetail describes an undefined reference error where the referenced

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2118,18 +2118,6 @@ func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
 	return rules
 }
 
-func refSliceEqual(a, b []Ref) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !a[i].Equal(b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 func hashMapAdd(rules *util.HasherMap[Ref, []Ref], pkg, rule Ref) {
 	prev, ok := rules.Get(pkg)
 	if !ok {
@@ -5677,17 +5665,15 @@ func resolveRefsInRule(globals map[Var]*usedRef, rule *Rule) error {
 			return true
 
 		case *Term:
-			if _, ok := x.Value.(Ref); ok {
-				if RootDocumentRefs.Contains(x) {
-					// We could support args named input, data, etc. however
-					// this would require rewriting terms in the head and body.
-					// Preventing root document shadowing is simpler, and
-					// arguably, will prevent confusing names from being used.
-					// NOTE: this check is also performed as part of strict-mode in
-					// checkRootDocumentOverrides.
-					err = fmt.Errorf("args must not shadow %v (use a different variable name)", x)
-					return true
-				}
+			if TermValueIs[Ref](x) && RootDocumentRefs.Contains(x) {
+				// We could support args named input, data, etc. however
+				// this would require rewriting terms in the head and body.
+				// Preventing root document shadowing is simpler, and
+				// arguably, will prevent confusing names from being used.
+				// NOTE: this check is also performed as part of strict-mode in
+				// checkRootDocumentOverrides.
+				err = fmt.Errorf("args must not shadow %v (use a different variable name)", x)
+				return true
 			}
 		}
 		return false

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -441,13 +441,7 @@ func refMapEqual(a, b *util.HasherMap[Ref, []Ref]) bool {
 	}
 	return !a.Iter(func(k Ref, v []Ref) bool {
 		v2, ok := b.Get(k)
-		if !ok {
-			return true
-		}
-		if !refSliceEqual(v, v2) {
-			return true
-		}
-		return false
+		return !ok || !slices.EqualFunc(v, v2, RefEqual)
 	})
 }
 
@@ -2055,9 +2049,7 @@ r[x] := y if {
 				t.Fatal("expected error")
 			}
 
-			var errs Errors
-			errors.As(err, &errs)
-
+			errs, _ := errors.AsType[Errors](err)
 			if len(errs) != len(tc.expectedErrs) {
 				t.Fatalf("expected %d errors, got %d", len(tc.expectedErrs), len(errs))
 			}
@@ -12070,8 +12062,8 @@ func TestQueryCompilerWithUnsafeBuiltins(t *testing.T) {
 				qc = tc.opts(qc)
 			}
 			_, err := qc.Compile(MustParseBody(tc.query))
-			var errs Errors
-			if !errors.As(err, &errs) {
+			errs, ok := errors.AsType[Errors](err)
+			if !ok {
 				t.Fatalf("expected error type %T, got %v %[2]T", errs, err)
 			}
 			if exp, act := 1, len(errs); exp != act {

--- a/v1/ast/errors.go
+++ b/v1/ast/errors.go
@@ -67,10 +67,8 @@ const (
 
 // IsError returns true if err is an AST error with code.
 func IsError(code string, err error) bool {
-	if err, ok := err.(*Error); ok {
-		return err.Code == code
-	}
-	return false
+	e, ok := err.(*Error)
+	return ok && e.Code == code
 }
 
 // ErrorDetails defines the interface for detailed error messages.
@@ -90,7 +88,6 @@ func (e *Error) Error() string {
 	var prefix string
 
 	if e.Location != nil {
-
 		if len(e.Location.File) > 0 {
 			prefix += e.Location.File + ":" + strconv.Itoa(e.Location.Row)
 		} else {

--- a/v1/ast/oracle/target.go
+++ b/v1/ast/oracle/target.go
@@ -30,11 +30,9 @@ func findTarget(stack []ast.Node) *target {
 
 	// First, check if the very top node is a Var - this handles cases like
 	// function arguments in dynamic refs: input.foo[x] where x is the target
-	if top, ok := stack[len(stack)-1].(*ast.Term); ok {
-		if _, ok := top.Value.(ast.Var); ok {
-			targetTerm = top
-			targetIsVar = true
-		}
+	if top, ok := stack[len(stack)-1].(*ast.Term); ok && ast.TermValueIs[ast.Var](top) {
+		targetTerm = top
+		targetIsVar = true
 	}
 
 	// If top wasn't a var, walk up the stack looking for a Ref.

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -5568,8 +5568,8 @@ func TestRuleFromBodyRefs(t *testing.T) {
 
 func assertErrorWithMessage(t *testing.T, err error, msg string) {
 	t.Helper()
-	var errs Errors
-	if !errors.As(err, &errs) {
+	errs, ok := errors.AsType[Errors](err)
+	if !ok {
 		t.Fatalf("expected Errors, got %v %[1]T", err)
 	}
 	if exp, act := 1, len(errs); exp != act {

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -511,10 +511,8 @@ func IsValidImportPath(v Value) (err error) {
 		if err := IsValidImportPath(v[0].Value); err != nil {
 			return fmt.Errorf("invalid path %v: path must begin with input or data", v)
 		}
-		for _, e := range v[1:] {
-			if _, ok := e.Value.(String); !ok {
-				return fmt.Errorf("invalid path %v: path elements must be strings", v)
-			}
+		if !util.Every(v[1:], TermValueIs[String]) {
+			return fmt.Errorf("invalid path %v: path elements must be strings", v)
 		}
 	default:
 		return fmt.Errorf("invalid path %v: path must be ref or var", v)
@@ -1343,10 +1341,8 @@ func (expr *Expr) Operands() []*Term {
 func (expr *Expr) IsGround() bool {
 	switch ts := expr.Terms.(type) {
 	case []*Term:
-		for _, t := range ts[1:] {
-			if !t.IsGround() {
-				return false
-			}
+		if !util.Every(ts[1:], (*Term).IsGround) {
+			return false
 		}
 	case *Term:
 		return ts.IsGround()

--- a/v1/ast/policy_appenders.go
+++ b/v1/ast/policy_appenders.go
@@ -21,7 +21,9 @@ func (mod *Module) AppendText(buf []byte) ([]byte, error) {
 		// rule annotations are attached to rules, so only check for package scoped ones here
 		if annotations.Scope == "package" || annotations.Scope == "subpackages" {
 			buf = append(buf, "# METADATA\n# "...)
-			buf = append(buf, annotations.String()...)
+			if buf, err = annotations.AppendText(buf); err != nil {
+				return nil, err
+			}
 			buf = append(buf, '\n')
 		}
 	}
@@ -98,7 +100,10 @@ func (rule *Rule) appendWithOpts(opts toStringOpts, buf []byte) ([]byte, error) 
 	// See note in [Module.AppendText] regarding annotations.
 	for _, annotations := range rule.Annotations {
 		buf = append(buf, "# METADATA\n# "...)
-		buf = append(buf, annotations.String()...)
+		var err error
+		if buf, err = annotations.AppendText(buf); err != nil {
+			return nil, err
+		}
 		buf = append(buf, '\n')
 	}
 

--- a/v1/ast/rego_v1.go
+++ b/v1/ast/rego_v1.go
@@ -33,14 +33,15 @@ func checkRootDocumentOverrides(node any) Errors {
 		}
 
 		if ReservedVars.Contains(name) {
-			errors = append(errors, NewError(CompileErr, rule.Location, "rules must not shadow %v (use a different rule name)", name))
+			errors = append(errors,
+				NewError(CompileErr, rule.Location, "rules must not shadow %v (use a different rule name)", name))
 		}
 
 		for _, arg := range rule.Head.Args {
-			if _, ok := arg.Value.(Ref); ok {
-				if RootDocumentRefs.Contains(arg) {
-					errors = append(errors, NewError(CompileErr, arg.Location, "args must not shadow %v (use a different variable name)", arg))
-				}
+			if _, ok := arg.Value.(Ref); ok && RootDocumentRefs.Contains(arg) {
+				errors = append(errors, NewError(
+					CompileErr, arg.Location, "args must not shadow %v (use a different variable name)", arg,
+				))
 			}
 		}
 
@@ -49,11 +50,12 @@ func checkRootDocumentOverrides(node any) Errors {
 
 	WalkExprs(node, func(expr *Expr) bool {
 		if expr.IsAssignment() {
-			// assign() can be called directly, so we need to assert its given first operand exists before checking its name.
+			// assign() can be called directly, so assert its given first operand exists before checking its name.
 			if nameOp := expr.Operand(0); nameOp != nil {
-				name := Var(nameOp.String())
-				if ReservedVars.Contains(name) {
-					errors = append(errors, NewError(CompileErr, expr.Location, "variables must not shadow %v (use a different variable name)", name))
+				if name := Var(nameOp.String()); ReservedVars.Contains(name) {
+					errors = append(errors, NewError(
+						CompileErr, expr.Location, "variables must not shadow %v (use a different variable name)", name,
+					))
 				}
 			}
 		}

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1235,20 +1235,8 @@ func (ref Ref) CopyNonGround() Ref {
 
 // Equal returns true if ref is equal to other.
 func (ref Ref) Equal(other Value) bool {
-	switch o := other.(type) {
-	case Ref:
-		if len(ref) == len(o) {
-			for i := range ref {
-				if !ref[i].Equal(o[i]) {
-					return false
-				}
-			}
-
-			return true
-		}
-	}
-
-	return false
+	o, ok := other.(Ref)
+	return ok && slices.EqualFunc(ref, o, (*Term).Equal)
 }
 
 // Compare compares ref to other, return <0, 0, or >0 if it is less than, equal to,

--- a/v1/debug/debugger.go
+++ b/v1/debug/debugger.go
@@ -346,11 +346,10 @@ func (d *debugger) LaunchEval(ctx context.Context, props LaunchEvalProperties, o
 		defer func() { _ = tracer.Close() }()
 		rs, evalErr := pq.Eval(s.ctx, evalArgs...)
 		if evalErr != nil {
-			var topdownErr *topdown.Error
-			if errors.As(evalErr, &topdownErr) && topdownErr.Code == topdown.CancelErr {
-				return
+			topdownErr, ok := errors.AsType[*topdown.Error](evalErr)
+			if !ok || topdownErr.Code != topdown.CancelErr {
+				d.logger.Error("Evaluation failed: %v", evalErr)
 			}
-			d.logger.Error("Evaluation failed: %v", evalErr)
 			return
 		}
 

--- a/v1/download/download_test.go
+++ b/v1/download/download_test.go
@@ -793,8 +793,8 @@ func TestFailureUnexpected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	var hErr HTTPError
-	if !errors.As(err, &hErr) {
+	hErr, ok := errors.AsType[HTTPError](err)
+	if !ok {
 		t.Fatal("expected HTTPError")
 	}
 	if hErr.StatusCode != 500 {
@@ -825,8 +825,8 @@ func TestFailureUnexpectedWithResponseBody(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	var hErr HTTPError
-	if !errors.As(err, &hErr) {
+	hErr, ok := errors.AsType[HTTPError](err)
+	if !ok {
 		t.Fatal("expected HTTPError")
 	}
 	if hErr.StatusCode != 500 {

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -596,14 +596,16 @@ func (w *writer) writeComments(comments []*ast.Comment) error {
 func (w *writer) writeRules(rules []*ast.Rule, comments []*ast.Comment) ([]*ast.Comment, error) {
 	for i, rule := range rules {
 		var err error
-		comments, err = w.insertComments(comments, rule.Location)
-		if err != nil && !errors.As(err, &unexpectedCommentError{}) {
-			w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+		if comments, err = w.insertComments(comments, rule.Location); err != nil {
+			if _, ok := errors.AsType[unexpectedCommentError](err); !ok {
+				w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+			}
 		}
 
-		comments, err = w.writeRule(rule, false, comments)
-		if err != nil && !errors.As(err, &unexpectedCommentError{}) {
-			w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+		if comments, err = w.writeRule(rule, false, comments); err != nil {
+			if _, ok := errors.AsType[unexpectedCommentError](err); !ok {
+				w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+			}
 		}
 
 		if i < len(rules)-1 && w.groupableOneLiner(rule) {
@@ -671,9 +673,7 @@ func (w *writer) writeRule(rule *ast.Rule, isElse bool, comments []*ast.Comment)
 	var unexpectedComment bool
 	comments, err = w.writeHead(rule.Head, rule.Default, isExpandedConst, comments)
 	if err != nil {
-		if errors.As(err, &unexpectedCommentError{}) {
-			unexpectedComment = true
-		} else {
+		if unexpectedComment = isUnexpectedCommentError(err); !unexpectedComment {
 			return nil, err
 		}
 	}
@@ -739,7 +739,7 @@ func (w *writer) writeRule(rule *ast.Rule, isElse bool, comments []*ast.Comment)
 	comments, err = w.writeBody(rule.Body, comments)
 	if err != nil {
 		// the unexpected comment error is passed up to be handled by writeHead
-		if !errors.As(err, &unexpectedCommentError{}) {
+		if _, ok := errors.AsType[unexpectedCommentError](err); !ok {
 			return nil, err
 		}
 	}
@@ -976,9 +976,10 @@ func (w *writer) writeBody(body ast.Body, comments []*ast.Comment) ([]*ast.Comme
 		}
 		w.startLine()
 
-		comments, err = w.writeExpr(expr, comments)
-		if err != nil && !errors.As(err, &unexpectedCommentError{}) {
-			w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+		if comments, err = w.writeExpr(expr, comments); err != nil {
+			if _, ok := errors.AsType[unexpectedCommentError](err); !ok {
+				w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
+			}
 		}
 		w.endLine()
 	}
@@ -1209,11 +1210,9 @@ func (w *writer) writeEvery(every *ast.Every, loc *ast.Location, comments []*ast
 	}
 	w.write(" {")
 	comments, err = w.writeComprehensionBody('{', '}', every.Body, loc, loc, comments)
-	if err != nil {
+	if err != nil && !isUnexpectedCommentError(err) {
 		// the unexpected comment error is passed up to be handled by writeHead
-		if !errors.As(err, &unexpectedCommentError{}) {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	if len(every.Body) == 1 &&
@@ -1246,10 +1245,8 @@ func (w *writer) writeNot(not *ast.Not, loc *ast.Location, comments []*ast.Comme
 
 		w.write("{")
 		comments, err = w.writeComprehensionBody('{', '}', not.Body, loc, loc, comments)
-		if err != nil {
-			if !errors.As(err, &unexpectedCommentError{}) {
-				return nil, err
-			}
+		if err != nil && !isUnexpectedCommentError(err) {
+			return nil, err
 		}
 
 		if last := not.Body[len(not.Body)-1]; last.Location != nil && last.Location.Row == loc.Row {
@@ -1263,10 +1260,8 @@ func (w *writer) writeNot(not *ast.Not, loc *ast.Location, comments []*ast.Comme
 		}
 
 		comments, err = w.writeExpr(not.Body[0], comments)
-		if err != nil {
-			if !errors.As(err, &unexpectedCommentError{}) {
-				return nil, err
-			}
+		if err != nil && !isUnexpectedCommentError(err) {
+			return nil, err
 		}
 
 		if parens {
@@ -1345,7 +1340,7 @@ func (w *writer) writeLogical(expr *ast.Expr, comments []*ast.Comment) ([]*ast.C
 	lhs, steps := flattenLogical(expr)
 
 	comments, err := w.writeLogicalOperand(lhs, comments)
-	if err != nil && !errors.As(err, &unexpectedCommentError{}) {
+	if err != nil && !isUnexpectedCommentError(err) {
 		return comments, err
 	}
 
@@ -1367,7 +1362,7 @@ func (w *writer) writeLogical(expr *ast.Expr, comments []*ast.Comment) ([]*ast.C
 		}
 
 		comments, err = w.writeLogicalOperand(s.rhs, comments)
-		if err != nil && !errors.As(err, &unexpectedCommentError{}) {
+		if err != nil && !isUnexpectedCommentError(err) {
 			return comments, err
 		}
 	}
@@ -1398,10 +1393,8 @@ func (w *writer) writeLogicalOperand(o logicalOperand, comments []*ast.Comment) 
 
 	w.write("{")
 	comments, err := w.writeComprehensionBody('{', '}', o.body, o.brace, o.brace, comments)
-	if err != nil {
-		if !errors.As(err, &unexpectedCommentError{}) {
-			return comments, err
-		}
+	if err != nil && !isUnexpectedCommentError(err) {
+		return comments, err
 	}
 
 	if last := o.body[len(o.body)-1]; last.Location != nil && last.Location.Row == o.brace.Row {
@@ -1623,14 +1616,12 @@ func (w *writer) writeWith(with *ast.With, comments []*ast.Comment, indented boo
 	}
 	w.write(" as ")
 	comments, err = w.writeTerm(with.Value, comments)
-	if err != nil {
+	if err != nil && !isUnexpectedCommentError(err) {
 		// An unexpectedCommentError from writeTerm signals that it fell
 		// back to writing the term's original unformatted text — the value
 		// was written successfully, so don't abort the surrounding chain
 		// of `with` clauses (issue #8765).
-		if !errors.As(err, &unexpectedCommentError{}) {
-			return comments, err
-		}
+		return comments, err
 	}
 	return comments, nil
 }
@@ -1659,7 +1650,7 @@ func (w *writer) writeTerm(term *ast.Term, comments []*ast.Comment) ([]*ast.Comm
 
 	comments, err := w.writeTermParens(false, term, comments)
 	if err != nil {
-		if errors.As(err, &unexpectedCommentError{}) {
+		if isUnexpectedCommentError(err) {
 			w.buf.Truncate(currentLen)
 			w.level = currentLevel
 
@@ -1921,7 +1912,7 @@ func (w *writer) writeRef(x ast.Ref, comments []*ast.Comment) ([]*ast.Comment, e
 				w.write("[")
 				comments, err = w.writeTerm(t, comments)
 				if err != nil {
-					if errors.As(err, &unexpectedCommentError{}) {
+					if _, ok := errors.AsType[unexpectedCommentError](err); ok {
 						// add a new line so that the closing bracket isn't part of the unexpected comment
 						w.write("\n")
 					} else {
@@ -3069,4 +3060,9 @@ func isRegoV1Compatible(imp *ast.Import) bool {
 	return len(path) == 2 &&
 		ast.RegoRootDocument.Equal(path[0]) &&
 		path[1].Equal(ast.InternedTerm("v1"))
+}
+
+func isUnexpectedCommentError(err error) bool {
+	_, ok := errors.AsType[unexpectedCommentError](err)
+	return ok
 }

--- a/v1/plugins/bundle/errors.go
+++ b/v1/plugins/bundle/errors.go
@@ -31,17 +31,13 @@ type Error struct {
 }
 
 func NewBundleError(bundleName string, cause error) Error {
-	var (
-		httpError download.HTTPError
-	)
-	switch {
-	case cause == nil:
+	if cause == nil {
 		return Error{BundleName: bundleName, Code: "", HTTPCode: -1, Message: "", Err: nil}
-	case errors.As(cause, &httpError):
-		return Error{BundleName: bundleName, Code: errCode, HTTPCode: httpError.StatusCode, Message: httpError.Error(), Err: cause}
-	default:
-		return Error{BundleName: bundleName, Code: errCode, HTTPCode: -1, Message: cause.Error(), Err: cause}
 	}
+	if httpError, ok := errors.AsType[download.HTTPError](cause); ok {
+		return Error{BundleName: bundleName, Code: errCode, HTTPCode: httpError.StatusCode, Message: httpError.Error(), Err: cause}
+	}
+	return Error{BundleName: bundleName, Code: errCode, HTTPCode: -1, Message: cause.Error(), Err: cause}
 }
 
 func (e Error) Error() string {

--- a/v1/plugins/bundle/errors_test.go
+++ b/v1/plugins/bundle/errors_test.go
@@ -46,8 +46,8 @@ func TestUnwrap(t *testing.T) {
 	errs := Errors{serverHTTPError, clientHTTPError, NewBundleError("ast", astErrors)}
 
 	// unwrap first bundle.Error
-	var bundleError Error
-	if !errors.As(errs, &bundleError) {
+	bundleError, ok := errors.AsType[Error](errs)
+	if !ok {
 		t.Fatal("failed to unwrap Error")
 	}
 	if bundleError.Error() != serverHTTPError.Error() {
@@ -55,8 +55,8 @@ func TestUnwrap(t *testing.T) {
 	}
 
 	// unwrap first HTTPError
-	var httpError download.HTTPError
-	if !errors.As(errs, &httpError) {
+	httpError, ok := errors.AsType[download.HTTPError](errs)
+	if !ok {
 		t.Fatal("failed to unwrap Error")
 	}
 	if httpError.Error() != serverHTTPError.Err.Error() {
@@ -64,15 +64,16 @@ func TestUnwrap(t *testing.T) {
 	}
 
 	// unwrap HTTPError from bundle.Error
-	if !errors.As(bundleError, &httpError) {
+	httpError, ok = errors.AsType[download.HTTPError](bundleError)
+	if !ok {
 		t.Fatal("failed to unwrap HTTPError")
 	}
 	if httpError.Error() != serverHTTPError.Err.Error() {
 		t.Fatalf("expected: %v \nbgot: %v", serverHTTPError.Err, httpError)
 	}
 
-	var unwrappedAstErrors ast.Errors
-	if !errors.As(errs, &unwrappedAstErrors) {
+	unwrappedAstErrors, ok := errors.AsType[ast.Errors](errs)
+	if !ok {
 		t.Fatal("failed to unwrap ast.Errors")
 	}
 	if unwrappedAstErrors.Error() != astErrors.Error() {

--- a/v1/plugins/bundle/status.go
+++ b/v1/plugins/bundle/status.go
@@ -63,18 +63,12 @@ func (s *Status) SetBundleSize(size int) {
 // SetError updates the status object to reflect a failure to download or
 // activate. If err is nil, the error status is cleared.
 func (s *Status) SetError(err error) {
-	var (
-		astErrors ast.Errors
-		httpError download.HTTPError
-	)
-	switch {
-	case err == nil:
+	if err == nil {
 		s.Code = ""
 		s.HTTPCode = ""
 		s.Message = ""
 		s.Errors = nil
-
-	case errors.As(err, &astErrors):
+	} else if astErrors, ok := errors.AsType[ast.Errors](err); ok {
 		s.Code = errCode
 		s.HTTPCode = ""
 		s.Message = types.MsgCompileModuleError
@@ -82,14 +76,12 @@ func (s *Status) SetError(err error) {
 		for i := range astErrors {
 			s.Errors[i] = astErrors[i]
 		}
-
-	case errors.As(err, &httpError):
+	} else if httpError, ok := errors.AsType[download.HTTPError](err); ok {
 		s.Code = errCode
 		s.HTTPCode = json.Number(strconv.Itoa(httpError.StatusCode))
 		s.Message = err.Error()
 		s.Errors = nil
-
-	default:
+	} else {
 		s.Code = errCode
 		s.HTTPCode = ""
 		s.Message = err.Error()

--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -690,7 +690,7 @@ func (p *Plugin) flushDecisions(ctx context.Context) {
 
 	go func(ctx context.Context, done chan bool) {
 		for ctx.Err() == nil {
-			if err := p.b.Upload(ctx); err != nil && !errors.Is(err, &bufferEmpty{}) {
+			if err := p.b.Upload(ctx); err != nil && !util.ErrorIs[*bufferEmpty](err) {
 				p.logger.Error("Error flushing decisions: %s", err)
 				// Wait some before retrying, but skip incrementing interval since we are shutting down
 				time.Sleep(1 * time.Second)
@@ -972,13 +972,12 @@ func (*uploadCancelled) Error() string {
 	return "cancelled upload"
 }
 
-func (p *Plugin) doOneShot(ctx context.Context) error {
-	err := p.b.Upload(ctx)
-	if err != nil {
-		if errors.Is(err, &bufferEmpty{}) {
+func (p *Plugin) doOneShot(ctx context.Context) (err error) {
+	if err = p.b.Upload(ctx); err != nil {
+		if util.ErrorIs[*bufferEmpty](err) {
 			p.logger.Debug("Log upload queue was empty.")
 			err = nil
-		} else if errors.Is(err, &uploadCancelled{}) {
+		} else if util.ErrorIs[*uploadCancelled](err) {
 			err = nil
 		} else {
 			p.logger.Error("%v.", err)
@@ -1006,7 +1005,7 @@ func (p *Plugin) reconfigure(ctx context.Context, config any) {
 	p.config = *newConfig
 
 	// upload all events in the current buffer type
-	if err := p.b.Upload(ctx); err != nil && !errors.Is(err, &bufferEmpty{}) {
+	if err := p.b.Upload(ctx); err != nil && !util.ErrorIs[*bufferEmpty](err) {
 		p.setStatus(err)
 	}
 	p.b.Stop(ctx)

--- a/v1/plugins/logs/status/status.go
+++ b/v1/plugins/logs/status/status.go
@@ -30,22 +30,15 @@ type Status struct {
 // SetError updates the status object to reflect a failure to upload or
 // process a log. If err is nil, the error status is cleared.
 func (s *Status) SetError(err error) {
-	var httpError HTTPError
-
-	switch {
-	case err == nil:
+	s.Code = errCode
+	s.HTTPCode = ""
+	if err == nil {
 		s.Code = ""
-		s.HTTPCode = ""
 		s.Message = ""
-
-	case errors.As(err, &httpError):
-		s.Code = errCode
+	} else if httpError, ok := errors.AsType[HTTPError](err); ok {
 		s.HTTPCode = json.Number(strconv.Itoa(httpError.StatusCode))
 		s.Message = err.Error()
-
-	default:
-		s.Code = errCode
-		s.HTTPCode = ""
+	} else {
 		s.Message = err.Error()
 	}
 }

--- a/v1/plugins/rest/aws_test.go
+++ b/v1/plugins/rest/aws_test.go
@@ -1191,7 +1191,7 @@ func TestWebIdentityCredentialService(t *testing.T) {
 		t.Setenv("AWS_ROLE_ARN", "BrokenRole")
 		_ = cs.populateFromEnv()
 		cs.expiration = time.Now()
-		creds, err = cs.credentials(t.Context())
+		_, err = cs.credentials(t.Context())
 		assertErr("failed to parse credential response from STS service: EOF", err, t)
 	})
 }

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -2979,11 +2979,9 @@ func iteration(x any) bool {
 			}
 		case ast.Ref:
 			if !stopped {
-				if bi := ast.BuiltinMap[x.String()]; bi != nil {
-					if bi.Relation {
-						stopped = true
-						return stopped
-					}
+				if bi := ast.BuiltinMap[x.String()]; bi != nil && bi.Relation {
+					stopped = true
+					return stopped
 				}
 				for i := 1; i < len(x); i++ {
 					if _, ok := x[i].Value.(ast.Var); ok {

--- a/v1/rego/rego_external_source_test.go
+++ b/v1/rego/rego_external_source_test.go
@@ -317,8 +317,8 @@ allow if data.external.authz.foo("bar")`
 		if err == nil {
 			t.Fatal("Expected error when calling external function with argument, but got none")
 		}
-		var errs ast.Errors
-		if !errors.As(err, &errs) {
+		errs, ok := errors.AsType[ast.Errors](err)
+		if !ok {
 			t.Fatalf("Expected ast.Errors, got: %T: %v", err, err)
 		}
 		if !slices.ContainsFunc(errs, func(e *ast.Error) bool { return e.Code == ast.TypeErr }) {

--- a/v1/sdk/opa.go
+++ b/v1/sdk/opa.go
@@ -552,7 +552,7 @@ const (
 func undefinedDecisionErr(path string) *Error {
 	return &Error{
 		Code:    UndefinedErr,
-		Message: fmt.Sprintf("%v decision was undefined", path),
+		Message: path + " decision was undefined",
 	}
 }
 

--- a/v1/server/types/types.go
+++ b/v1/server/types/types.go
@@ -617,12 +617,12 @@ type BadRequestErr string
 // BadPatchOperationErr returns BadRequestErr indicating the patch operation was
 // invalid.
 func BadPatchOperationErr(op string) error {
-	return BadRequestErr(fmt.Sprintf("bad patch operation: %v", op))
+	return BadRequestErr("bad patch operation: " + op)
 }
 
 // BadPatchPathErr returns BadRequestErr indicating the patch path was invalid.
 func BadPatchPathErr(path string) error {
-	return BadRequestErr(fmt.Sprintf("bad patch path: %v", path))
+	return BadRequestErr("bad patch path: " + path)
 }
 
 func (err BadRequestErr) Error() string {

--- a/v1/storage/disk/txn_test.go
+++ b/v1/storage/disk/txn_test.go
@@ -58,8 +58,7 @@ func TestSetTxnIsTooBigToFitIntoOneRequestWhenUseDiskStoreReturnsError(t *testin
 	}
 
 	_, err = storage.ReadOne(ctx, s, storage.MustParsePath("/foo"))
-	var notFound *storage.Error
-	ok := errors.As(err, &notFound)
+	notFound, ok := errors.AsType[*storage.Error](err)
 	if !ok {
 		t.Errorf("expected %T, got %v", notFound, err)
 	}

--- a/v1/storage/errors.go
+++ b/v1/storage/errors.go
@@ -52,37 +52,22 @@ func (err *Error) Error() string {
 
 // IsNotFound returns true if this error is a NotFoundErr.
 func IsNotFound(err error) bool {
-	if err, ok := err.(*Error); ok {
-		return err.Code == NotFoundErr
-	}
-	return false
+	return isError(err, NotFoundErr)
 }
 
 // IsWriteConflictError returns true if this error a WriteConflictErr.
 func IsWriteConflictError(err error) bool {
-	switch err := err.(type) {
-	case *Error:
-		return err.Code == WriteConflictErr
-	}
-	return false
+	return isError(err, WriteConflictErr)
 }
 
 // IsInvalidPatch returns true if this error is a InvalidPatchErr.
 func IsInvalidPatch(err error) bool {
-	switch err := err.(type) {
-	case *Error:
-		return err.Code == InvalidPatchErr
-	}
-	return false
+	return isError(err, InvalidPatchErr)
 }
 
 // IsInvalidTransaction returns true if this error is a InvalidTransactionErr.
 func IsInvalidTransaction(err error) bool {
-	switch err := err.(type) {
-	case *Error:
-		return err.Code == InvalidTransactionErr
-	}
-	return false
+	return isError(err, InvalidTransactionErr)
 }
 
 // IsIndexingNotSupported is a stub for backwards-compatibility.
@@ -114,4 +99,9 @@ func policyNotSupportedError() *Error {
 	return &Error{
 		Code: PolicyNotSupportedErr,
 	}
+}
+
+func isError(err error, code string) bool {
+	e, ok := err.(*Error)
+	return ok && e.Code == code
 }

--- a/v1/tester/runner_test.go
+++ b/v1/tester/runner_test.go
@@ -1248,8 +1248,8 @@ func TestResultUnmarshalJSONEvalError(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 
-	var tdErr *topdown.Error
-	if !errors.As(result.Error, &tdErr) {
+	tdErr, ok := errors.AsType[*topdown.Error](result.Error)
+	if !ok {
 		t.Fatalf("Expected *topdown.Error, got %T", result.Error)
 	}
 

--- a/v1/topdown/errors.go
+++ b/v1/topdown/errors.go
@@ -12,6 +12,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
+var cancelErr = &Error{Code: CancelErr}
+
 // Halt is a special error type that built-in function implementations return to indicate
 // that policy evaluation should stop immediately.
 type Halt struct {
@@ -34,7 +36,6 @@ type Error struct {
 }
 
 const (
-
 	// InternalErr represents an unknown evaluation error.
 	InternalErr string = "eval_internal_error"
 
@@ -62,13 +63,13 @@ const (
 
 // IsError returns true if the err is an Error.
 func IsError(err error) bool {
-	var e *Error
-	return errors.As(err, &e)
+	_, ok := errors.AsType[*Error](err)
+	return ok
 }
 
 // IsCancel returns true if err was caused by cancellation.
 func IsCancel(err error) bool {
-	return errors.Is(err, &Error{Code: CancelErr})
+	return errors.Is(err, cancelErr)
 }
 
 // Is allows matching topdown errors using errors.Is (see IsCancel).

--- a/v1/topdown/errors_test.go
+++ b/v1/topdown/errors_test.go
@@ -13,7 +13,8 @@ func TestErrorWrapping(t *testing.T) {
 	t.Parallel()
 
 	isHalt := func(err error) bool {
-		return errors.As(err, &topdown.Halt{})
+		_, ok := errors.AsType[topdown.Halt](err)
+		return ok
 	}
 
 	builtinErr := errors.New("builtin error")

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -2532,12 +2532,12 @@ type deferredEarlyExitContainer struct {
 }
 
 func (dc *deferredEarlyExitContainer) handleErr(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if dc.deferred == nil && errors.As(err, &dc.deferred) && dc.deferred != nil {
-		return nil
+	if err != nil && dc.deferred == nil {
+		var ok bool
+		dc.deferred, ok = errors.AsType[*deferredEarlyExitError](err)
+		if ok && dc.deferred != nil {
+			return nil
+		}
 	}
 
 	return err

--- a/v1/topdown/eval_test.go
+++ b/v1/topdown/eval_test.go
@@ -1718,8 +1718,8 @@ func TestEvalBuiltinUnevaluatedOperand(t *testing.T) {
 				t.Fatalf("expected error but got results: %v", qrs)
 			}
 
-			var topdownErr *Error
-			if !errors.As(err, &topdownErr) {
+			topdownErr, ok := errors.AsType[*Error](err)
+			if !ok {
 				t.Fatalf("expected *topdown.Error but got %#v", err)
 			}
 
@@ -1799,8 +1799,8 @@ func TestEvalBuiltinUnevaluatedVariadicOperand(t *testing.T) {
 
 	_, err := query.Run(t.Context())
 
-	var topdownErr *Error
-	if !errors.As(err, &topdownErr) {
+	topdownErr, ok := errors.AsType[*Error](err)
+	if !ok {
 		t.Fatalf("expected *topdown.Error but got %#v", err)
 	}
 

--- a/v1/topdown/external_source_test.go
+++ b/v1/topdown/external_source_test.go
@@ -396,8 +396,8 @@ check if data.authz.allow`)
 	if err == nil {
 		t.Fatal("Expected compilation error from external source, got nil")
 	}
-	var errs ast.Errors
-	if !errors.As(err, &errs) {
+	errs, ok := errors.AsType[ast.Errors](err)
+	if !ok {
 		t.Fatalf("Expected ast.Errors, got: %T: %v", err, err)
 	}
 	if !slices.ContainsFunc(errs, func(e *ast.Error) bool { return e.Code == ast.UnsafeVarErr }) {

--- a/v1/util/errors.go
+++ b/v1/util/errors.go
@@ -1,0 +1,11 @@
+package util
+
+import "errors"
+
+// ErrorIs is a shorthand for [errors.AsType] returning only the boolean result.
+// This is typically cheaper than [errors.Is], but it's not a drop-in replacement
+// for scenario where e.g. custom `Is` methods need to be taken into account.
+func ErrorIs[E error](err error) bool {
+	_, ok := errors.AsType[E](err)
+	return ok
+}


### PR DESCRIPTION
Generic implementation > throwaway pointers.

With that in place, configure the `forbidigo` linter to flag all use of `errors.As` from here on. If there's any reason not to that I missed, we can of course revert it later. But at least no occurence in our current codebase that wasn't easily replaced by `errors.AsType`.

Also some general error handling improvements while at it.