### PR TITLE
download: fix ignored OCI downloader settings

### DIFF
--- a/v1/download/download.go
+++ b/v1/download/download.go
@@ -53,7 +53,6 @@ type Downloader struct {
 	config             Config                              // downloader configuration for tuning polling and other downloader behaviour
 	client             rest.Client                         // HTTP client to use for bundle downloading
 	path               string                              // path to use in bundle download request
-	trigger            chan chan struct{}                  // channel to signal downloads when manual triggering is enabled
 	stop               chan chan struct{}                  // used to signal plugin to stop running
 	f                  func(context.Context, Update) error // callback function invoked when download updates occur
 	etag               string                              // HTTP Etag for caching purposes
@@ -62,7 +61,6 @@ type Downloader struct {
 	respHdrTimeoutSec  int64
 	wg                 sync.WaitGroup
 	logger             logging.Logger
-	stopped            bool
 	stopOnce           sync.Once
 	persist            bool
 	longPollingEnabled bool
@@ -85,7 +83,6 @@ func New(config Config, client rest.Client, path string) *Downloader {
 		config:             config,
 		client:             client,
 		path:               path,
-		trigger:            make(chan chan struct{}),
 		stop:               make(chan chan struct{}),
 		logger:             client.Logger(),
 		longPollingEnabled: config.Polling.LongPollingTimeoutSeconds != nil,
@@ -195,7 +192,6 @@ func (d *Downloader) doStart(context.Context) {
 	done := <-d.stop // blocks until there's something to read
 	cancel()
 	d.wg.Wait()
-	d.stopped = true
 	close(done)
 }
 

--- a/v1/download/download_test.go
+++ b/v1/download/download_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -152,17 +153,39 @@ func TestStopWithMultipleCalls(t *testing.T) {
 		t.Fatal("expected bundle with at least one module but got:", u1)
 	}
 
-	done := make(chan struct{})
-	go func() {
-		d.Stop(ctx)
-		close(done)
-	}()
+	// Stop must be safe to call concurrently and more than once: the first
+	// call shuts the downloader down and any later call is a no-op, rather
+	// than blocking forever on the stop channel.
+	stopReturns := func(n int) bool {
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for range n {
+			go func() {
+				defer wg.Done()
+				d.Stop(ctx)
+			}()
+		}
 
-	d.Stop(ctx)
-	<-done
+		returned := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(returned)
+		}()
 
-	if !d.stopped {
-		t.Fatal("expected downloader to be stopped")
+		select {
+		case <-returned:
+			return true
+		case <-time.After(10 * time.Second):
+			return false
+		}
+	}
+
+	if !stopReturns(2) {
+		t.Fatal("expected concurrent Stop calls to return, but they blocked")
+	}
+
+	if !stopReturns(1) {
+		t.Fatal("expected Stop on an already-stopped downloader to return, but it blocked")
 	}
 }
 

--- a/v1/download/oci_download.go
+++ b/v1/download/oci_download.go
@@ -57,7 +57,6 @@ func NewOCI(config Config, client rest.Client, path, storePath string) *OCIDownl
 		localStorePath:   storePath,
 		localStoreIsTemp: localStoreIsTemp,
 		client:           client,
-		trigger:          make(chan chan struct{}),
 		stop:             make(chan chan struct{}),
 		logger:           client.Logger(),
 		store:            localstore,
@@ -303,12 +302,25 @@ func (d *OCIDownloader) download(ctx context.Context, m metrics.Metrics) (*downl
 	tee := io.TeeReader(r, &buf)
 
 	loader := bundle.NewTarballLoaderWithBaseURL(tee, d.localStorePath)
+
+	// Setting the size limit on the loader allows early exit in the case
+	// of any file exceeding the limit, without the file getting loaded
+	if d.sizeLimitBytes != nil {
+		loader = loader.WithSizeLimitBytes(*d.sizeLimitBytes)
+	}
+
 	reader := bundle.NewCustomReader(loader).
 		WithMetrics(m).
 		WithBundleVerificationConfig(d.bvc).
 		WithBundleEtag(etag).
 		WithRegoVersion(d.bundleParserOpts.RegoVersion).
-		WithProcessAnnotations(d.bundleParserOpts.ProcessAnnotation)
+		WithProcessAnnotations(d.bundleParserOpts.ProcessAnnotation).
+		WithBundlePersistence(d.persist)
+
+	if d.sizeLimitBytes != nil {
+		reader = reader.WithSizeLimitBytes(*d.sizeLimitBytes)
+	}
+
 	bundleInfo, err := reader.Read()
 	if err != nil {
 		return &downloaderResponse{}, fmt.Errorf("unexpected error %w", err)

--- a/v1/download/oci_downloader.go
+++ b/v1/download/oci_downloader.go
@@ -17,7 +17,6 @@ type OCIDownloader struct {
 	path             string                              // path for OCI image as <registry>/<org>/<repo>:<tag>
 	localStorePath   string                              // path for the local OCI storage
 	localStoreIsTemp bool                                // whether localStorePath should be removed when stopping
-	trigger          chan chan struct{}                  // channel to signal downloads when manual triggering is enabled
 	stop             chan chan struct{}                  // used to signal plugin to stop running
 	f                func(context.Context, Update) error // callback function invoked when download updates occur
 	sizeLimitBytes   *int64                              // max bundle file size in bytes (passed to reader)


### PR DESCRIPTION
Running the unused linter with field-writes-are-uses set to false, which is not enabled in .golangci.yaml, flags five fields in this package that are only ever written. Two of them are real bugs.

OCIDownloader.WithSizeLimitBytes and WithBundlePersistence stored their arguments in fields download() never read, so size_limit_bytes went unenforced for OCI bundle sources and the reader's guard on persisted delta bundles could never fire. Wire both through as Downloader does.

The rest are dead: the trigger channel on both downloaders, unused since Trigger() calls oneShot directly, and Downloader.stopped, dead since Stop() moved to sync.Once. TestStopWithMultipleCalls asserted on the latter, a check that could not fail; it now asserts the Stop calls return, the deadlock it guards.
