### PR TITLE
fix(topdown): bound regex template cache to prevent unbounded growth

### DIFF
--- a/v1/topdown/regex.go
+++ b/v1/topdown/regex.go
@@ -165,6 +165,13 @@ func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, e
 			return nil, err
 		}
 		regexpCacheLock.Lock()
+		if len(regexpCache) >= regexCacheMaxSize {
+			// Delete a (semi-)random key to make room for the new one.
+			for k := range regexpCache {
+				delete(regexpCache, k)
+				break
+			}
+		}
 		regexpCache[pat] = re
 		regexpCacheLock.Unlock()
 	}


### PR DESCRIPTION
getRegexpTemplate bypasses the regexCacheMaxSize guard that getRegexp enforces. Repeated calls to builtinRegexMatchTemplate cause the shared regexCache to grow without bound, and existing cleanup in getRegexp only removes one entry at a time.

Add the same size check in getRegexpTemplate before inserting into the cache.

Fixes #9087