### PR TITLE
debug: Adding `query` stack-trace framing mode

### DIFF
--- a/debug/debugger.go
+++ b/debug/debugger.go
@@ -49,6 +49,24 @@ type LaunchTestProperties = v1.LaunchTestProperties
 
 type LaunchProperties = v1.LaunchProperties
 
+// StackTraceMode determines how the events of a trace are grouped into the frames
+// of a StackTrace.
+type StackTraceMode = v1.StackTraceMode
+
+const (
+	// StackTraceModeDefault is the zero value of StackTraceMode, and is equivalent to
+	// StackTraceModeQuery.
+	StackTraceModeDefault = v1.StackTraceModeDefault
+
+	// StackTraceModeQuery frames the stack trace by query, where each frame represents
+	// a query scope. This is the default.
+	StackTraceModeQuery = v1.StackTraceModeQuery
+
+	// StackTraceModeEvent frames the stack trace by trace event, where each frame
+	// represents a single event consumed by the debugger.
+	StackTraceModeEvent = v1.StackTraceModeEvent
+)
+
 type LaunchOption = v1.LaunchOption
 
 // RegoOption adds a rego option to the internal Rego instance.

--- a/v1/debug/README.md
+++ b/v1/debug/README.md
@@ -98,22 +98,22 @@ if err := session.StepOver(threads[0].ID); err != nil {
 ```
 allow if {
   x := f(input) >-+
-  x == 1          |
-}                 |
-                  |
-f(x) := y if {  <-+
+  x == 1        <-+
+}
+
+f(x) := y if {
   y := x + 1
 }
 ```
 
-### Example 2
+#### Example 2
 
 ```
 allow if {
   every x in l { >-+
-    x < 10       <-+
-  }
-  input.x == 1
+    x < 10         |
+  }                |
+  input.x == 1   <-+
 ```
 
 ### Step In
@@ -127,7 +127,7 @@ if err := session.StepIn(threads[0].ID); err != nil {
 }
 ```
 
-### Example 1
+#### Example 1
 
 ```
 allow if {
@@ -140,7 +140,7 @@ f(x) := y if {  <-+
 }
 ```
 
-### Example 2
+#### Example 2
 
 ```
 allow if {
@@ -174,7 +174,7 @@ f(x) := y if {    |
 }
 ```
 
-### Example 2
+#### Example 2
 
 ```
 allow if {
@@ -184,6 +184,71 @@ allow if {
   input.x == 1   <-+
 }
 ```
+
+## Stack Traces
+
+`StackTrace()` returns the frames of a thread, ordered from the most recent frame to the least recent.
+How trace events are grouped into frames is controlled by `LaunchProperties.StackTraceMode`, which accepts
+three values:
+
+| Value     | Constant                | Mode                                    |
+| --------- | ----------------------- | --------------------------------------- |
+| `""`      | `StackTraceModeDefault` | same as `query`; the zero value default |
+| `"query"` | `StackTraceModeQuery`   | one frame per query scope               |
+| `"event"` | `StackTraceModeEvent`   | one frame per consumed trace event      |
+
+```go
+launchProps := debug.LaunchProperties{
+    StackTraceMode: debug.StackTraceModeQuery, // the default
+}
+```
+
+### Query Mode
+
+`StackTraceModeQuery` (the default) creates one frame per query scope: the base query, a rule or
+function body, a comprehension, or an `every` expression and its body. Frames are pushed and popped as
+evaluation descends into, and returns from, referenced rules, called functions, comprehensions, and every
+expressions.
+
+A frame is named for the query it represents, prefixed with the ID of that query to allow correlating
+frames with the query IDs reported in OPA's traces. A frame is located on the expression that query is
+currently evaluating. For a frame below the top of the stack, that is the expression from which the query
+above it was entered. Expressions filtered out by `LaunchProperties.SkipOps` are not considered.
+
+Stopped on a breakpoint on row 7 of:
+
+```rego
+package example         # 1
+                        # 2
+allow if {              # 3
+	x := f(input.n)     # 4
+	x > 1               # 5
+	every y in input.l { # 6
+		y < 10          # 7 <- breakpoint
+	}                   # 8
+}                       # 9
+                        # 10
+f(n) := n + 1           # 11
+```
+
+the stack trace has four frames:
+
+```
+4: lt(__local2__, 10)                                          policy.rego:7
+3: every __local1__, __local2__ in __local5__ { lt(...) }      policy.rego:6
+1: data.example.allow                                          policy.rego:6
+0: data.example.allow = x                                      query:1
+```
+
+Note that frame names are rendered from the compiled policy, so rewritten local variables appear in their
+generated form.
+
+### Event Mode
+
+`StackTraceModeEvent` creates one frame per trace event consumed by the debugger, named after the
+event's pretty-printed trace line. Events filtered out by `LaunchProperties.SkipOps` also get a frame, and
+the number of frames grows with the number of events consumed rather than with query nesting; the same
+stop as above produces 29 frames.
 
 ## Fetching Variable Values
 

--- a/v1/debug/debugger.go
+++ b/v1/debug/debugger.go
@@ -7,14 +7,12 @@
 package debug
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
@@ -218,6 +216,24 @@ type LaunchTestProperties struct {
 	Run string
 }
 
+// StackTraceMode determines how the events of a trace are grouped into the frames
+// of a StackTrace.
+type StackTraceMode string
+
+const (
+	// StackTraceModeDefault is the zero value of StackTraceMode, and is equivalent to
+	// StackTraceModeQuery.
+	StackTraceModeDefault StackTraceMode = ""
+
+	// StackTraceModeQuery frames the stack trace by query, where each frame represents
+	// a query scope. This is the default.
+	StackTraceModeQuery StackTraceMode = "query"
+
+	// StackTraceModeEvent frames the stack trace by trace event, where each frame
+	// represents a single event consumed by the debugger.
+	StackTraceModeEvent StackTraceMode = "event"
+)
+
 type LaunchProperties struct {
 	BundlePaths         []string
 	DataPaths           []string
@@ -228,6 +244,15 @@ type LaunchProperties struct {
 	SkipOps             []topdown.Op
 	StrictBuiltinErrors bool
 	RuleIndexing        bool
+	StackTraceMode      StackTraceMode
+}
+
+func (lp LaunchProperties) validate() error {
+	switch lp.StackTraceMode {
+	case StackTraceModeDefault, StackTraceModeQuery, StackTraceModeEvent:
+		return nil
+	}
+	return fmt.Errorf("unsupported stack trace mode: %q", lp.StackTraceMode)
 }
 
 type LaunchOption func(options *launchOptions)
@@ -262,6 +287,10 @@ func (lp LaunchProperties) String() string {
 }
 
 func (d *debugger) LaunchEval(ctx context.Context, props LaunchEvalProperties, opts ...LaunchOption) (Session, error) {
+	if err := props.validate(); err != nil {
+		return nil, err
+	}
+
 	options := newLaunchOptions(opts)
 
 	store := inmem.New()
@@ -384,34 +413,33 @@ func readInput(path string) (any, error) {
 }
 
 type session struct {
-	d              *debugger
-	properties     LaunchProperties
-	threads        []*thread
-	frames         []*stackFrame
-	framesByThread map[ThreadID][]*stackFrame
-	breakpoints    *breakpointCollection
-	ctx            context.Context
-	cancel         context.CancelFunc
-	varManager     *variableManager
-	mtx            sync.Mutex
+	d           *debugger
+	properties  LaunchProperties
+	threads     []*thread
+	frames      *frameStore
+	breakpoints *breakpointCollection
+	ctx         context.Context
+	cancel      context.CancelFunc
+	varManager  *variableManager
+	mtx         sync.Mutex
 }
 
 func newSession(ctx context.Context, debugger *debugger, varManager *variableManager, props LaunchProperties, threads []*thread) *session {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &session{
-		d:              debugger,
-		varManager:     varManager,
-		properties:     props,
-		threads:        threads,
-		frames:         []*stackFrame{},
-		framesByThread: map[ThreadID][]*stackFrame{},
-		breakpoints:    newBreakpointCollection(),
-		ctx:            ctx,
-		cancel:         cancel,
+		d:           debugger,
+		varManager:  varManager,
+		properties:  props,
+		threads:     threads,
+		frames:      newFrameStore(),
+		breakpoints: newBreakpointCollection(),
+		ctx:         ctx,
+		cancel:      cancel,
 	}
 
 	for _, t := range threads {
 		t.eventHandler = s.handleEvent
+		t.framer = newFramer(props, s.frames)
 	}
 
 	return s
@@ -738,63 +766,7 @@ func (s *session) StackTrace(threadID ThreadID) (StackTrace, error) {
 		return nil, err
 	}
 
-	threadFrames := s.framesByThread[t.id]
-	if threadFrames == nil {
-		threadFrames = []*stackFrame{}
-	}
-
-	stackIndex := 0
-	if len(threadFrames) > 0 {
-		stackIndex = threadFrames[len(threadFrames)-1].stackIndex + 1
-	}
-	newEvents := t.stackEvents(stackIndex)
-	for _, e := range newEvents {
-		info := s.newStackFrame(e, t, stackIndex)
-		stackIndex++
-		threadFrames = append(threadFrames, info)
-	}
-	s.framesByThread[t.id] = threadFrames
-
-	frames := make([]StackFrame, 0, len(threadFrames))
-	for _, f := range threadFrames {
-		frames = append(frames, f)
-	}
-	slices.Reverse(frames)
-
-	return frames, nil
-}
-
-func (s *session) newStackFrame(e *topdown.Event, t *thread, stackIndex int) *stackFrame {
-	id := len(s.frames) + 1 // frames are 1-indexed
-
-	var expl string
-	if e.Node != nil {
-		pretty := new(bytes.Buffer)
-		topdown.PrettyTrace(pretty, []*topdown.Event{e})
-		expl = strings.Trim(pretty.String(), "\n")
-	} else {
-		expl = fmt.Sprintf("%s, %s", e.Op, e.Location)
-	}
-
-	frame := &stackFrame{
-		id:         FrameID(id),
-		name:       fmt.Sprintf("#%d: %d %s", id, e.QueryID, expl),
-		location:   e.Location,
-		thread:     t.id,
-		stackIndex: stackIndex,
-		e:          e,
-	}
-
-	s.frames = append(s.frames, frame)
-	return frame
-}
-
-func (s *session) frame(id FrameID) (*stackFrame, error) {
-	index := int(id) - 1
-	if index < 0 || index >= len(s.frames) {
-		return nil, fmt.Errorf("invalid frame id: %d", id)
-	}
-	return s.frames[index], nil
+	return t.stackTrace(), nil
 }
 
 func (s *session) Scopes(frameID FrameID) ([]Scope, error) {
@@ -805,7 +777,7 @@ func (s *session) Scopes(frameID FrameID) ([]Scope, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	f, err := s.frame(frameID)
+	f, err := s.frames.get(frameID)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/debug/debugger_test.go
+++ b/v1/debug/debugger_test.go
@@ -1469,14 +1469,25 @@ func TestDebuggerStepOut(t *testing.T) {
 }
 
 func TestDebuggerStackTrace(t *testing.T) {
+	mod := ast.MustParseModule(`package test
+
+p if q
+
+q if true
+`)
+	pRule, qRule := mod.Rules[0], mod.Rules[1]
+
 	tests := []struct {
-		note     string
-		events   []*topdown.Event
-		expTrace []*stackFrame
+		note          string
+		events        []*topdown.Event
+		skipOps       []topdown.Op
+		expQueryTrace []*stackFrame
+		expEventTrace []*stackFrame
 	}{
 		{
-			note:     "empty stack",
-			expTrace: []*stackFrame{},
+			note:          "empty stack",
+			expQueryTrace: []*stackFrame{},
+			expEventTrace: []*stackFrame{},
 		},
 		{
 			note: "single stack frame, no event node",
@@ -1490,7 +1501,18 @@ func TestDebuggerStackTrace(t *testing.T) {
 					},
 				},
 			},
-			expTrace: []*stackFrame{
+			expQueryTrace: []*stackFrame{
+				{
+					id:     1,
+					name:   "1",
+					thread: 1,
+					location: &location.Location{
+						File: "test.rego",
+						Row:  42,
+					},
+				},
+			},
+			expEventTrace: []*stackFrame{
 				{
 					id:     1,
 					name:   "#1: 1 Eval, test.rego:42",
@@ -1515,7 +1537,18 @@ func TestDebuggerStackTrace(t *testing.T) {
 					},
 				},
 			},
-			expTrace: []*stackFrame{
+			expQueryTrace: []*stackFrame{
+				{
+					id:     1,
+					name:   "1",
+					thread: 1,
+					location: &location.Location{
+						File: "test.rego",
+						Row:  42,
+					},
+				},
+			},
+			expEventTrace: []*stackFrame{
 				{
 					id:     1,
 					name:   "#1: 1 | Eval data.test.p[x]",
@@ -1528,7 +1561,7 @@ func TestDebuggerStackTrace(t *testing.T) {
 			},
 		},
 		{
-			note: "multiple stack frames",
+			note: "multiple events, single query",
 			events: []*topdown.Event{
 				{
 					Op:      topdown.EvalOp,
@@ -1549,8 +1582,20 @@ func TestDebuggerStackTrace(t *testing.T) {
 					},
 				},
 			},
+			// One frame for the query, anchored on its most recent event.
+			expQueryTrace: []*stackFrame{
+				{
+					id:     1,
+					name:   "5",
+					thread: 1,
+					location: &location.Location{
+						File: "test.rego",
+						Row:  3,
+					},
+				},
+			},
 			// Reversed order
-			expTrace: []*stackFrame{
+			expEventTrace: []*stackFrame{
 				{
 					id:     2,
 					name:   "#2: 5 | Unify y = 1",
@@ -1571,47 +1616,446 @@ func TestDebuggerStackTrace(t *testing.T) {
 				},
 			},
 		},
+		{
+			note: "nested queries",
+			events: []*topdown.Event{
+				{
+					Op:       topdown.EnterOp,
+					Node:     ast.MustParseBody("data.test.p = x"),
+					QueryID:  0,
+					ParentID: 0,
+					Location: &location.Location{Row: 1},
+				},
+				{
+					Op:       topdown.EvalOp,
+					Node:     ast.MustParseExpr("data.test.p = x"),
+					QueryID:  0,
+					ParentID: 0,
+					Location: &location.Location{Row: 1},
+				},
+				{
+					Op:       topdown.EnterOp,
+					Node:     pRule,
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					Op:       topdown.EvalOp,
+					Node:     ast.MustParseExpr("data.test.q"),
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					Op:       topdown.EnterOp,
+					Node:     qRule,
+					QueryID:  2,
+					ParentID: 1,
+					Location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					Op:       topdown.EvalOp,
+					Node:     ast.MustParseExpr("true"),
+					QueryID:  2,
+					ParentID: 1,
+					Location: &location.Location{File: "test.rego", Row: 5},
+				},
+			},
+			expQueryTrace: []*stackFrame{
+				{
+					id:       1,
+					name:     "2: data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					id:       2,
+					name:     "1: data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					id:       3,
+					name:     "0: data.test.p = x",
+					thread:   1,
+					location: &location.Location{Row: 1},
+				},
+			},
+			expEventTrace: []*stackFrame{
+				{
+					id:       6,
+					name:     "#6: 2 | Eval true",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					id:       5,
+					name:     "#5: 2 Enter data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					id:       4,
+					name:     "#4: 1 | Eval data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					id:       3,
+					name:     "#3: 1 Enter data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					id:       2,
+					name:     "#2: 0 | Eval data.test.p = x",
+					thread:   1,
+					location: &location.Location{Row: 1},
+				},
+				{
+					id:       1,
+					name:     "#1: 0 Enter data.test.p = x",
+					thread:   1,
+					location: &location.Location{Row: 1},
+				},
+			},
+		},
+		{
+			note:    "ancestor query anchored past skipped events",
+			skipOps: []topdown.Op{topdown.UnifyOp},
+			events: []*topdown.Event{
+				{
+					Op:       topdown.EnterOp,
+					Node:     pRule,
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					Op:       topdown.EvalOp,
+					Node:     ast.MustParseExpr("data.test.q"),
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					Op:       topdown.UnifyOp,
+					Node:     ast.MustParseExpr("x = 1"),
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 4},
+				},
+				{
+					Op:       topdown.EnterOp,
+					Node:     qRule,
+					QueryID:  2,
+					ParentID: 1,
+					Location: &location.Location{File: "test.rego", Row: 5},
+				},
+			},
+			// The ancestor frame skips the Unify event on row 4.
+			expQueryTrace: []*stackFrame{
+				{
+					id:       1,
+					name:     "2: data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					id:       2,
+					name:     "1: data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+			},
+			expEventTrace: []*stackFrame{
+				{
+					id:       4,
+					name:     "#4: 2 Enter data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 5},
+				},
+				{
+					id:       3,
+					name:     "#3: 1 | Unify x = 1",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 4},
+				},
+				{
+					id:       2,
+					name:     "#2: 1 | Eval data.test.q",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					id:       1,
+					name:     "#1: 1 Enter data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+			},
+		},
+		{
+			note:    "top frame anchored on skipped event",
+			skipOps: []topdown.Op{topdown.UnifyOp},
+			events: []*topdown.Event{
+				{
+					Op:       topdown.EnterOp,
+					Node:     pRule,
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 3},
+				},
+				{
+					Op:       topdown.UnifyOp,
+					Node:     ast.MustParseExpr("x = 1"),
+					QueryID:  1,
+					ParentID: 0,
+					Location: &location.Location{File: "test.rego", Row: 4},
+				},
+			},
+			// The top frame always tracks the most recent event, skipped or not.
+			expQueryTrace: []*stackFrame{
+				{
+					id:       1,
+					name:     "1: data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 4},
+				},
+			},
+			expEventTrace: []*stackFrame{
+				{
+					id:       2,
+					name:     "#2: 1 | Unify x = 1",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 4},
+				},
+				{
+					id:       1,
+					name:     "#1: 1 Enter data.test.p",
+					thread:   1,
+					location: &location.Location{File: "test.rego", Row: 3},
+				},
+			},
+		},
+	}
+
+	modes := []struct {
+		name string
+		mode StackTraceMode
+	}{
+		{name: "default", mode: StackTraceModeDefault},
+		{name: "query", mode: StackTraceModeQuery},
+		{name: "event", mode: StackTraceModeEvent},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.note, func(t *testing.T) {
-			ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(5*time.Second))
+		for _, m := range modes {
+			t.Run(tc.note+" ("+m.name+" mode)", func(t *testing.T) {
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(5*time.Second))
+				defer cancel()
+
+				expTrace := tc.expQueryTrace
+				if m.mode == StackTraceModeEvent {
+					expTrace = tc.expEventTrace
+				}
+
+				props := LaunchProperties{
+					SkipOps:        tc.skipOps,
+					StackTraceMode: m.mode,
+				}
+
+				stk := newTestStack(tc.events...)
+				eh := newTestEventHandler()
+				_, s, thr := setupDebuggerSession(ctx, stk, props, eh.HandleEvent, nil, nil, nil)
+
+				if err := s.start(); err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+
+				if err := s.ResumeAll(); err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+
+				if e := eh.WaitFor(ctx, TerminatedEventType); e == nil {
+					t.Fatal("Run never terminated")
+				}
+
+				trace, err := s.StackTrace(thr.id)
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+
+				if len(trace) != len(expTrace) {
+					t.Fatalf("Expected %d stack frames, got %d:\n\n%v", len(expTrace), len(trace), trace)
+				}
+
+				for i := range trace {
+					if !trace[i].Equal(expTrace[i]) {
+						t.Errorf("Expected stack frame (%d):\n\n%v\n\ngot:\n\n%v", i, expTrace[i], trace[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDebuggerStackTraceModesOnEval(t *testing.T) {
+	modName := "policy.rego"
+	files := map[string]string{
+		modName: `package example
+
+allow if {
+	x := f(input.n)
+	x > 1
+	every y in input.l {
+		y < 10          # breakpoint
+	}
+}
+
+f(n) := n + 1
+`,
+	}
+	brRow := 7
+
+	expQueryFrames := []struct {
+		name string
+		row  int
+	}{
+		{name: "4: lt(__local2__, 10)", row: 7},
+		{name: "3: every __local1__, __local2__ in __local5__ { lt(__local2__, 10) }", row: 6},
+		{name: "1: data.example.allow", row: 6},
+		{name: "0: data.example.allow = x", row: 1},
+	}
+
+	for _, m := range []struct {
+		name string
+		mode StackTraceMode
+	}{
+		{name: "default", mode: StackTraceModeDefault},
+		{name: "query", mode: StackTraceModeQuery},
+		{name: "event", mode: StackTraceModeEvent},
+	} {
+		t.Run(m.name+" mode", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
-			stk := newTestStack(tc.events...)
-			eh := newTestEventHandler()
-			_, s, thr := setupDebuggerSession(ctx, stk, LaunchProperties{}, eh.HandleEvent, nil, nil, nil)
+			rootDir := test.TempDir(t, files)
 
-			if err := s.start(); err != nil {
+			eh := newTestEventHandler()
+			d := NewDebugger(SetEventHandler(eh.HandleEvent))
+
+			launchProps := LaunchEvalProperties{
+				LaunchProperties: LaunchProperties{
+					DataPaths:      []string{path.Join(rootDir, modName)},
+					StackTraceMode: m.mode,
+				},
+				Query: "data.example.allow = x",
+				Input: map[string]any{"n": 5, "l": []any{1, 2}},
+			}
+
+			s, err := d.LaunchEval(ctx, launchProps)
+			if err != nil {
+				t.Fatalf("Unexpected error launching debug session: %v", err)
+			}
+
+			if _, err := s.AddBreakpoint(location.Location{File: path.Join(rootDir, modName), Row: brRow}); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
 			if err := s.ResumeAll(); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
+				t.Fatalf("Unexpected error resuming threads: %v", err)
 			}
 
-			if e := eh.WaitFor(ctx, TerminatedEventType); e == nil {
-				t.Fatal("Run never terminated")
+			if e := eh.WaitFor(ctx, StoppedEventType); e == nil {
+				t.Fatal("Expected stopped event")
+			} else if e.stackEvent.Location.Row != brRow {
+				t.Fatalf("Expected to stop on row %d, got %d", brRow, e.stackEvent.Location.Row)
 			}
 
-			trace, err := s.StackTrace(thr.id)
+			eh.IgnoreAll(ctx)
+
+			trace, err := s.StackTrace(ThreadID(1))
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			if len(trace) != len(tc.expTrace) {
-				t.Fatalf("Expected %d stack frames, got %d", len(tc.expTrace), len(trace))
+			if m.mode == StackTraceModeEvent {
+				// Every consumed trace event gets a frame, including those skipped by SkipOps.
+				if exp := s.(*session).threads[0].consumed; len(trace) != exp {
+					t.Errorf("Expected %d stack frames, got %d", exp, len(trace))
+				}
+				if trace[0].Location().Row != brRow {
+					t.Errorf("Expected top frame on row %d, got %d", brRow, trace[0].Location().Row)
+				}
+				return
 			}
 
-			if len(trace) != len(tc.expTrace) {
-				t.Errorf("Expected stack trace:\n\n%v\n\ngot:\n\n%v", tc.expTrace, trace)
+			if len(trace) != len(expQueryFrames) {
+				t.Fatalf("Expected %d stack frames, got %d:\n\n%v", len(expQueryFrames), len(trace), trace)
 			}
-			for i := range trace {
-				if !trace[i].Equal(tc.expTrace[i]) {
-					t.Errorf("Expected stack frame (%d):\n\n%v\n\ngot:\n\n%v", i, tc.expTrace[i], trace[i])
+
+			for i, exp := range expQueryFrames {
+				if trace[i].Name() != exp.name {
+					t.Errorf("Expected frame %d name %q, got %q", i, exp.name, trace[i].Name())
+				}
+				if trace[i].Location().Row != exp.row {
+					t.Errorf("Expected frame %d on row %d, got %d", i, exp.row, trace[i].Location().Row)
 				}
 			}
 		})
+	}
+}
+
+func TestLaunchPropertiesStackTraceModeValidation(t *testing.T) {
+	tests := []struct {
+		note   string
+		mode   StackTraceMode
+		expErr string
+	}{
+		{note: "default (unset)", mode: StackTraceModeDefault},
+		{note: "query", mode: StackTraceModeQuery},
+		{note: "event", mode: StackTraceModeEvent},
+		{note: "unknown", mode: "events", expErr: `unsupported stack trace mode: "events"`},
+		{note: "wrong case", mode: "Query", expErr: `unsupported stack trace mode: "Query"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			err := LaunchProperties{StackTraceMode: tc.mode}.validate()
+
+			if tc.expErr == "" {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("Expected error %q, got nil", tc.expErr)
+			}
+			if err.Error() != tc.expErr {
+				t.Errorf("Expected error %q, got %q", tc.expErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestDebuggerLaunchEvalInvalidStackTraceMode(t *testing.T) {
+	d := NewDebugger()
+
+	_, err := d.LaunchEval(t.Context(), LaunchEvalProperties{
+		LaunchProperties: LaunchProperties{StackTraceMode: "events"},
+		Query:            "1 == 1",
+	})
+
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+
+	if exp := `unsupported stack trace mode: "events"`; err.Error() != exp {
+		t.Errorf("Expected error %q, got %q", exp, err.Error())
 	}
 }
 

--- a/v1/debug/stacktrace.go
+++ b/v1/debug/stacktrace.go
@@ -1,0 +1,246 @@
+// Copyright 2024 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package debug
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown"
+)
+
+const maxFrameNameLength = 80
+
+// frameStore holds every StackFrame created during a session, and is the resolver for
+// the FrameID handed out to clients. Frames are 1-indexed.
+type frameStore struct {
+	frames []*stackFrame
+}
+
+func newFrameStore() *frameStore {
+	return &frameStore{}
+}
+
+func (fs *frameStore) add(f *stackFrame) *stackFrame {
+	f.id = FrameID(len(fs.frames) + 1)
+	fs.frames = append(fs.frames, f)
+	return f
+}
+
+func (fs *frameStore) get(id FrameID) (*stackFrame, error) {
+	index := int(id) - 1
+	if index < 0 || index >= len(fs.frames) {
+		return nil, fmt.Errorf("invalid frame id: %d", id)
+	}
+	return fs.frames[index], nil
+}
+
+// framer groups the trace events of a thread into the frames of a StackTrace.
+type framer interface {
+	// consume records the event at stackIndex in the thread's event history.
+	// Events are consumed once, in order.
+	consume(stackIndex int, e *topdown.Event, t *thread)
+
+	// stackTrace returns the frames of the thread's stack, most recent frame first.
+	stackTrace(t *thread) StackTrace
+}
+
+func newFramer(props LaunchProperties, frames *frameStore) framer {
+	if props.StackTraceMode == StackTraceModeEvent {
+		return &eventFramer{store: frames}
+	}
+	return &queryFramer{store: frames, skipOps: props.SkipOps, queries: newQueryIndex()}
+}
+
+// eventFramer creates one frame per consumed trace event, including events filtered
+// out by LaunchProperties.SkipOps.
+type eventFramer struct {
+	store *frameStore
+	// frames is this thread's stack, in event order.
+	frames []*stackFrame
+}
+
+func (f *eventFramer) consume(stackIndex int, e *topdown.Event, t *thread) {
+	var expl string
+	if e.Node != nil {
+		pretty := new(bytes.Buffer)
+		topdown.PrettyTrace(pretty, []*topdown.Event{e})
+		expl = strings.Trim(pretty.String(), "\n")
+	} else {
+		expl = fmt.Sprintf("%s, %s", e.Op, e.Location)
+	}
+
+	frame := f.store.add(&stackFrame{
+		location:   e.Location,
+		thread:     t.id,
+		stackIndex: stackIndex,
+		e:          e,
+	})
+	frame.name = fmt.Sprintf("#%d: %d %s", frame.id, e.QueryID, expl)
+
+	f.frames = append(f.frames, frame)
+}
+
+func (f *eventFramer) stackTrace(*thread) StackTrace {
+	frames := make(StackTrace, 0, len(f.frames))
+	for i := len(f.frames) - 1; i >= 0; i-- {
+		frames = append(frames, f.frames[i])
+	}
+
+	return frames
+}
+
+// queryFramer creates one frame per query scope: the base query, a rule or function
+// body, a comprehension, or an every expression and its body.
+type queryFramer struct {
+	store   *frameStore
+	skipOps []topdown.Op
+	queries *queryIndex
+}
+
+func (f *queryFramer) consume(stackIndex int, e *topdown.Event, _ *thread) {
+	f.queries.add(stackIndex, e, slices.Contains(f.skipOps, e.Op))
+}
+
+// stackTrace walks the QueryID -> ParentID chain up from the most recently consumed
+// event. Query IDs are allocated in creation order, so a parent always has a lower ID
+// than its child, which makes the walk terminating.
+func (f *queryFramer) stackTrace(t *thread) StackTrace {
+	frames := StackTrace{}
+
+	stackIndex := t.consumed - 1
+	e := t.stack.Event(stackIndex)
+	if e == nil {
+		return frames
+	}
+
+	queryID := e.QueryID
+
+	for {
+		frames = append(frames, f.newFrame(t, queryID, stackIndex))
+
+		if queryID == 0 {
+			break
+		}
+
+		parent, ok := f.queries.parent[queryID]
+		if !ok || parent >= queryID {
+			break
+		}
+
+		if stackIndex, ok = f.queries.anchor(parent); !ok {
+			break
+		}
+
+		queryID = parent
+	}
+
+	return frames
+}
+
+func (f *queryFramer) newFrame(t *thread, queryID uint64, stackIndex int) *stackFrame {
+	e := t.stack.Event(stackIndex)
+
+	frame := &stackFrame{
+		name:       f.name(t, queryID),
+		thread:     t.id,
+		stackIndex: stackIndex,
+		e:          e,
+	}
+
+	if e != nil {
+		frame.location = e.Location
+	}
+
+	return f.store.add(frame)
+}
+
+// name names a frame for the query it represents, prefixed with the query ID to let
+// users correlate frames with the query IDs reported in OPA's traces.
+func (f *queryFramer) name(t *thread, queryID uint64) string {
+	if i, ok := f.queries.enter[queryID]; ok {
+		if name := queryNodeName(t.stack.Event(i)); name != "" {
+			return fmt.Sprintf("%d: %s", queryID, name)
+		}
+	}
+
+	return strconv.FormatUint(queryID, 10)
+}
+
+// queryIndex tracks, per query ID, where in the event history that query was entered,
+// which query entered it, and the events it has most recently emitted.
+type queryIndex struct {
+	parent           map[uint64]uint64
+	enter            map[uint64]int
+	latestAny        map[uint64]int
+	latestNonSkipped map[uint64]int
+}
+
+func newQueryIndex() *queryIndex {
+	return &queryIndex{
+		parent:           map[uint64]uint64{},
+		enter:            map[uint64]int{},
+		latestAny:        map[uint64]int{},
+		latestNonSkipped: map[uint64]int{},
+	}
+}
+
+func (qi *queryIndex) add(stackIndex int, e *topdown.Event, skipped bool) {
+	if e == nil {
+		return
+	}
+
+	if _, ok := qi.parent[e.QueryID]; !ok {
+		qi.parent[e.QueryID] = e.ParentID
+	}
+
+	if e.Op == topdown.EnterOp {
+		if _, ok := qi.enter[e.QueryID]; !ok {
+			qi.enter[e.QueryID] = stackIndex
+		}
+	}
+
+	qi.latestAny[e.QueryID] = stackIndex
+	if !skipped {
+		qi.latestNonSkipped[e.QueryID] = stackIndex
+	}
+}
+
+// anchor returns the index of the event that a frame for queryID is anchored to.
+func (qi *queryIndex) anchor(queryID uint64) (int, bool) {
+	if i, ok := qi.latestNonSkipped[queryID]; ok {
+		return i, true
+	}
+	if i, ok := qi.enter[queryID]; ok {
+		return i, true
+	}
+
+	i, ok := qi.latestAny[queryID]
+	return i, ok
+}
+
+func queryNodeName(e *topdown.Event) string {
+	if e == nil {
+		return ""
+	}
+
+	switch n := e.Node.(type) {
+	case *ast.Rule:
+		if n.Module != nil {
+			return truncatedString(n.Ref().String(), maxFrameNameLength)
+		}
+		return truncatedString(n.Head.Ref().String(), maxFrameNameLength)
+	case *ast.Expr:
+		return truncatedString(n.String(), maxFrameNameLength)
+	case ast.Body:
+		return truncatedString(n.String(), maxFrameNameLength)
+	}
+
+	return ""
+}

--- a/v1/debug/thread.go
+++ b/v1/debug/thread.go
@@ -53,6 +53,8 @@ type thread struct {
 	virtualCache    topdown.VirtualCache
 	store           storage.Store
 	logger          logging.Logger
+	framer          framer
+	consumed        int
 	mtx             sync.Mutex
 }
 
@@ -287,6 +289,17 @@ func (t *thread) stackEvents(from int) []*topdown.Event {
 		from++
 	}
 	return events
+}
+
+// stackTrace consumes any trace events not yet seen by the thread's framer, and returns
+// the resulting stack, ordered from the most recent frame to the least recent.
+func (t *thread) stackTrace() StackTrace {
+	for _, e := range t.stackEvents(t.consumed) {
+		t.framer.consume(t.consumed, e, t)
+		t.consumed++
+	}
+
+	return t.framer.stackTrace(t)
 }
 
 // Scope represents the variable state of a StackFrame.


### PR DESCRIPTION
and making it the default.

Users can set `LaunchProperties.StackTraceMode` to `StackTraceModeEvent` to go back to the old event-based framing mode (`"stackTraceMode": "event"/"query"` in vs-code launch settings).

