### PR TITLE
ci: publish benchmark trend on a schedule instead of per-push

### DIFF
--- a/.github/workflows/benchmarks-publish.yaml
+++ b/.github/workflows/benchmarks-publish.yaml
@@ -1,0 +1,170 @@
+name: Benchmarks (publish)
+
+# Publishes the long-term benchmark trend to the `benchmarks` branch.
+#
+# This runs on a schedule rather than on every push to main: a full benchmark
+# run takes up to 120 minutes, so per-push runs could never keep up with main's
+# traffic. They piled up in the concurrency queue instead, and since GitHub only
+# ever holds ONE waiting run per group, all but the newest queued run were
+# cancelled ("Canceling since a higher priority waiting request ... exists").
+# A fixed schedule gets the same trend data without the queue churn.
+#
+# Per-push regression detection lives in benchmarks.yaml.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Every 6 hours. Keep LOOKBACK below wider than this interval.
+    - cron: '0 */6 * * *'
+
+# Both jobs below push to the `benchmarks` branch, so runs must not overlap.
+# cancel-in-progress: false protects the in-flight run; the schedule above is
+# spaced well beyond the 120 minute job timeout so nothing should ever queue.
+concurrency:
+  group: benchmarks
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Skip the run entirely if main saw no Go changes in the lookback window,
+  # so quiet periods don't burn two hours of runner time for a flat datapoint.
+  check-changes:
+    name: Check what files changed
+    runs-on: ubuntu-24.04
+    outputs:
+      go: ${{ steps.changes.outputs.go }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download OPA
+        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+        with:
+          version: edge
+
+      - name: Check for file changes
+        id: changes
+        env:
+          # Wider than the cron interval on purpose: overlapping windows may
+          # re-benchmark an already-covered range, which is harmless, whereas a
+          # gap would silently lose a datapoint.
+          LOOKBACK: '8 hours ago'
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -e
+
+          # A manual dispatch is an explicit request -- always run.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manually dispatched, running benchmarks"
+            echo "go=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Default to running: if we cannot work out a base commit we would
+          # rather spend the runner time than lose a datapoint.
+          echo "go=true" >> $GITHUB_OUTPUT
+
+          BASE_SHA=$(git rev-list -1 --before="$LOOKBACK" HEAD)
+          if [ -z "$BASE_SHA" ]; then
+            echo "Warning: no commit older than '$LOOKBACK', running benchmarks"
+            exit 0
+          fi
+
+          echo "Comparing $BASE_SHA with HEAD"
+          git diff --name-only "$BASE_SHA" HEAD \
+            | jq -R '{filename: .}' | jq -s '.' > changed_files.json
+
+          if [ ! -s changed_files.json ] || [ "$(cat changed_files.json)" = "[]" ]; then
+            echo "No changes since $BASE_SHA, skipping benchmarks"
+            echo "go=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Changed files:"
+          jq -r '.[].filename' changed_files.json
+
+          opa eval \
+          --data build/policy/pr-check/pr_check.rego \
+          --input changed_files.json \
+          --format pretty \
+          'data.policy["pr-check"]' > opa_result.json
+
+          go_result=$(jq -r '.changes.go // false' opa_result.json)
+
+          echo "go=${go_result}" >> $GITHUB_OUTPUT
+
+          echo "Final outputs:"
+          echo "  go=${go_result}"
+
+  benchmarks:
+    permissions:
+      contents: write # we'll push to the `benchmarks` branch
+    name: Benchmarks
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.go == 'true' }}
+    uses: ./.github/workflows/run-benchmarks.yaml
+    with:
+      publish: true
+      publish_branch: benchmarks
+
+  notebook:
+    permissions:
+      contents: write # we'll push to the `benchmarks` branch
+    name: update notebook
+    runs-on: ubuntu-24.04
+    needs: [check-changes, benchmarks] # force sequential commits for notebook and benchmark results
+    if: ${{ needs.check-changes.outputs.go == 'true' }}
+    steps:
+      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: benchmarks
+          persist-credentials: true
+      - name: Setup Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Setup Clojure
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+        with:
+          install: true
+          cache: true
+          mise_toml: |
+            [tools]
+            clojure = "1.12.5.1638"
+      - name: Cache Clojure dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: clj-${{ hashFiles('clay/deps.edn') }}
+          restore-keys: clj-
+      - name: Clean previous output
+        run: rm -rf docs/*.html
+      - name: update notebook
+        run: |
+          clojure -J-Xss32m -M -m opa-bench.generate
+        working-directory: clay/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: commit if changed
+        working-directory: docs/
+        run: |
+          if ! git diff-index --quiet HEAD -- .; then
+            git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git config --local user.name "${GITHUB_ACTOR}"
+            git add -f .
+            git diff --staged --name-only
+            git commit -m "benchmarks: update notebook for ${GITHUB_SHA}"
+            git push origin benchmarks
+          else
+            echo "no changes, no commit"
+          fi

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -5,20 +5,21 @@ on:
   push:
     branches: [main]
 
-concurrency:
-  group: benchmarks
-  cancel-in-progress: false
+# NOTE(sr): No concurrency group here on purpose: this workflow only reads, and
+# comments on, a single push. It must not be serialized with the benchmark
+# results published by benchmarks-publish.yaml -- GitHub only ever queues one
+# waiting run per group, so sharing a group made these regression comments get
+# dropped whenever two pushes landed close together.
 
 permissions:
   contents: read
 
 jobs:
-    # Check what types of changes this PR contains
+  # Check what types of changes this push contains
   check-changes:
     name: Check what files changed
     runs-on: ubuntu-24.04
     outputs:
-      go: ${{ steps.changes.outputs.go }}
       bench: ${{ steps.changes.outputs.bench }}
     steps:
       - name: Check out code
@@ -40,9 +41,6 @@ jobs:
         run: |
           set -e
 
-          # Default to running all checks
-          echo "go=true" >> $GITHUB_OUTPUT
-
           echo "Comparing $BEFORE_SHA with $CURRENT_SHA"
           git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" \
             | jq -R '{filename: .}' | jq -s '.' > changed_files.json
@@ -61,26 +59,12 @@ jobs:
           --format pretty \
           'data.policy["pr-check"]' > opa_result.json
 
-          go_result=$(jq -r '.changes.go // false' opa_result.json)
           bench_result=$(jq -c '.changes.bench // []' opa_result.json)
 
-          echo "go=${go_result}" >> $GITHUB_OUTPUT
           echo "bench=${bench_result}" >> $GITHUB_OUTPUT
 
           echo "Final outputs:"
-          echo "  go=${go_result}"
           echo "  bench=${bench_result}"
-
-  benchmarks:
-    permissions:
-      contents: write # we'll push to the `benchmarks` branch
-    name: Benchmarks
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.go == 'true' }}
-    uses: ./.github/workflows/run-benchmarks.yaml
-    with:
-      publish: true
-      publish_branch: benchmarks
 
   regression-check:
     permissions:
@@ -113,60 +97,3 @@ jobs:
           AFTER_SHA: ${{ github.event.after }}
           BENCH_PKGS: ${{ needs.check-changes.outputs.bench }}
         run: go run ./build/bench-comment
-
-  notebook:
-    permissions:
-      contents: write # we'll push to the `benchmarks` branch
-    name: update notebook
-    runs-on: ubuntu-24.04
-    needs: [check-changes, benchmarks] # force sequential commits for notebook and benchmark results
-    if: ${{ needs.check-changes.outputs.go == 'true' }}
-    steps:
-      - uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
-      - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: benchmarks
-          persist-credentials: true
-      - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Setup Clojure
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
-        with:
-          install: true
-          cache: true
-          mise_toml: |
-            [tools]
-            clojure = "1.12.5.1638"
-      - name: Cache Clojure dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-          key: clj-${{ hashFiles('clay/deps.edn') }}
-          restore-keys: clj-
-      - name: Clean previous output
-        run: rm -rf docs/*.html
-      - name: update notebook
-        run: |
-          clojure -J-Xss32m -M -m opa-bench.generate
-        working-directory: clay/
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: commit if changed
-        working-directory: docs/
-        run: |
-          if ! git diff-index --quiet HEAD -- .; then
-            git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-            git config --local user.name "${GITHUB_ACTOR}"
-            git add -f .
-            git diff --staged --name-only
-            git commit -m "benchmarks: update notebook for ${GITHUB_SHA}"
-            git push origin benchmarks
-          else
-            echo "no changes, no commit"
-          fi


### PR DESCRIPTION
A full benchmark run takes up to 120 minutes, so per-push runs on main could never keep up with the branch traffic. Serializing them with a concurrency group stopped the racing writes to the `benchmarks` branch, but GitHub only ever holds ONE waiting run per group, so all but the newest queued run were cancelled ("Canceling since a higher priority waiting request for benchmarks exists") and their datapoints lost.

Split the workflow instead:

- benchmarks-publish.yaml (new) runs the publishing jobs on a 6-hourly cron, keeps the concurrency group as a safety net for manual dispatches, and skips the run when main saw no Go changes in the lookback window.
- benchmarks.yaml keeps the per-push regression comment and drops the concurrency group entirely. That job only reads, so it was being cancelled as collateral damage whenever two pushes landed close together.
