### PR TITLE
benchmarks: change how we do this

### DIFF
--- a/.github/workflows/benchmarks-nightly.yaml
+++ b/.github/workflows/benchmarks-nightly.yaml
@@ -1,0 +1,203 @@
+name: Benchmarks (nightly)
+
+# The nightly benchlab experiment: a curated benchmark set measured at a fixed
+# baseline, the previous night's commit, and HEAD, with all arms in one benchlab
+# invocation per package so they are interleaved on a single machine.
+#
+# Why nightly and curated rather than per-push and complete: three arms over the
+# full published set is on the order of a day of measurement, and only arms
+# measured together on one machine are comparable. Blanket coverage stays with
+# the (noisier, cross-machine) gobenchdata run that publishes to the benchmarks
+# branch; this workflow buys precision on the evaluation hot paths instead of
+# breadth.
+#
+# See build/bench-nightly/main.go for the reasoning behind the three arms, and
+# build/bench-nightly/set.json for the set itself.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # 02:00 UTC, off the hour to avoid coinciding with the other benchmark
+    # publishers' schedules.
+    - cron: '0 2 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve the experiment once, so that every shard measures the same three
+  # commits. bench-nightly refuses to merge shards that disagree, and that check
+  # is only meaningful if the values come from a single place.
+  plan:
+    name: Plan the experiment
+    runs-on: ubuntu-24.04
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+      baseline_sha: ${{ steps.plan.outputs.baseline_sha }}
+      baseline_tag: ${{ steps.plan.outputs.baseline_tag }}
+      prev_sha: ${{ steps.plan.outputs.prev_sha }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out previous results
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: benchmarks
+          path: results
+          sparse-checkout: benchlab.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Resolve shards, baseline and previous night
+        id: plan
+        run: |
+          set -euo pipefail
+
+          shards=$(jq -c '[.targets[].shard] | unique' build/bench-nightly/set.json)
+          echo "shards=${shards}" >> $GITHUB_OUTPUT
+
+          # The newest v* tag reachable from HEAD. Reachability matters twice:
+          # benchlab has to be able to build it, and the notebook anchors its
+          # charts to a tag it found in the data, which is also a main commit.
+          # Patch tags cut on a release branch are correctly ignored here.
+          baseline_tag=$(git describe --tags --abbrev=0 --match 'v*')
+          baseline_sha=$(git rev-parse "${baseline_tag}^{commit}")
+          echo "baseline_tag=${baseline_tag}" >> $GITHUB_OUTPUT
+          echo "baseline_sha=${baseline_sha}" >> $GITHUB_OUTPUT
+
+          # Last night's HEAD. Empty on the first ever run, which drops the prev
+          # arm and with it that night's calibration.
+          prev_sha=""
+          if [ -f results/benchlab.json ]; then
+            prev_sha=$(jq -r '.[-1].head // ""' results/benchlab.json)
+          fi
+          echo "prev_sha=${prev_sha}" >> $GITHUB_OUTPUT
+
+          echo "shards:       ${shards}"
+          echo "baseline:     ${baseline_sha} (${baseline_tag})"
+          echo "previous:     ${prev_sha:-<none>}"
+          echo "head:         $(git rev-parse HEAD)"
+
+  measure:
+    name: Measure ${{ matrix.shard }}
+    needs: plan
+    runs-on: ubuntu-24.04
+    # Three arms over a shard runs for hours; the hosted-runner ceiling is six.
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # benchlab builds each commit in its own worktree, so it needs the
+          # baseline and previous commits present locally.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: .go-version
+          cache-dependency-path: go.sum
+
+      - name: Install tools
+        run: cd build/tools && go install tool
+
+      - name: Run benchlab
+        env:
+          BASELINE_SHA: ${{ needs.plan.outputs.baseline_sha }}
+          PREV_SHA: ${{ needs.plan.outputs.prev_sha }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          go run ./build/bench-nightly \
+            -shard "$SHARD" \
+            -baseline "$BASELINE_SHA" \
+            -prev "$PREV_SHA" \
+            -out "benchlab.${SHARD}.json"
+
+      - name: Upload results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchlab-${{ matrix.shard }}
+          path: benchlab.${{ matrix.shard }}.json
+          if-no-files-found: error
+
+      - name: Upload raw benchmark output
+        # The raw files are the canonical Go benchmark format and are what makes
+        # a night re-analysable later (different alpha, different confidence)
+        # without re-measuring. Cheap to keep, impossible to recover.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: benchlab-raw-${{ matrix.shard }}
+          path: .benchlab/bench.*.txt
+          if-no-files-found: warn
+
+  publish:
+    name: Publish results
+    needs: [plan, measure]
+    # A shard that fails should cost its own benchmarks, not the whole night.
+    # The merged record lists the shards it actually contains.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # we'll push to the `benchmarks` branch
+    # Only this job writes to the `benchmarks` branch, so only this job belongs
+    # in the group. Holding it for the hours the measurement takes would block
+    # the branch's other writers for no reason.
+    concurrency:
+      group: benchmarks
+      cancel-in-progress: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: opa
+          persist-credentials: false
+
+      - name: Check out results branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: benchmarks
+          path: results
+          persist-credentials: true
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: opa/.go-version
+          cache-dependency-path: opa/go.sum
+
+      - name: Download shard results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: benchlab-*
+          path: shards
+          merge-multiple: true
+
+      - name: Merge shards into benchlab.json
+        working-directory: opa
+        run: |
+          go run ./build/bench-nightly \
+            -merge ../shards \
+            -history ../results/benchlab.json \
+            -keep 120
+
+      - name: Commit if changed
+        working-directory: results
+        run: |
+          set -euo pipefail
+          if git diff-index --quiet HEAD -- benchlab.json; then
+            echo "no changes, no commit"
+            exit 0
+          fi
+          git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --local user.name "${GITHUB_ACTOR}"
+          git add benchlab.json
+          git commit -m "benchmarks: nightly benchlab results for ${GITHUB_SHA}"
+          git push origin benchmarks

--- a/build/bench-nightly/main.go
+++ b/build/bench-nightly/main.go
@@ -1,0 +1,840 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Command bench-nightly runs the nightly benchlab experiment and turns it into
+// the data the benchmarks site charts.
+//
+// Each night a curated set of benchmarks (see set.json) is measured at three
+// commits -- a fixed baseline, the previous night's commit, and HEAD -- with all
+// three passed to a single benchlab invocation per package. benchlab repeats the
+// whole commit list once per rep, so the arms are round-robin interleaved on one
+// machine and drift is spread across them instead of biasing whichever ran
+// first. That interleaving is the only thing that makes the arms comparable, so
+// commits that need comparing must go into the same invocation.
+//
+// Deltas measured on different machines are not comparable, so a trend line
+// cannot be built by chaining each night's "yesterday vs today" measurement:
+// the errors compound and there is no way to re-anchor. Re-measuring a fixed
+// baseline every night keeps "% vs baseline" comparable across nights even
+// though the machines are not. Carrying the previous night's commit along costs
+// one extra arm and buys two things: the "what landed today" delta, and a
+// calibration signal -- (baseline, prev) is measured tonight and was measured
+// last night on a different machine, and since the commits are identical any
+// disagreement is pure measurement error.
+//
+// Run mode measures one shard and writes its results as JSON. Merge mode folds
+// one night's shards into a single record, computes that night's calibration
+// against the previous night, and appends it to benchlab.json.
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const opaModulePath = "github.com/open-policy-agent/opa"
+
+// measureForUnit maps benchstat's units onto the measure names benchmarks.json
+// already uses, so both data sources can be charted on the same axes.
+var measureForUnit = map[string]string{
+	"sec/op":    "NsPerOp",
+	"ns/op":     "NsPerOp",
+	"B/op":      "BytesPerOp",
+	"allocs/op": "AllocsPerOp",
+}
+
+// target is one curated entry: a package and the benchmarks to run within it.
+type target struct {
+	Shard string `json:"shard"`
+	Pkg   string `json:"pkg"`
+	Bench string `json:"bench"`
+}
+
+type benchmarkSet struct {
+	Targets []target `json:"targets"`
+}
+
+// delta is one pairwise comparison between two arms of the same experiment.
+type delta struct {
+	Pct         float64 `json:"pct"`
+	P           float64 `json:"p"`
+	N           int     `json:"n"`
+	Significant bool    `json:"significant"`
+}
+
+// result is one benchmark/measure pair's comparisons for one night.
+type result struct {
+	Pkg     string `json:"pkg"`
+	Name    string `json:"name"`
+	Measure string `json:"measure"`
+
+	BaselineValue float64 `json:"baseline_value"`
+	HeadValue     float64 `json:"head_value"`
+	BaselineCIPct float64 `json:"baseline_ci_pct"`
+	HeadCIPct     float64 `json:"head_ci_pct"`
+
+	// VsBaseline is the trend datapoint. VsPrev is the "what landed today"
+	// signal. PrevVsBaseline is tonight's measurement of a pair that last
+	// night also measured, and feeds the calibration summary.
+	VsBaseline     *delta `json:"vs_baseline,omitempty"`
+	VsPrev         *delta `json:"vs_prev,omitempty"`
+	PrevVsBaseline *delta `json:"prev_vs_baseline,omitempty"`
+}
+
+// calibration summarises how far tonight's measurement of (baseline, prev)
+// drifted from last night's measurement of the same two commits. The commits
+// are identical, so this is measurement error and nothing else -- a night with
+// large drift should not be read as a real change.
+type calibration struct {
+	ComparedTo   string  `json:"compared_to"`
+	N            int     `json:"n"`
+	MedianAbsPct float64 `json:"median_abs_drift_pct"`
+	P90AbsPct    float64 `json:"p90_abs_drift_pct"`
+	MaxAbsPct    float64 `json:"max_abs_drift_pct"`
+}
+
+// night is one nightly experiment, as stored in benchlab.json.
+type night struct {
+	Date        int64    `json:"date"`
+	Head        string   `json:"head"`
+	Prev        string   `json:"prev,omitempty"`
+	BaselineSHA string   `json:"baseline_sha"`
+	BaselineTag string   `json:"baseline_tag"`
+	Shards      []string `json:"shards"`
+
+	Reps       int     `json:"reps"`
+	Count      int     `json:"count"`
+	Benchtime  string  `json:"benchtime"`
+	Alpha      float64 `json:"alpha"`
+	Confidence float64 `json:"confidence"`
+
+	Calibration *calibration `json:"calibration,omitempty"`
+	Results     []result     `json:"results"`
+}
+
+func main() {
+	log.SetPrefix("bench-nightly: ")
+	log.SetFlags(0)
+
+	var (
+		mergeDir = flag.String("merge", "", "merge mode: fold the shard JSON files in this `dir` into -history")
+		history  = flag.String("history", "", "path to benchlab.json; read for -prev in run mode, read and rewritten in merge mode")
+		keep     = flag.Int("keep", 120, "merge mode: retain at most `N` nights of history")
+
+		setPath  = flag.String("set", "build/bench-nightly/set.json", "path to the curated benchmark `set`")
+		shard    = flag.String("shard", "", "run only the targets with this `shard` label")
+		baseline = flag.String("baseline", "", "baseline `commit`; defaults to the newest v* tag")
+		prev     = flag.String("prev", "", "previous night's `commit`; defaults to the newest night in -history")
+		out      = flag.String("out", "", "write results to this `file` (default benchlab.<shard>.json)")
+
+		reps       = flag.Int("reps", 15, "benchlab -reps")
+		count      = flag.Int("count", 1, "benchlab -count")
+		benchtime  = flag.String("benchtime", "2s", "benchlab -benchtime")
+		tags       = flag.String("tags", "opa_wasm", "build `tags` for the benchlab host spec")
+		alpha      = flag.Float64("alpha", 0.001, "benchstat -alpha")
+		confidence = flag.Float64("confidence", 0.95, "benchstat -confidence")
+	)
+	flag.Parse()
+
+	if *mergeDir != "" {
+		if *history == "" {
+			log.Fatal("-history is required with -merge")
+		}
+		runMerge(*mergeDir, *history, *keep)
+		return
+	}
+
+	if *shard == "" {
+		log.Fatal("-shard is required")
+	}
+
+	targets := loadTargets(*setPath, *shard)
+	if len(targets) == 0 {
+		log.Fatalf("no targets with shard %q in %s", *shard, *setPath)
+	}
+
+	head := gitOutput("rev-parse", "HEAD")
+	baseSHA, baseTag := resolveBaseline(*baseline)
+	prevSHA := resolvePrev(*prev, *history)
+
+	if prevSHA == head {
+		// Nothing landed since the last night. The prev arm would measure the
+		// same commit twice under two labels: pure cost, no signal.
+		log.Printf("prev (%s) is HEAD; dropping the prev arm", short(prevSHA))
+		prevSHA = ""
+	}
+
+	n := night{
+		Date:        time.Now().Unix(),
+		Head:        head,
+		Prev:        prevSHA,
+		BaselineSHA: baseSHA,
+		BaselineTag: baseTag,
+		Shards:      []string{*shard},
+		Reps:        *reps,
+		Count:       *count,
+		Benchtime:   *benchtime,
+		Alpha:       *alpha,
+		Confidence:  *confidence,
+	}
+
+	log.Printf("shard %s: baseline %s (%s), prev %s, head %s",
+		*shard, short(baseSHA), baseTag, short(prevSHA), short(head))
+
+	for _, t := range targets {
+		rs, err := measure(t, n, *tags)
+		if err != nil {
+			log.Fatalf("%s: %v", t.Pkg, err)
+		}
+		if len(rs) == 0 {
+			log.Printf("warning: %s matched no benchmarks for -bench %q", t.Pkg, t.Bench)
+		}
+		n.Results = append(n.Results, rs...)
+	}
+
+	path := *out
+	if path == "" {
+		path = "benchlab." + *shard + ".json"
+	}
+	writeJSON(path, n)
+	log.Printf("wrote %s (%d results)", path, len(n.Results))
+}
+
+func loadTargets(path, shard string) []target {
+	var set benchmarkSet
+	readJSON(path, &set)
+	var out []target
+	for _, t := range set.Targets {
+		if t.Shard == shard {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// resolveBaseline returns the baseline commit and the tag naming it. The tag
+// matters because the notebook anchors its charts to a release tag too; if the
+// two disagree the traces are in different units and are silently
+// incomparable, so the tag is recorded for the notebook to check.
+func resolveBaseline(want string) (sha, tag string) {
+	if want == "" {
+		tag = gitOutput("describe", "--tags", "--abbrev=0", "--match", "v*")
+		return gitOutput("rev-parse", tag+"^{commit}"), tag
+	}
+	sha = gitOutput("rev-parse", want+"^{commit}")
+	// Best-effort: an explicitly passed baseline may not be a tag at all.
+	if out, err := exec.Command("git", "describe", "--tags", "--exact-match", sha).Output(); err == nil {
+		tag = strings.TrimSpace(string(out))
+	}
+	return sha, tag
+}
+
+// resolvePrev returns the commit the previous night measured as its HEAD.
+func resolvePrev(want, history string) string {
+	if want != "" {
+		return gitOutput("rev-parse", want+"^{commit}")
+	}
+	if history == "" {
+		return ""
+	}
+	nights := readHistory(history)
+	if len(nights) == 0 {
+		return ""
+	}
+	return nights[len(nights)-1].Head
+}
+
+// measure runs one benchlab invocation covering every arm, then re-analyses its
+// raw output with benchstat to extract the pairwise comparisons.
+func measure(t target, n night, tags string) ([]result, error) {
+	commits := []string{n.BaselineSHA}
+	if n.Prev != "" {
+		commits = append(commits, n.Prev)
+	}
+	commits = append(commits, n.Head)
+
+	raw, err := runBenchlab(t, n, tags, commits)
+	if err != nil {
+		return nil, err
+	}
+
+	// One invocation covering (baseline, prev, head) already yields both
+	// deltas against the baseline, because benchstat compares every column
+	// with the first one. Only head-vs-prev needs a second pass, and it is
+	// pure re-analysis of the same file rather than more measurement.
+	vsBase, err := benchstatTables(raw, commits, n)
+	if err != nil {
+		return nil, err
+	}
+	var vsPrev map[string]*csvTable
+	if n.Prev != "" {
+		if vsPrev, err = benchstatTables(raw, []string{n.Prev, n.Head}, n); err != nil {
+			return nil, err
+		}
+	}
+
+	return assemble(t, n, vsBase, vsPrev)
+}
+
+// runBenchlab runs benchlab for one target and returns the raw output file it
+// wrote. benchlab picks a fresh .benchlab/bench.<date>[.N].txt each invocation,
+// so the new file is found by diffing the directory rather than guessed at.
+//
+// -run '^$' skips the test phase benchlab would otherwise use to avoid
+// benchmarking broken code; the per-push job already establishes that HEAD's
+// tests pass, and paying for them again at three commits is not worth the
+// wall-clock. This mirrors what build/bench-comment does.
+func runBenchlab(t target, n night, tags string, commits []string) (string, error) {
+	before := benchFiles()
+
+	args := []string{
+		"-commit", strings.Join(commits, ","),
+		"-pkg", t.Pkg,
+		"-host", "local:tags=" + tags,
+		"-reps", strconv.Itoa(n.Reps),
+		"-count", strconv.Itoa(n.Count),
+		"-benchtime", n.Benchtime,
+		"-run", "^$",
+	}
+	if t.Bench != "" {
+		args = append(args, "-bench", t.Bench)
+	}
+
+	cmd := exec.Command("benchlab", args...)
+	cmd.Stdout = os.Stderr // benchlab's progress output is not our data
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("benchlab: %w", err)
+	}
+
+	added := []string{}
+	for _, f := range benchFiles() {
+		if !slices.Contains(before, f) {
+			added = append(added, f)
+		}
+	}
+	switch len(added) {
+	case 1:
+		return added[0], nil
+	case 0:
+		return "", fmt.Errorf("benchlab wrote no new raw output file")
+	default:
+		return "", fmt.Errorf("benchlab wrote %d new raw output files: %v", len(added), added)
+	}
+}
+
+func benchFiles() []string {
+	files, _ := filepath.Glob(".benchlab/bench.*.txt")
+	slices.Sort(files)
+	return files
+}
+
+// benchstatTables re-analyses a benchlab raw output file, splitting it into one
+// column per commit. benchlab tags every section it writes with a "commit:"
+// configuration key precisely so that this is possible.
+func benchstatTables(raw string, commits []string, n night) (map[string]*csvTable, error) {
+	quoted := make([]string, len(commits))
+	for i, c := range commits {
+		quoted[i] = strconv.Quote(c)
+	}
+	cmd := exec.Command("benchstat",
+		"-format=csv",
+		fmt.Sprintf("-alpha=%g", n.Alpha),
+		fmt.Sprintf("-confidence=%g", n.Confidence),
+		fmt.Sprintf("-col=commit@(%s)", strings.Join(quoted, " ")),
+		raw,
+	)
+	cmd.Stderr = os.Stderr // benchstat reports warnings here
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("benchstat: %w", err)
+	}
+	return parseBenchstatCSV(string(out))
+}
+
+// csvColumn is one benchstat CSV column: a named group of samples, plus, for
+// every column after the first, its comparison against the first column.
+type csvColumn struct {
+	name     string
+	valueIdx int
+	ciIdx    int
+	deltaIdx int
+	pIdx     int
+}
+
+// csvTable is one benchstat CSV table, holding every row for a single unit.
+type csvTable struct {
+	pkg     string
+	unit    string
+	columns []csvColumn
+	rows    map[string][]string
+}
+
+func (t *csvTable) column(name string) (csvColumn, bool) {
+	for _, c := range t.columns {
+		if c.name == name {
+			return c, true
+		}
+	}
+	return csvColumn{}, false
+}
+
+func (t *csvTable) cell(row []string, idx int) string {
+	if idx < 0 || idx >= len(row) {
+		return ""
+	}
+	return row[idx]
+}
+
+// parseBenchstatCSV parses benchstat -format=csv into one table per unit, keyed
+// by measure name. The layout is a preamble of "key: value" lines followed by
+// blank-line separated tables, each opening with a row of column names and a row
+// describing that column's sub-columns.
+func parseBenchstatCSV(out string) (map[string]*csvTable, error) {
+	lines := strings.Split(out, "\n")
+
+	preamble := map[string]string{}
+	i := 0
+	for ; i < len(lines); i++ {
+		line := strings.TrimRight(lines[i], "\r")
+		if strings.HasPrefix(line, ",") {
+			break
+		}
+		if key, value, ok := strings.Cut(line, ": "); ok {
+			preamble[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+
+	pkg := strings.Replace(preamble["pkg"], opaModulePath, ".", 1)
+
+	tables := map[string]*csvTable{}
+	for i < len(lines) {
+		if strings.TrimSpace(lines[i]) == "" {
+			i++
+			continue
+		}
+		var block []string
+		for i < len(lines) && strings.TrimSpace(lines[i]) != "" {
+			block = append(block, lines[i])
+			i++
+		}
+		table, err := parseTableBlock(block, pkg)
+		if err != nil {
+			return nil, err
+		}
+		if table == nil {
+			continue
+		}
+		measure, ok := measureForUnit[table.unit]
+		if !ok {
+			log.Printf("warning: ignoring benchstat table with unrecognised unit %q", table.unit)
+			continue
+		}
+		tables[measure] = table
+	}
+	return tables, nil
+}
+
+func parseTableBlock(block []string, pkg string) (*csvTable, error) {
+	if len(block) < 3 {
+		return nil, nil // a header with no data rows carries nothing
+	}
+	r := csv.NewReader(strings.NewReader(strings.Join(block, "\n")))
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parsing benchstat csv: %w", err)
+	}
+	if len(records) < 3 {
+		return nil, nil
+	}
+
+	names, units := records[0], records[1]
+	table := &csvTable{pkg: pkg, rows: map[string][]string{}}
+
+	// Sub-columns run [unit, CI] for the first column and [unit, CI, vs base,
+	// P] for the rest. Walking the header rather than assuming fixed offsets
+	// keeps this working whether or not a comparison column is present.
+	for j := 1; j < len(units); {
+		if units[j] == "" {
+			j++
+			continue
+		}
+		col := csvColumn{valueIdx: j, ciIdx: -1, deltaIdx: -1, pIdx: -1}
+		if j < len(names) {
+			col.name = names[j]
+		}
+		if table.unit == "" {
+			table.unit = units[j]
+		}
+		j++
+		if j < len(units) && units[j] == "CI" {
+			col.ciIdx = j
+			j++
+		}
+		if j < len(units) && units[j] == "vs base" {
+			col.deltaIdx = j
+			j++
+		}
+		if j < len(units) && units[j] == "P" {
+			col.pIdx = j
+			j++
+		}
+		table.columns = append(table.columns, col)
+	}
+
+	for _, row := range records[2:] {
+		if len(row) == 0 || row[0] == "" || row[0] == "geomean" {
+			continue
+		}
+		table.rows[row[0]] = row
+	}
+	return table, nil
+}
+
+// assemble turns the parsed benchstat tables into results.
+func assemble(t target, n night, vsBase, vsPrev map[string]*csvTable) ([]result, error) {
+	var out []result
+
+	measures := make([]string, 0, len(vsBase))
+	for m := range vsBase {
+		measures = append(measures, m)
+	}
+	sort.Strings(measures)
+
+	for _, measure := range measures {
+		table := vsBase[measure]
+
+		baseCol, ok := table.column(n.BaselineSHA)
+		if !ok {
+			return nil, fmt.Errorf("%s: no benchstat column for baseline %s", measure, short(n.BaselineSHA))
+		}
+		headCol, ok := table.column(n.Head)
+		if !ok {
+			return nil, fmt.Errorf("%s: no benchstat column for head %s", measure, short(n.Head))
+		}
+		prevCol, hasPrev := table.column(n.Prev)
+
+		names := make([]string, 0, len(table.rows))
+		for name := range table.rows {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			row := table.rows[name]
+
+			baseVal, okB := parseFloat(table.cell(row, baseCol.valueIdx))
+			headVal, okH := parseFloat(table.cell(row, headCol.valueIdx))
+			if !okB || !okH {
+				continue
+			}
+			baseVal = round4(toMeasureUnits(table.unit, baseVal))
+			headVal = round4(toMeasureUnits(table.unit, headVal))
+
+			r := result{
+				// benchstat strips the "Benchmark" prefix from names in its
+				// tables, but the published chart pages are keyed by the full
+				// Go benchmark name, so it has to go back on.
+				Pkg:           t.Pkg,
+				Name:          "Benchmark" + name,
+				Measure:       measure,
+				BaselineValue: baseVal,
+				HeadValue:     headVal,
+				BaselineCIPct: parsePct(table.cell(row, baseCol.ciIdx)),
+				HeadCIPct:     parsePct(table.cell(row, headCol.ciIdx)),
+				VsBaseline: newDelta(baseVal, headVal,
+					table.cell(row, headCol.deltaIdx), table.cell(row, headCol.pIdx)),
+			}
+
+			if hasPrev {
+				if prevVal, ok := parseFloat(table.cell(row, prevCol.valueIdx)); ok {
+					r.PrevVsBaseline = newDelta(baseVal, toMeasureUnits(table.unit, prevVal),
+						table.cell(row, prevCol.deltaIdx), table.cell(row, prevCol.pIdx))
+				}
+			}
+
+			if pt := vsPrev[measure]; pt != nil {
+				r.VsPrev = deltaFromTable(pt, n.Prev, n.Head, name)
+			}
+
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func deltaFromTable(t *csvTable, from, to, name string) *delta {
+	row, ok := t.rows[name]
+	if !ok {
+		return nil
+	}
+	fromCol, ok1 := t.column(from)
+	toCol, ok2 := t.column(to)
+	if !ok1 || !ok2 {
+		return nil
+	}
+	fromVal, okF := parseFloat(t.cell(row, fromCol.valueIdx))
+	toVal, okT := parseFloat(t.cell(row, toCol.valueIdx))
+	if !okF || !okT {
+		return nil
+	}
+	return newDelta(toMeasureUnits(t.unit, fromVal), toMeasureUnits(t.unit, toVal),
+		t.cell(row, toCol.deltaIdx), t.cell(row, toCol.pIdx))
+}
+
+// newDelta builds a comparison from two group medians plus benchstat's verdict.
+//
+// The point estimate is computed from the medians rather than read from
+// benchstat's "vs base" cell, because benchstat prints "~" there whenever a
+// difference is not distinguishable from noise. On a quiet night that is most
+// benchmarks, and taking the cell at face value would punch holes in the trend
+// line exactly where it is flat. The cell is still used for the significance
+// verdict, which is the part benchstat is authoritative about.
+func newDelta(from, to float64, deltaCell, pCell string) *delta {
+	d := &delta{
+		Significant: strings.HasPrefix(deltaCell, "+") || strings.HasPrefix(deltaCell, "-"),
+		P:           math.NaN(),
+	}
+	if from != 0 {
+		d.Pct = round4((to/from - 1) * 100)
+	}
+	for _, field := range strings.Fields(pCell) {
+		if v, ok := strings.CutPrefix(field, "p="); ok {
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				d.P = round4(f)
+			}
+		}
+		if v, ok := strings.CutPrefix(field, "n="); ok {
+			// Unequal sample counts are reported as "n=15+14".
+			if f, err := strconv.Atoi(strings.SplitN(v, "+", 2)[0]); err == nil {
+				d.N = f
+			}
+		}
+	}
+	if math.IsNaN(d.P) {
+		d.P = 0
+	}
+	return d
+}
+
+// toMeasureUnits converts benchstat's seconds to the nanoseconds
+// benchmarks.json records, leaving byte and allocation counts alone.
+func toMeasureUnits(unit string, v float64) float64 {
+	if unit == "sec/op" {
+		return v * 1e9
+	}
+	return v
+}
+
+// round4 trims float noise. A median ratio over fifteen samples does not carry
+// seventeen significant digits, and every excess character is paid for ~900
+// times a night in a file the notebook reads whole.
+func round4(v float64) float64 {
+	return math.Round(v*1e4) / 1e4
+}
+
+func parseFloat(s string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return v, err == nil
+}
+
+// parsePct reads benchstat's CI cell, which is a percentage such as "2%".
+func parsePct(s string) float64 {
+	v, _ := parseFloat(strings.TrimSuffix(strings.TrimSpace(s), "%"))
+	return v
+}
+
+// runMerge folds one night's shards into a single record and appends it to the
+// history, computing the night's calibration while last night's numbers are at
+// hand.
+func runMerge(dir, historyPath string, keep int) {
+	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	slices.Sort(files)
+	if len(files) == 0 {
+		log.Fatalf("no shard JSON files in %s", dir)
+	}
+
+	var merged night
+	for i, f := range files {
+		var shard night
+		readJSON(f, &shard)
+		if i == 0 {
+			merged = shard
+			merged.Results = slices.Clone(shard.Results)
+			continue
+		}
+		// Shards of one night must describe the same experiment, or the
+		// results are not commensurable and the record would be a fiction.
+		if shard.Head != merged.Head || shard.BaselineSHA != merged.BaselineSHA || shard.Prev != merged.Prev {
+			log.Fatalf("%s disagrees with %s about the experiment (head/baseline/prev)", f, files[0])
+		}
+		merged.Shards = append(merged.Shards, shard.Shards...)
+		merged.Results = append(merged.Results, shard.Results...)
+	}
+	slices.Sort(merged.Shards)
+
+	nights := readHistory(historyPath)
+	if len(nights) > 0 {
+		merged.Calibration = calibrate(nights[len(nights)-1], merged)
+	}
+
+	nights = append(nights, merged)
+	if keep > 0 && len(nights) > keep {
+		nights = nights[len(nights)-keep:]
+	}
+	compactHistory(nights)
+	writeCompactJSON(historyPath, nights)
+
+	log.Printf("merged %d shard(s), %d results; history now %d night(s)",
+		len(files), len(merged.Results), len(nights))
+	if c := merged.Calibration; c != nil {
+		log.Printf("calibration vs %s: median %.2f%%, p90 %.2f%%, max %.2f%% over %d benchmarks",
+			short(c.ComparedTo), c.MedianAbsPct, c.P90AbsPct, c.MaxAbsPct, c.N)
+	}
+}
+
+// compactHistory drops from every night but the newest the two comparisons only
+// the newest one needs.
+//
+// vs_prev is the "what landed today" signal, which is only actionable for the
+// most recent night. prev_vs_baseline exists solely to be compared against the
+// previous night's vs_baseline, and that has already happened by the time a
+// night is written -- the outcome is its calibration summary. Retaining either
+// on older nights roughly triples the size of a file the notebook slurps whole
+// on every render.
+func compactHistory(nights []night) {
+	if len(nights) < 2 {
+		return
+	}
+	for i := range nights[:len(nights)-1] {
+		for j := range nights[i].Results {
+			nights[i].Results[j].VsPrev = nil
+			nights[i].Results[j].PrevVsBaseline = nil
+		}
+	}
+}
+
+// calibrate compares tonight's measurement of (baseline, prev) with last
+// night's measurement of (baseline, its own head) -- the same two commits, a
+// different machine. Any disagreement is measurement error.
+func calibrate(last, tonight night) *calibration {
+	if tonight.Prev == "" || last.Head != tonight.Prev || last.BaselineSHA != tonight.BaselineSHA {
+		return nil
+	}
+
+	type key struct{ pkg, name, measure string }
+	lastByKey := map[key]*delta{}
+	for _, r := range last.Results {
+		if r.VsBaseline != nil {
+			lastByKey[key{r.Pkg, r.Name, r.Measure}] = r.VsBaseline
+		}
+	}
+
+	var drifts []float64
+	for _, r := range tonight.Results {
+		if r.PrevVsBaseline == nil {
+			continue
+		}
+		if prior, ok := lastByKey[key{r.Pkg, r.Name, r.Measure}]; ok {
+			drifts = append(drifts, math.Abs(r.PrevVsBaseline.Pct-prior.Pct))
+		}
+	}
+	if len(drifts) == 0 {
+		return nil
+	}
+	sort.Float64s(drifts)
+
+	return &calibration{
+		ComparedTo:   last.Head,
+		N:            len(drifts),
+		MedianAbsPct: quantile(drifts, 0.5),
+		P90AbsPct:    quantile(drifts, 0.9),
+		MaxAbsPct:    drifts[len(drifts)-1],
+	}
+}
+
+// quantile returns the q-th quantile of a sorted slice by nearest rank.
+func quantile(sorted []float64, q float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	i := int(math.Round(q * float64(len(sorted)-1)))
+	return sorted[max(0, min(i, len(sorted)-1))]
+}
+
+func readHistory(path string) []night {
+	var nights []night
+	if _, err := os.Stat(path); err != nil {
+		return nil // first run: no history yet
+	}
+	readJSON(path, &nights)
+	return nights
+}
+
+func readJSON(path string, v any) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		log.Fatalf("parsing %s: %v", path, err)
+	}
+}
+
+// writeJSON writes v indented, for the per-shard files a human may read.
+func writeJSON(path string, v any) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	write(path, b)
+}
+
+// writeCompactJSON writes v without indentation. benchlab.json accumulates
+// roughly nine hundred results a night and the notebook reads it whole, so the
+// whitespace is not free.
+func writeCompactJSON(path string, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		log.Fatal(err)
+	}
+	write(path, b)
+}
+
+func write(path string, b []byte) {
+	if err := os.WriteFile(path, append(b, '\n'), 0o644); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func gitOutput(args ...string) string {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		log.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func short(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/build/bench-nightly/main.go
+++ b/build/bench-nightly/main.go
@@ -31,6 +31,7 @@ package main
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -39,7 +40,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -330,7 +330,7 @@ func runBenchlab(t target, n night, tags string, commits []string) (string, erro
 	case 1:
 		return added[0], nil
 	case 0:
-		return "", fmt.Errorf("benchlab wrote no new raw output file")
+		return "", errors.New("benchlab wrote no new raw output file")
 	default:
 		return "", fmt.Errorf("benchlab wrote %d new raw output files: %v", len(added), added)
 	}
@@ -392,7 +392,9 @@ func (t *csvTable) column(name string) (csvColumn, bool) {
 	return csvColumn{}, false
 }
 
-func (t *csvTable) cell(row []string, idx int) string {
+// cell reads one field of a benchstat CSV row, tolerating a column index the row
+// does not reach: benchstat omits trailing empty cells.
+func cell(row []string, idx int) string {
 	if idx < 0 || idx >= len(row) {
 		return ""
 	}
@@ -513,7 +515,7 @@ func assemble(t target, n night, vsBase, vsPrev map[string]*csvTable) ([]result,
 	for m := range vsBase {
 		measures = append(measures, m)
 	}
-	sort.Strings(measures)
+	slices.Sort(measures)
 
 	for _, measure := range measures {
 		table := vsBase[measure]
@@ -532,13 +534,13 @@ func assemble(t target, n night, vsBase, vsPrev map[string]*csvTable) ([]result,
 		for name := range table.rows {
 			names = append(names, name)
 		}
-		sort.Strings(names)
+		slices.Sort(names)
 
 		for _, name := range names {
 			row := table.rows[name]
 
-			baseVal, okB := parseFloat(table.cell(row, baseCol.valueIdx))
-			headVal, okH := parseFloat(table.cell(row, headCol.valueIdx))
+			baseVal, okB := parseFloat(cell(row, baseCol.valueIdx))
+			headVal, okH := parseFloat(cell(row, headCol.valueIdx))
 			if !okB || !okH {
 				continue
 			}
@@ -554,16 +556,16 @@ func assemble(t target, n night, vsBase, vsPrev map[string]*csvTable) ([]result,
 				Measure:       measure,
 				BaselineValue: baseVal,
 				HeadValue:     headVal,
-				BaselineCIPct: parsePct(table.cell(row, baseCol.ciIdx)),
-				HeadCIPct:     parsePct(table.cell(row, headCol.ciIdx)),
+				BaselineCIPct: parsePct(cell(row, baseCol.ciIdx)),
+				HeadCIPct:     parsePct(cell(row, headCol.ciIdx)),
 				VsBaseline: newDelta(baseVal, headVal,
-					table.cell(row, headCol.deltaIdx), table.cell(row, headCol.pIdx)),
+					cell(row, headCol.deltaIdx), cell(row, headCol.pIdx)),
 			}
 
 			if hasPrev {
-				if prevVal, ok := parseFloat(table.cell(row, prevCol.valueIdx)); ok {
+				if prevVal, ok := parseFloat(cell(row, prevCol.valueIdx)); ok {
 					r.PrevVsBaseline = newDelta(baseVal, toMeasureUnits(table.unit, prevVal),
-						table.cell(row, prevCol.deltaIdx), table.cell(row, prevCol.pIdx))
+						cell(row, prevCol.deltaIdx), cell(row, prevCol.pIdx))
 				}
 			}
 
@@ -587,13 +589,13 @@ func deltaFromTable(t *csvTable, from, to, name string) *delta {
 	if !ok1 || !ok2 {
 		return nil
 	}
-	fromVal, okF := parseFloat(t.cell(row, fromCol.valueIdx))
-	toVal, okT := parseFloat(t.cell(row, toCol.valueIdx))
+	fromVal, okF := parseFloat(cell(row, fromCol.valueIdx))
+	toVal, okT := parseFloat(cell(row, toCol.valueIdx))
 	if !okF || !okT {
 		return nil
 	}
 	return newDelta(toMeasureUnits(t.unit, fromVal), toMeasureUnits(t.unit, toVal),
-		t.cell(row, toCol.deltaIdx), t.cell(row, toCol.pIdx))
+		cell(row, toCol.deltaIdx), cell(row, toCol.pIdx))
 }
 
 // newDelta builds a comparison from two group medians plus benchstat's verdict.
@@ -612,7 +614,7 @@ func newDelta(from, to float64, deltaCell, pCell string) *delta {
 	if from != 0 {
 		d.Pct = round4((to/from - 1) * 100)
 	}
-	for _, field := range strings.Fields(pCell) {
+	for field := range strings.FieldsSeq(pCell) {
 		if v, ok := strings.CutPrefix(field, "p="); ok {
 			if f, err := strconv.ParseFloat(v, 64); err == nil {
 				d.P = round4(f)
@@ -759,7 +761,7 @@ func calibrate(last, tonight night) *calibration {
 	if len(drifts) == 0 {
 		return nil
 	}
-	sort.Float64s(drifts)
+	slices.Sort(drifts)
 
 	return &calibration{
 		ComparedTo:   last.Head,

--- a/build/bench-nightly/main_test.go
+++ b/build/bench-nightly/main_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math"
+	"os"
+	"testing"
+)
+
+// The testdata CSV files are real `benchstat -format=csv` output, produced from
+// a synthetic benchlab raw file in which prev was built to be 2% slower than
+// the baseline and head 8% slower, with allocations going 12 -> 12 -> 14 and
+// bytes held constant. Those known quantities are what the assertions below
+// check, so a change in benchstat's output shape fails here rather than
+// silently producing wrong charts.
+const (
+	baseSHA = "basesha"
+	prevSHA = "prevsha"
+	headSHA = "headsha"
+)
+
+func loadTable(t *testing.T, path string) map[string]*csvTable {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tables, err := parseBenchstatCSV(string(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tables
+}
+
+func TestParseBenchstatCSV(t *testing.T) {
+	tables := loadTable(t, "testdata/vsbase.csv")
+
+	for _, measure := range []string{"NsPerOp", "BytesPerOp", "AllocsPerOp"} {
+		if _, ok := tables[measure]; !ok {
+			t.Errorf("no table for measure %q", measure)
+		}
+	}
+	if len(tables) != 3 {
+		t.Errorf("got %d tables, want 3", len(tables))
+	}
+
+	table := tables["NsPerOp"]
+	if table.pkg != "./v1/topdown" {
+		t.Errorf("pkg = %q, want ./v1/topdown", table.pkg)
+	}
+	if len(table.columns) != 3 {
+		t.Fatalf("got %d columns, want 3", len(table.columns))
+	}
+	for _, sha := range []string{baseSHA, prevSHA, headSHA} {
+		if _, ok := table.column(sha); !ok {
+			t.Errorf("no column for %q", sha)
+		}
+	}
+
+	// The first column carries no comparison; later ones do.
+	if c, _ := table.column(baseSHA); c.deltaIdx != -1 {
+		t.Errorf("baseline column has a delta index %d, want -1", c.deltaIdx)
+	}
+	if c, _ := table.column(headSHA); c.deltaIdx == -1 || c.pIdx == -1 {
+		t.Errorf("head column missing delta/P indices: %+v", c)
+	}
+
+	// geomean is a summary row, not a benchmark.
+	if len(table.rows) != 2 {
+		t.Errorf("got %d rows, want 2: %v", len(table.rows), table.rows)
+	}
+	if _, ok := table.rows["geomean"]; ok {
+		t.Error("geomean row was not skipped")
+	}
+}
+
+func TestAssemble(t *testing.T) {
+	n := night{BaselineSHA: baseSHA, Prev: prevSHA, Head: headSHA}
+	results, err := assemble(
+		target{Pkg: "./v1/topdown"}, n,
+		loadTable(t, "testdata/vsbase.csv"),
+		loadTable(t, "testdata/vsprev.csv"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 6 { // 2 benchmarks x 3 measures
+		t.Fatalf("got %d results, want 6", len(results))
+	}
+
+	find := func(name, measure string) result {
+		t.Helper()
+		for _, r := range results {
+			if r.Name == name && r.Measure == measure {
+				return r
+			}
+		}
+		t.Fatalf("no result for %s/%s", name, measure)
+		return result{}
+	}
+
+	t.Run("time", func(t *testing.T) {
+		r := find("BenchmarkGlob/100-4", "NsPerOp")
+
+		// benchstat reports seconds; benchmarks.json records nanoseconds.
+		approx(t, "baseline value", r.BaselineValue, 1002, 0.5)
+		approx(t, "head value", r.HeadValue, 1080.7, 0.5)
+
+		approx(t, "vs baseline", r.VsBaseline.Pct, 7.85, 0.01)
+		approx(t, "prev vs baseline", r.PrevVsBaseline.Pct, 2.13, 0.01)
+		approx(t, "vs prev", r.VsPrev.Pct, 5.61, 0.01)
+
+		for label, d := range map[string]*delta{
+			"vs baseline": r.VsBaseline, "prev vs baseline": r.PrevVsBaseline, "vs prev": r.VsPrev,
+		} {
+			if !d.Significant {
+				t.Errorf("%s: not significant, want significant", label)
+			}
+			if d.N != 15 {
+				t.Errorf("%s: n = %d, want 15", label, d.N)
+			}
+		}
+	})
+
+	t.Run("allocations", func(t *testing.T) {
+		r := find("BenchmarkGlob/100-4", "AllocsPerOp")
+		approx(t, "baseline value", r.BaselineValue, 12, 0.001)
+		approx(t, "head value", r.HeadValue, 14, 0.001)
+		approx(t, "vs baseline", r.VsBaseline.Pct, 16.67, 0.01)
+		// prev and baseline both allocate 12, so benchstat prints "~".
+		if r.PrevVsBaseline.Significant {
+			t.Error("prev vs baseline: significant, want not significant")
+		}
+		approx(t, "prev vs baseline", r.PrevVsBaseline.Pct, 0, 0.001)
+	})
+
+	t.Run("bytes are unchanged and not significant", func(t *testing.T) {
+		r := find("BenchmarkGlob/100-4", "BytesPerOp")
+		approx(t, "head value", r.HeadValue, 512, 0.001)
+		if r.VsBaseline.Significant {
+			t.Error("vs baseline: significant, want not significant")
+		}
+	})
+}
+
+// A "~" verdict means "not distinguishable from noise", not "no measurement".
+// Dropping the point estimate along with the verdict would leave holes in the
+// trend line on exactly the nights where nothing changed.
+func TestInsignificantDeltaKeepsPointEstimate(t *testing.T) {
+	d := newDelta(100, 103, "~", "p=0.400 n=15")
+	if d.Significant {
+		t.Error("Significant = true, want false")
+	}
+	approx(t, "pct", d.Pct, 3, 0.001)
+	approx(t, "p", d.P, 0.4, 0.001)
+	if d.N != 15 {
+		t.Errorf("n = %d, want 15", d.N)
+	}
+}
+
+func TestNewDeltaUnequalSampleCounts(t *testing.T) {
+	if d := newDelta(1, 1, "~", "p=0.500 n=15+14"); d.N != 15 {
+		t.Errorf("n = %d, want 15", d.N)
+	}
+}
+
+func TestCalibrate(t *testing.T) {
+	key := func(pct float64) result {
+		return result{
+			Pkg: "./v1/topdown", Name: "BenchmarkGlob-4", Measure: "NsPerOp",
+			VsBaseline:     &delta{Pct: pct},
+			PrevVsBaseline: &delta{Pct: pct},
+		}
+	}
+
+	last := night{Head: prevSHA, BaselineSHA: baseSHA, Results: []result{key(2.0)}}
+	// Tonight re-measures (baseline, prev) and gets 2.5% where last night got
+	// 2.0%: the commits are identical, so the 0.5 point difference is noise.
+	tonight := night{Head: headSHA, Prev: prevSHA, BaselineSHA: baseSHA, Results: []result{key(2.5)}}
+
+	c := calibrate(last, tonight)
+	if c == nil {
+		t.Fatal("calibrate returned nil")
+	}
+	if c.ComparedTo != prevSHA {
+		t.Errorf("ComparedTo = %q, want %q", c.ComparedTo, prevSHA)
+	}
+	if c.N != 1 {
+		t.Errorf("N = %d, want 1", c.N)
+	}
+	approx(t, "median drift", c.MedianAbsPct, 0.5, 0.001)
+
+	t.Run("refuses to compare unrelated nights", func(t *testing.T) {
+		// Last night's head is not what tonight measured as prev, so the two
+		// numbers are not measurements of the same pair of commits.
+		mismatched := night{Head: "other", BaselineSHA: baseSHA, Results: []result{key(2.0)}}
+		if c := calibrate(mismatched, tonight); c != nil {
+			t.Errorf("got %+v, want nil", c)
+		}
+	})
+
+	t.Run("refuses when the baseline was re-anchored", func(t *testing.T) {
+		rebased := night{Head: prevSHA, BaselineSHA: "newbase", Results: []result{key(2.0)}}
+		if c := calibrate(rebased, tonight); c != nil {
+			t.Errorf("got %+v, want nil", c)
+		}
+	})
+}
+
+// The workflow derives its shard matrix from set.json with jq while the tool
+// reads the same file with -shard, so the two have to agree about its shape.
+func TestLoadTargetsFromSet(t *testing.T) {
+	for _, shard := range []string{"topdown", "ast", "rego", "inmem"} {
+		targets := loadTargets("set.json", shard)
+		if len(targets) == 0 {
+			t.Errorf("shard %q resolved no targets", shard)
+			continue
+		}
+		for _, target := range targets {
+			if target.Pkg == "" || target.Bench == "" {
+				t.Errorf("shard %q has an incomplete target: %+v", shard, target)
+			}
+		}
+	}
+	if targets := loadTargets("set.json", "nonexistent"); len(targets) != 0 {
+		t.Errorf("unknown shard resolved %d targets, want 0", len(targets))
+	}
+}
+
+// Only the newest night keeps vs_prev/prev_vs_baseline; older nights have had
+// everything they contribute (alerting, calibration) already extracted.
+func TestCompactHistory(t *testing.T) {
+	mk := func(head string) night {
+		return night{Head: head, Results: []result{{
+			Pkg: "./v1/topdown", Name: "BenchmarkGlob-4", Measure: "NsPerOp",
+			VsBaseline:     &delta{Pct: 1},
+			VsPrev:         &delta{Pct: 2},
+			PrevVsBaseline: &delta{Pct: 3},
+		}}}
+	}
+	nights := []night{mk("h1"), mk("h2"), mk("h3")}
+	compactHistory(nights)
+
+	for i, n := range nights[:2] {
+		r := n.Results[0]
+		if r.VsPrev != nil || r.PrevVsBaseline != nil {
+			t.Errorf("night %d (%s) kept a transient comparison: %+v", i, n.Head, r)
+		}
+		// The trend datapoint and the next night's calibration input must survive.
+		if r.VsBaseline == nil {
+			t.Errorf("night %d (%s) lost vs_baseline", i, n.Head)
+		}
+	}
+	newest := nights[2].Results[0]
+	if newest.VsPrev == nil || newest.PrevVsBaseline == nil {
+		t.Errorf("newest night was stripped: %+v", newest)
+	}
+
+	t.Run("a single night is left alone", func(t *testing.T) {
+		one := []night{mk("h1")}
+		compactHistory(one)
+		if one[0].Results[0].VsPrev == nil {
+			t.Error("the only night was stripped")
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		again := []night{mk("h1"), mk("h2")}
+		compactHistory(again)
+		compactHistory(again)
+		if again[1].Results[0].VsPrev == nil {
+			t.Error("second pass stripped the newest night")
+		}
+	})
+}
+
+func TestRound4(t *testing.T) {
+	approx(t, "trims float noise", round4(16.666666666666675), 16.6667, 1e-9)
+	approx(t, "leaves short values alone", round4(0.5), 0.5, 1e-9)
+}
+
+func TestQuantile(t *testing.T) {
+	sorted := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	approx(t, "median", quantile(sorted, 0.5), 5, 0.001)
+	approx(t, "p90", quantile(sorted, 0.9), 8, 0.001)
+	if got := quantile(nil, 0.5); got != 0 {
+		t.Errorf("quantile(nil) = %v, want 0", got)
+	}
+}
+
+func approx(t *testing.T, label string, got, want, tolerance float64) {
+	t.Helper()
+	if math.Abs(got-want) > tolerance {
+		t.Errorf("%s = %v, want %v (+/- %v)", label, got, want, tolerance)
+	}
+}

--- a/build/bench-nightly/set.json
+++ b/build/bench-nightly/set.json
@@ -1,0 +1,30 @@
+{
+  "//": "Curated benchmark set for the nightly benchlab experiment. Each target is measured at three commits in one benchlab invocation, so the cost of adding a target is roughly three times its plain benchmark time -- see build/bench-nightly/main.go. The full published set is ~1118 cases, far too many to measure this way nightly; these targets cover the evaluation hot paths, and the noisier blanket coverage is left to the per-push gobenchdata run. Case counts in the comments are as published on the benchmarks branch, and are a rough sizing guide rather than a promise.",
+
+  "targets": [
+    {
+      "shard": "topdown",
+      "pkg": "./v1/topdown",
+      "//": "~106 of 492 cases: rule evaluation, comprehensions, bindings, partial eval, base-document access and iteration. Deliberately excludes the JSONPatch*, Tokens and Builtin* families, which are builtin micro-benchmarks rather than evaluation hot paths.",
+      "bench": "^Benchmark(VirtualDocs|VirtualCache|ComplexRules|RuleBindings|RuleWithComprehensions|Comprehension|Bindings|Biunify|PartialEval|Concurrency|InliningFullScan|Enumerate|ArrayIteration|ObjectIteration|SetIteration|ObjectGet|MemberWithKeyFromBaseDoc|LargeJSON)"
+    },
+    {
+      "shard": "ast",
+      "pkg": "./v1/ast",
+      "//": "~101 of 336 cases: parsing, object/set construction and lookup, and term rewriting. Excludes the NoASTTypeAllocates*/NoNodeTypeAllocates* families, which are allocation assertions rather than trend material.",
+      "bench": "^Benchmark(Parse|ObjectGet|ObjectFind|ObjectConstruction|ObjectCreationAndLookup|SetCreationAndLookup|RewriteDynamics|RefString)"
+    },
+    {
+      "shard": "rego",
+      "pkg": "./v1/rego",
+      "//": "All ~53 cases: the public evaluation API, the closest thing here to end-to-end user-visible performance.",
+      "bench": "."
+    },
+    {
+      "shard": "inmem",
+      "pkg": "./v1/storage/inmem",
+      "//": "All ~48 cases: the store read/write hot path.",
+      "bench": "."
+    }
+  ]
+}

--- a/build/bench-nightly/testdata/vsbase.csv
+++ b/build/bench-nightly/testdata/vsbase.csv
@@ -1,0 +1,22 @@
+host: local
+goos: linux
+goarch: amd64
+pkg: github.com/open-policy-agent/opa/v1/topdown
+cpu: AMD EPYC 7763 64-Core Processor
+,basesha,,prevsha,,,,headsha,,,
+,sec/op,CI,sec/op,CI,vs base,P,sec/op,CI,vs base,P
+Glob/100-4,1.002e-06,0%,1.0233e-06,1%,+2.13%,p=0.000 n=15,1.0807e-06,0%,+7.85%,p=0.000 n=15
+Eval/small-4,3.006e-06,0%,3.0698000000000002e-06,1%,+2.12%,p=0.000 n=15,3.2421000000000003e-06,0%,+7.85%,p=0.000 n=15
+geomean,1.7355149091840155e-06,,1.7723787236366852e-06,,+2.12%,,1.8718273077396858e-06,,+7.85%,
+
+,basesha,,prevsha,,,,headsha,,,
+,B/op,CI,B/op,CI,vs base,P,B/op,CI,vs base,P
+Glob/100-4,512,0%,512,0%,~,p=1.000 n=15,512,0%,~,p=1.000 n=15
+Eval/small-4,2048,0%,2048,0%,~,p=1.000 n=15,2048,0%,~,p=1.000 n=15
+geomean,1024,,1024,,+0.00%,,1024,,+0.00%,
+
+,basesha,,prevsha,,,,headsha,,,
+,allocs/op,CI,allocs/op,CI,vs base,P,allocs/op,CI,vs base,P
+Glob/100-4,12,0%,12,0%,~,p=1.000 n=15,14,0%,+16.67%,p=0.000 n=15
+Eval/small-4,24,0%,24,0%,~,p=1.000 n=15,28,0%,+16.67%,p=0.000 n=15
+geomean,16.970562748477143,,16.970562748477143,,+0.00%,,19.798989873223334,,+16.67%,

--- a/build/bench-nightly/testdata/vsprev.csv
+++ b/build/bench-nightly/testdata/vsprev.csv
@@ -1,0 +1,22 @@
+host: local
+goos: linux
+goarch: amd64
+pkg: github.com/open-policy-agent/opa/v1/topdown
+cpu: AMD EPYC 7763 64-Core Processor
+,prevsha,,headsha,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Glob/100-4,1.0233e-06,1%,1.0807e-06,0%,+5.61%,p=0.000 n=15
+Eval/small-4,3.0698000000000002e-06,1%,3.2421000000000003e-06,0%,+5.61%,p=0.000 n=15
+geomean,1.7723787236366852e-06,,1.8718273077396858e-06,,+5.61%,
+
+,prevsha,,headsha,,,
+,B/op,CI,B/op,CI,vs base,P
+Glob/100-4,512,0%,512,0%,~,p=1.000 n=15
+Eval/small-4,2048,0%,2048,0%,~,p=1.000 n=15
+geomean,1024,,1024,,+0.00%,
+
+,prevsha,,headsha,,,
+,allocs/op,CI,allocs/op,CI,vs base,P
+Glob/100-4,12,0%,14,0%,+16.67%,p=0.000 n=15
+Eval/small-4,24,0%,28,0%,+16.67%,p=0.000 n=15
+geomean,16.970562748477143,,19.798989873223334,,+16.67%,


### PR DESCRIPTION
Leaning into less measurements, using benchlab, recording the diffs in another file. Let's do this for a bit, see if it's better than what did before -- which was slightly broken (skipping commits, GHA aborting jobs, ...)