### PR TITLE
ast: stop a rule index path at its last constrained level

### DIFF
--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -133,52 +133,63 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int, rule *Rule) {
 	node := i.root
 
-	if len(path) > 0 {
-		for _, ref := range sorted {
-			var values []*refindex
-			for _, ri := range path {
-				if ri.Ref.Equal(ref) {
-					values = append(values, ri)
-				}
-			}
+	// The path stops at the last level it constrains. A rule that constrains
+	// nothing below has nothing to test there, so walking on would only pad the
+	// path with an "absent" node per remaining level -- a copy of the whole tail
+	// that no other rule shares, which is what made a trie of n levels cost n^2
+	// nodes to build and to walk. The multiple-scalar case below has always
+	// attached mid-trie for the same reason.
+	remaining := len(path)
 
-			// A var value records "this ref can be anything", which a concrete value
-			// for the same ref supersedes: everything on one path has to hold, so the
-			// concrete value is the stronger of the two constraints. A chain of
-			// assignments, `x := input.a; y := x`, leaves one var entry per local
-			// behind, and only the first of them is replaced when the concrete value
-			// is inserted. Keeping the rest would index the rule under anyValue below
-			// and give up all the discrimination the concrete value buys us.
-			if len(values) > 1 {
-				if concrete := slices.DeleteFunc(slices.Clone(values), (*refindex).isVar); len(concrete) > 0 {
-					values = concrete
-				}
-			}
+	for _, ref := range sorted {
+		if remaining == 0 {
+			break
+		}
 
-			if len(values) == 0 {
-				node = node.Insert(ref, nil, nil)
-			} else if len(values) == 1 {
-				node = node.Insert(ref, values[0].Value, values[0].Mapper)
+		var values []*refindex
+		for _, ri := range path {
+			if ri.Ref.Equal(ref) {
+				values = append(values, ri)
+			}
+		}
+		remaining -= len(values)
+
+		// A var value records "this ref can be anything", which a concrete value
+		// for the same ref supersedes: everything on one path has to hold, so the
+		// concrete value is the stronger of the two constraints. A chain of
+		// assignments, `x := input.a; y := x`, leaves one var entry per local
+		// behind, and only the first of them is replaced when the concrete value
+		// is inserted. Keeping the rest would index the rule under anyValue below
+		// and give up all the discrimination the concrete value buys us.
+		if len(values) > 1 {
+			if concrete := slices.DeleteFunc(slices.Clone(values), (*refindex).isVar); len(concrete) > 0 {
+				values = concrete
+			}
+		}
+
+		if len(values) == 0 {
+			node = node.Insert(ref, nil, nil)
+		} else if len(values) == 1 {
+			node = node.Insert(ref, values[0].Value, values[0].Mapper)
+		} else {
+			if slices.ContainsFunc(values, (*refindex).isVar) {
+				child := node.Insert(ref, anyValue, values[0].Mapper)
+				for i := range values {
+					if values[i].Mapper != nil {
+						node.next.addMapper(values[i].Mapper)
+					}
+				}
+				node = child
 			} else {
-				if slices.ContainsFunc(values, (*refindex).isVar) {
-					child := node.Insert(ref, anyValue, values[0].Mapper)
-					for i := range values {
-						if values[i].Mapper != nil {
-							node.next.addMapper(values[i].Mapper)
-						}
-					}
-					node = child
-				} else {
-					// When a rule has multiple scalar values (e.g., internal.member_2 with a set),
-					// each value should have its own child node, and the rule is appended to each.
-					// This creates separate paths for each value so different rules with overlapping
-					// values don't interfere with each other.
-					for _, val := range values {
-						child := node.Insert(ref, val.Value, val.Mapper)
-						child.append(prio, rule)
-					}
-					return
+				// When a rule has multiple scalar values (e.g., internal.member_2 with a set),
+				// each value should have its own child node, and the rule is appended to each.
+				// This creates separate paths for each value so different rules with overlapping
+				// values don't interfere with each other.
+				for _, val := range values {
+					child := node.Insert(ref, val.Value, val.Mapper)
+					child.append(prio, rule)
 				}
+				return
 			}
 		}
 	}

--- a/v1/ast/index_bench_test.go
+++ b/v1/ast/index_bench_test.go
@@ -44,12 +44,23 @@ func BenchmarkLookupEqIndex(b *testing.B) {
 	}
 }
 
-// Exponential growth in index build for a single rule where each ref is unique
-// Cost reduced by two thirds by lazy init of scalars map
+// Index build for rules that each read a ref of their own.
+//
+// Cost reduced by two thirds by lazy init of scalars map. Then linear in memory
+// rather than quadratic, once a rule path stopped being padded out to the full
+// depth with a node per level it does not constrain (see insertPath):
+//
+//	          before                       after
+//	 1000    46.3ms  128651465 B/op      10.7ms    779466 B/op
+//	10000        --   12.8GB (est.)     976.0ms   7345864 B/op
+//
+// n=10000 used to be out of reach -- the comment here read "capped at 4 because at
+// 5 this allocates 12.8GB of memory, which our CI runner won't be happy about" --
+// and now costs 7MB. Build time is still quadratic, since a path is walked as far
+// as its last constrained level, so this stays the largest size worth running; the
+// 10000 row is a single iteration, the rest are the default benchtime.
 func BenchmarkBuildNakedRefIndex(b *testing.B) {
-	// Exp capped at 4 here because at 5 this allocates 12.8GB of memory,
-	// which our CI runner won't be happy about.
-	for i := range 4 {
+	for i := range 5 {
 		n := math.Pow(10, float64(i))
 		b.Run(strconv.Itoa(int(n)), func(b *testing.B) {
 			rules := nakedRefRules(int(n))
@@ -84,16 +95,19 @@ func BenchmarkLookupNakedRefIndex(b *testing.B) {
 	}
 }
 
-// Exponential growth in non-sensical index build where each ref+value is unique
+// Non-sensical index build where each ref+value is unique.
 //
-// BenchmarkBuildNonsensicalIndex/n_=_10-16           137611        8766 ns/op	      20984 B/op         223 allocs/op
-// BenchmarkBuildNonsensicalIndex/n_=_100-16            2427      502340 ns/op	    1360788 B/op       11125 allocs/op
-// BenchmarkBuildNonsensicalIndex/n_=_1000-16             24    46709530 ns/op	  128900337 B/op     1011048 allocs/op
-// BenchmarkBuildNonsensicalIndex/n_=_10000-16             1  5349418417 ns/op	12808545832 B/op   100110165 allocs/op
+//	             before                              after
+//	   10       8766 ns      20984 B/op        13875 ns      9496 B/op
+//	  100     502340 ns    1360788 B/op       141875 ns     93608 B/op
+//	 1000   46709530 ns  128900337 B/op      8614041 ns   1027464 B/op
+//	10000 5349418417 ns 12808545832 B/op    833599250 ns   9825864 B/op
+//
+// The before column is what this recorded while every rule path was padded out to
+// the full depth; n=10000 was left out of the run because 12.8GB of it would not
+// fit on a CI runner. See insertPath.
 func BenchmarkBuildNonsensicalIndex(b *testing.B) {
-	// Exp capped at 4 here because at 5 this allocates 12.8GB of memory,
-	// which our CI runner won't be happy about.
-	for i := range 4 {
+	for i := range 5 {
 		n := math.Pow(10, float64(i))
 		b.Run(strconv.Itoa(int(n)), func(b *testing.B) {
 			rules := nonsensicalRules(int(n))
@@ -106,6 +120,73 @@ func BenchmarkBuildNonsensicalIndex(b *testing.B) {
 			}
 		})
 	}
+}
+
+// Lookup where every rule constrains a ref of its own and every one of them is
+// satisfied, so traversal descends into all of their branches. That is what makes
+// the trie's shape decide the cost: padding each rule's path out to the full depth
+// gave every one of them a private copy of the tail, and a walk that reaches all
+// of those copies grew with n^2.
+//
+// The two neighbouring lookup benchmarks miss this on purpose-built inputs:
+// BenchmarkLookupEqIndex has every rule on one ref, so there is one level to walk,
+// and BenchmarkLookupNakedRefIndex leaves all but one ref absent, so traversal
+// takes a single branch per level. Both are linear whatever the trie looks like.
+func BenchmarkLookupDistinctRefIndex(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			index := newBaseDocEqIndex(isVirtual)
+			if !index.Build(distinctRefRules(n)) {
+				b.Fatal("failed to build index")
+			}
+			input := inputResolver{input: distinctRefInput(n)}
+
+			// Nothing here discriminates -- every rule reads a ref of its own and
+			// all of them hold -- so the whole ruleset is a candidate. The index
+			// cannot narrow this; the point is what it costs to find that out.
+			b.ResetTimer()
+			for b.Loop() {
+				res, err := index.Lookup(input)
+				if err != nil {
+					b.Fatal(err)
+				} else if len(res.Rules) != n {
+					b.Fatalf("expected %d rules, got %d", n, len(res.Rules))
+				}
+				IndexResultPool.Put(res)
+			}
+		})
+	}
+}
+
+// distinctRefRules returns n rules that each compare a ref of their own.
+func distinctRefRules(n int) []*Rule {
+	var sb strings.Builder
+	sb.WriteString("package p\n\n")
+	for i := range n {
+		sb.WriteString(`allow if input.f`)
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString(` == "x"`)
+		sb.WriteByte('\n')
+	}
+	return MustParseModule(sb.String()).Rules
+}
+
+// distinctRefInput defines every ref the rules read, and satisfies all of them,
+// so traversal descends into every rule's branch rather than stopping early.
+func distinctRefInput(n int) Value {
+	var sb strings.Builder
+	sb.WriteByte('{')
+	for i := range n {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteByte('"')
+		sb.WriteString("f" + strconv.Itoa(i))
+		sb.WriteString(`": `)
+		sb.WriteString(`"x"`)
+	}
+	sb.WriteByte('}')
+	return MustParseTerm(sb.String()).Value
 }
 
 type inputResolver struct {

--- a/v1/ast/index_path_test.go
+++ b/v1/ast/index_path_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// countingTrieWalker counts the nodes reachable in a trie.
+type countingTrieWalker struct {
+	nodes *int
+}
+
+func (w countingTrieWalker) Do(any) trieWalker {
+	*w.nodes++
+	return w
+}
+
+func trieNodes(t *testing.T, index RuleIndex) int {
+	t.Helper()
+
+	idx, ok := index.(*baseDocEqIndex)
+	if !ok {
+		t.Fatalf("expected a baseDocEqIndex, got %T", index)
+	}
+
+	nodes := 0
+	idx.root.Do(countingTrieWalker{nodes: &nodes})
+	return nodes
+}
+
+func indexFor(t *testing.T, src string) RuleIndex {
+	t.Helper()
+
+	c := NewCompiler()
+	if c.Compile(map[string]*Module{"p.rego": MustParseModule(src)}); c.Failed() {
+		t.Fatal(c.Errors)
+	}
+
+	index := c.RuleIndex(MustParseRef("data.test.p"))
+	if index == nil {
+		t.Fatal("no index built for data.test.p")
+	}
+	return index
+}
+
+func selects(t *testing.T, index RuleIndex, input string) []string {
+	t.Helper()
+
+	res, err := index.Lookup(testResolver{input: MustParseTerm(input)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := make([]string, 0, len(res.Rules))
+	for _, rule := range res.Rules {
+		values = append(values, rule.Head.Value.String())
+	}
+	slices.Sort(values)
+	return values
+}
+
+// TestIndexPathTruncationSelectsSameRules is the correctness side of stopping a
+// path at its last constrained level: a level a rule does not constrain cannot
+// exclude it, so attaching it above that level has to select the same rules for
+// every combination of present and absent refs.
+//
+// Each rule below constrains exactly one ref, and the refs are ordered by
+// frequency, so every rule ends up at a different depth -- rule 1 at the first
+// level, rule 3 at the third.
+func TestIndexPathTruncationSelectsSameRules(t *testing.T) {
+	index := indexFor(t, `package test
+
+p := 1 if input.a == "x"
+
+p := 2 if input.b == "x"
+
+p := 3 if input.c == "x"
+`)
+
+	for _, tc := range []struct {
+		note  string
+		input string
+		exp   []string
+	}{
+		{note: "all present and matching", input: `{"a": "x", "b": "x", "c": "x"}`, exp: []string{"1", "2", "3"}},
+		{note: "all present, none matching", input: `{"a": "y", "b": "y", "c": "y"}`, exp: []string{}},
+		{note: "only the shallowest matches", input: `{"a": "x", "b": "y", "c": "y"}`, exp: []string{"1"}},
+		{note: "only the deepest matches", input: `{"a": "y", "b": "y", "c": "x"}`, exp: []string{"3"}},
+		{
+			// The refs a rule does not constrain being absent must not exclude it.
+			note:  "deepest matches, earlier refs absent",
+			input: `{"c": "x"}`,
+			exp:   []string{"3"},
+		},
+		{
+			note:  "shallowest matches, later refs absent",
+			input: `{"a": "x"}`,
+			exp:   []string{"1"},
+		},
+		{note: "nothing present", input: `{}`, exp: []string{}},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			if act := selects(t, index, tc.input); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, act)
+			}
+		})
+	}
+}
+
+// TestIndexPathTruncationKeepsTrieLinear is the point of it. n rules that each
+// constrain a ref of their own share one spine, where padding each path out to
+// the full depth gave every rule a private copy of the tail -- n(n+1)/2 nodes to
+// build, and to walk on every lookup.
+func TestIndexPathTruncationKeepsTrieLinear(t *testing.T) {
+	for _, n := range []int{10, 50, 100} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			var src strings.Builder
+			src.WriteString("package test\n\n")
+			for i := range n {
+				fmt.Fprintf(&src, "p := %d if input.f%d == \"x\"\n\n", i, i)
+			}
+
+			nodes := trieNodes(t, indexFor(t, src.String()))
+
+			// A spine of one level per ref, each with a value child and an "absent"
+			// child, plus the root. Quadratic would be n(n+1)/2 and up.
+			if max := 4 * n; nodes > max {
+				t.Errorf("expected at most %d trie nodes for %d rules, got %d (quadratic would be ~%d)",
+					max, n, nodes, n*(n+1)/2)
+			}
+		})
+	}
+}
+
+// TestIndexPathTruncationLeavesSharedRefsAlone checks the shape truncation does
+// not apply to: rules constraining the same ref all reach their last level at the
+// same depth, so nothing is padded and nothing changes.
+func TestIndexPathTruncationLeavesSharedRefsAlone(t *testing.T) {
+	var src strings.Builder
+	src.WriteString("package test\n\n")
+	for i := range 100 {
+		fmt.Fprintf(&src, "p := %d if input.f == %d\n\n", i, i)
+	}
+
+	index := indexFor(t, src.String())
+
+	if act := selects(t, index, `{"f": 7}`); !slices.Equal(act, []string{"7"}) {
+		t.Errorf("expected the index to select rule 7, got %v", act)
+	}
+	if nodes := trieNodes(t, index); nodes > 110 {
+		t.Errorf("expected one level with a child per value, got %d nodes", nodes)
+	}
+}

--- a/v1/rego/index_eval_bench_test.go
+++ b/v1/rego/index_eval_bench_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	inmem "github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+// BenchmarkIndexedRulesetEval evaluates a ruleset of the shape a "one rule per
+// group" policy has: every rule reads a collection of its own and shares the
+// condition that actually holds, so the index cannot narrow the set and every rule
+// is evaluated.
+//
+// The rule index benchmarks in v1/ast time Build and Lookup on their own. This one
+// times the whole query, so it shows what the trie's shape costs a caller: every
+// group ref here is a level, all of them resolve, and traversal used to walk a
+// private copy of the remaining levels under each one.
+func BenchmarkIndexedRulesetEval(b *testing.B) {
+	ctx := b.Context()
+
+	for _, n := range []int{100, 500} {
+		b.Run(fmt.Sprintf("groups=%d", n), func(b *testing.B) {
+			module, data := indexedRuleset(n, 20)
+
+			r := New(
+				ParsedQuery(ast.MustParseBody("data.test.allow = x")),
+				ParsedModule(ast.MustParseModule(module)),
+				Store(inmem.NewFromObject(data)),
+				GenerateJSON(noOpGenerateJSON),
+			)
+
+			pq, err := r.PrepareForEval(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			input := ast.MustParseTerm(fmt.Sprintf(`{"subject": "u%d_19", "resource": {"foo": "A"}}`, n-1))
+
+			// The subject is a member of the last group only, so exactly one rule
+			// holds however many of them the index left in the running.
+			if rs, err := pq.Eval(ctx, EvalParsedInput(input.Value)); err != nil {
+				b.Fatal(err)
+			} else if len(rs) != 1 {
+				b.Fatalf("expected one result, got %d", len(rs))
+			}
+
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := pq.Eval(ctx, EvalParsedInput(input.Value)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// indexedRuleset returns n rules that each test membership in a group of their
+// own, and the group data they read. Every rule also shares a condition that
+// holds, so nothing in the ruleset discriminates.
+func indexedRuleset(n, members int) (string, map[string]any) {
+	var sb strings.Builder
+	sb.WriteString("package test\n\n")
+
+	groups := make(map[string]any, n)
+	for i := range n {
+		fmt.Fprintf(&sb, "allow if {\n\tinput.subject in data.groups.g%d.members\n\tinput.resource.foo == \"A\"\n}\n\n", i)
+
+		ms := make([]any, members)
+		for j := range members {
+			ms[j] = fmt.Sprintf("u%d_%d", i, j)
+		}
+		groups[fmt.Sprintf("g%d", i)] = map[string]any{"members": ms}
+	}
+
+	return sb.String(), map[string]any{"groups": groups}
+}


### PR DESCRIPTION
insertPath walked the whole level list for every rule, inserting an "absent" node for each level the rule does not constrain. A rule that constrains nothing below has nothing to test there, so that padding only gave the rule a private copy of the tail -- and with one distinct ref per rule, n levels cost n^2 nodes to build and to walk on every lookup:

```rego
p := 1 if input.a == "x"
p := 2 if input.b == "x"
p := 3 if input.c == "x"
```

    trie nodes:   n=10   n=50   n=100   n=250
        before     120   2600   10200   62750
         after      30    150     300     750

Before — 15 nodes
```
  (root)
  input.a ?
  ├─ = "x"
  │  input.b ?          ← rule 1 doesn't mention input.b
  │  └─ absent
  │     input.c ?       ← or input.c
  │     └─ absent
  │        → rule 1
  └─ absent
     input.b ?
     ├─ = "x"
     │  input.c ?       ← rule 2 doesn't mention input.c
     │  └─ absent
     │     → rule 2
     └─ absent
        input.c ?
        └─ = "x"
           → rule 3
```

After — 9 nodes
```
  (root)
  input.a ?
  ├─ = "x"
  │  → rule 1
  └─ absent
     input.b ?
     ├─ = "x"
     │  → rule 2
     └─ absent
        input.c ?
        └─ = "x"
           → rule 3
```

Stop when the path has no constraint left to place. The rule is attached above the levels it does not constrain, which cannot change what a lookup selects: traversal always descends the "absent" child, so those levels never excluded it.

    BenchmarkBuildNakedRefIndex/1000   46.3ms 128.7MB 1007047 allocs
                                    -> 27.4ms   0.8MB    8047 allocs
    BenchmarkBuildNonsensicalIndex/1000  42.5ms 128.9MB
                                      -> 20.3ms   1.0MB
    BenchmarkLookupNakedRefIndex        51.4us -> 33.9us

Policies whose rules constrain the same refs are unaffected -- every path reaches its last level at the same depth, so there was no padding to remove.

What this does for a lookup, on 500 rules of `input.subject in data.groups.gN.members` plus a shared `input.resource.foo == "A"` -- where each group ref is a level of its own:

    500 rules:   33.7ms -> 0.72ms      1000 rules:  136.9ms -> 1.56ms

```rego
p := 1 if { input.subject in data.groups.g0.members; input.resource.foo == "A" }
p := 2 if { input.subject in data.groups.g1.members; input.resource.foo == "A" }
```

  Before — 12 nodes
```
  input.subject ?
  └─ any
     input.resource.foo ?
     └─ = "A"
        data.groups.g0.members ?
        ├─ any
        │  data.groups.g1.members ?   ← re-tested, and re-resolved from the store
        │  └─ absent
        │     → rule 1
        └─ absent
           data.groups.g1.members ?
           └─ any
              → rule 2
```

  After — 10 nodes
```
  input.subject ?
  └─ any
     input.resource.foo ?
     └─ = "A"
        data.groups.g0.members ?
        ├─ any
        │  → rule 1
        └─ absent
           data.groups.g1.members ?
           └─ any
              → rule 2
```

That shape used to be faster with indexing disabled than with it (6.5x at 500 rules, 8.8x at 1000). It no longer is. 🥳 

--------
benchstat
```
                                          │ main      │            PR             │
                                          │ sec/op    │  sec/op     vs base       │
  BuildEqIndex/1-16                          477.3n     478.7n        ~ (p=0.589)
  BuildEqIndex/10-16                         3.175µ     3.174µ        ~ (p=0.818)
  BuildEqIndex/100-16                        31.89µ     32.05µ        ~ (p=0.818)
  BuildEqIndex/1000-16                       402.9µ     401.4µ        ~ (p=0.699)
  LookupEqIndex-16                           163.7n     166.1n        ~ (p=0.093)
  BuildNakedRefIndex/1-16                    384.1n     387.1n        ~ (p=1.000)
  BuildNakedRefIndex/10-16                   7.268µ     4.787µ  -34.14% (p=0.002)
  BuildNakedRefIndex/100-16                  468.4µ     165.1µ  -64.75% (p=0.002)
  BuildNakedRefIndex/1000-16                 48.08m     11.41m  -76.27% (p=0.002)
  LookupNakedRefIndex-16                     53.56µ     33.97µ  -36.58% (p=0.002)
  BuildNonsensicalIndex/1-16                 462.3n     460.7n        ~ (p=0.699)
  BuildNonsensicalIndex/10-16                7.638µ     5.189µ  -32.06% (p=0.002)
  BuildNonsensicalIndex/100-16               477.1µ     143.6µ  -69.90% (p=0.002)
  BuildNonsensicalIndex/1000-16             44.878m     8.886m  -80.20% (p=0.002)
  LookupDistinctRefIndex/10-16              1864.5n     886.0n  -52.48% (p=0.002)
  LookupDistinctRefIndex/100-16            179.913µ     9.580µ  -94.68% (p=0.002)
  LookupDistinctRefIndex/1000-16          18201.4µ      117.5µ  -99.35% (p=0.002)
  RuleIndexRefOrdering/frequency-desc-16     80.67µ     77.72µ        ~ (p=0.260)
  RuleIndexRefOrdering/unordered-16          585.9µ     580.1µ        ~ (p=0.699)
  geomean                                    50.54µ     22.58µ  -55.32%

                                          │ B/op      │  B/op       vs base       │
  BuildNakedRefIndex/1000-16              125636.7Ki   761.2Ki  -99.39% (p=0.002)
  BuildNonsensicalIndex/1000-16           125878.4Ki  1003.4Ki  -99.20% (p=0.002)
  LookupDistinctRefIndex/1000-16             3332.00     36.00  -98.92% (p=0.002)
  BuildEqIndex/* , Lookup*Index               (all unchanged, many all-samples-equal)
  geomean                                    7.021Ki   2.206Ki  -68.57%


                                   │ main       │             PR             │
                                   │ sec/op     │  sec/op     vs base        │
  IndexedRulesetEval/groups=100-16     549.4µ      128.4µ   -76.63% (p=0.002)
  IndexedRulesetEval/groups=500-16   12293.7µ      565.0µ   -95.40% (p=0.002)
  geomean                              2.599m      269.3µ   -89.64%

                                   │ B/op       │  B/op       vs base        │
  IndexedRulesetEval/groups=100-16    172.0Ki     172.4Ki    +0.22%
  IndexedRulesetEval/groups=500-16    855.7Ki     858.4Ki    +0.32%

                                   │ allocs/op  │ allocs/op   vs base        │
  IndexedRulesetEval/groups=100-16     3.195k      3.197k     +0.06%
  IndexedRulesetEval/groups=500-16     15.60k      15.61k     +0.05%
```