### PR TITLE
ast: hint at missing future keyword imports

### DIFF
--- a/v1/ast/capabilities_test.go
+++ b/v1/ast/capabilities_test.go
@@ -141,7 +141,7 @@ func TestParserCapabilitiesWithWildcardOptInAndOlderOPA(t *testing.T) {
 		t.Fatal("expected error")
 	} else if errs, ok := err.(Errors); !ok || len(errs) != 1 {
 		t.Fatal("expected exactly one error but got:", err)
-	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 7 || errs[0].Message != "unexpected identifier token: expected \\n or ; or }" {
+	} else if errs[0].Code != ParseErr || errs[0].Location.Row != 7 || errs[0].Message != "unexpected identifier token: expected \\n or ; or } (hint: `import future.keywords.in` for `x in xs` expressions)" {
 		t.Fatal("unexpected error:", err)
 	}
 }

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1191,6 +1191,7 @@ func (p *Parser) parseQuery(requireSemi bool, end tokens.Token) Body {
 		if !p.s.skippedNL {
 			// If there was already an error then don't pile this one on
 			if len(p.s.errors) == 0 {
+				p.hintMissingInfixKeyword()
 				p.illegal(`expected \n or %s or %s`, tokens.Semicolon, end)
 			}
 			return nil
@@ -1469,6 +1470,60 @@ func (p *Parser) attachWith(e *Expr) *Expr {
 		}
 	}
 	return e
+}
+
+// infixFutureKeywords are the future keywords usable as infix operators in a
+// rule body, mapped to an example of the expression each enables.
+var infixFutureKeywords = map[string]string{
+	"in":  "x in xs",
+	"and": "x and y",
+	"or":  "x or y",
+}
+
+// hintMissingInfixKeyword hints at the import for a body expression trailed by
+// a plain `in`/`and`/`or` identifier, or by the comma of `k, v in xs`. Only
+// call it when an error is about to be reported: an unconsumed hint would end
+// up attached to a later, unrelated error.
+func (p *Parser) hintMissingInfixKeyword() {
+	// Something more specific, like `some x in xs`, already hinted.
+	if len(p.s.hints) > 0 {
+		return
+	}
+
+	kw := "in"
+
+	switch p.s.tok {
+	case tokens.Ident:
+		// An active keyword scans as its own token, so an Ident means it's
+		// the import that's missing.
+		kw = p.s.lit
+		if _, ok := infixFutureKeywords[kw]; !ok {
+			return
+		}
+	case tokens.Comma:
+		// Only hint on `k, v in xs`, so require a membership expr after the comma.
+		s := p.save()
+		p.scan()
+		term := p.futureParser().parseTermInfixCall()
+		p.restore(s)
+
+		if term == nil {
+			return
+		}
+		call, ok := term.Value.(Call)
+		if !ok || len(call) == 0 {
+			return
+		}
+		switch call[0].String() {
+		case Member.Name, MemberWithKey.Name:
+		default:
+			return
+		}
+	default:
+		return
+	}
+
+	p.hint(fmt.Sprintf("`import future.keywords.%s` for `%s` expressions", kw, infixFutureKeywords[kw]))
 }
 
 func (p *Parser) errWithOnOperand(loc *Location, kw string) {

--- a/v1/ast/parser_ext.go
+++ b/v1/ast/parser_ext.go
@@ -703,7 +703,12 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoCo
 		case Body:
 			rule, err := ParseRuleFromBody(mod, stmt)
 			if err != nil {
-				errs = append(errs, NewError(ParseErr, stmt[0].Location, "%s", err.Error()))
+				msg := err.Error()
+				if kw, ok := missingHeadKeyword(mod.regoVersion, stmt, stmts, i+1); ok {
+					msg = fmt.Sprintf("%s (hint: `import future.keywords.%s` for `%s` rules)",
+						msg, kw, headFutureKeywords[kw])
+				}
+				errs = append(errs, NewError(ParseErr, stmt[0].Location, "%s", msg))
 				continue
 			}
 			rule.generatedBody = true
@@ -745,6 +750,66 @@ func parseModule(filename string, stmts []Statement, comments []*Comment, regoCo
 	attachRuleAnnotations(mod)
 
 	return mod, nil
+}
+
+// headFutureKeywords are the future keywords used in a rule head, mapped to an
+// example of the rule form each enables.
+var headFutureKeywords = map[string]string{
+	"if":       "p if { ... }",
+	"contains": "p contains x",
+}
+
+// missingHeadKeyword reports the rule-head future keyword a statement was
+// misparsed around. Unimported, the keyword is just a var, so `p if { ... }`
+// parses as the body `p` followed by a rule named `if`. idx is stmt's index
+// within stmts.
+func missingHeadKeyword(v RegoVersion, stmt Body, stmts []Statement, idx int) (string, bool) {
+	// From v1 on these are ordinary keywords.
+	if v != RegoV0 {
+		return "", false
+	}
+
+	if kw, ok := statementHeadKeyword(stmt); ok {
+		return kw, true
+	}
+
+	// The keyword starts its own statement; check the next one on the same line.
+	if idx+1 >= len(stmts) {
+		return "", false
+	}
+	next := stmts[idx+1]
+	if next.Loc() == nil || stmt.Loc() == nil || next.Loc().Row != stmt.Loc().Row {
+		return "", false
+	}
+
+	return statementHeadKeyword(next)
+}
+
+// statementHeadKeyword returns the rule-head future keyword a statement was
+// reduced to: a rule named after it, or a body holding only it as a var.
+func statementHeadKeyword(stmt Statement) (string, bool) {
+	var name Var
+
+	switch stmt := stmt.(type) {
+	case *Rule:
+		name = stmt.Head.Name
+	case Body:
+		if len(stmt) != 1 {
+			return "", false
+		}
+		term, ok := stmt[0].Terms.(*Term)
+		if !ok {
+			return "", false
+		}
+		if name, ok = term.Value.(Var); !ok {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+
+	_, ok := headFutureKeywords[string(name)]
+	return string(name), ok
 }
 
 func ruleDeclarationHasKeyword(rule *Rule, keyword tokens.Token) bool {

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -2538,6 +2538,241 @@ func TestEvery(t *testing.T) {
 	assertParseErrorContains(t, "invalid domain (internal.member_3)", "every internal.member_3()", "illegal domain", opts)
 }
 
+func TestMembershipExprHint(t *testing.T) {
+	v0 := ParserOptions{RegoVersion: RegoV0}
+	hint := "(hint: `import future.keywords.in` for `x in xs` expressions)"
+
+	hinted := []struct {
+		note  string
+		input string
+	}{
+		{"bare membership expr", `p {
+			input.request.operation in {"CREATE", "UPDATE"}
+		}`},
+		{"negated", `p {
+			not x in xs
+		}`},
+		{"semicolon separated", `p {
+			x in xs; x
+		}`},
+		{"comprehension body", `p {
+			ys := [y | y in xs]
+		}`},
+		{"assigned", `p {
+			x := y in ys
+		}`},
+		{"unified", `p {
+			x = y in ys
+		}`},
+		{"key/value membership", `p {
+			"k", v in {"k": "v"}
+		}`},
+	}
+
+	for _, tc := range hinted {
+		assertParseErrorContains(t, tc.note, tc.input, hint, v0)
+		assertNoParseError(t, tc.input, ParserOptions{RegoVersion: RegoV1})
+	}
+
+	// The comma only earns a hint when a membership expr follows it.
+	assertParseErrorContains(t, "unrelated comma error gets no hint", `p {
+		x, y
+	}`,
+		"unexpected , token: expected \\n or ; or }\n\tx, y\n", v0)
+
+	// `in` on its own line is just a var in v0.
+	assertNoParseError(t, `p {
+		x
+		in
+	}`, v0)
+
+	// A recovered membership expr must not leave a hint for a later error.
+	if _, err := ParseBodyWithOpts("x in xs\n1 +++ 2", v0); err == nil {
+		t.Fatal("expected parse error")
+	} else if strings.Contains(err.Error(), "hint") {
+		t.Errorf("expected no hint on unrelated error, got: %v", err)
+	}
+}
+
+func TestMembershipExprHintWithLogicalKeywords(t *testing.T) {
+	v0 := ParserOptions{RegoVersion: RegoV0}
+	hint := "(hint: `import future.keywords.in` for `x in xs` expressions)"
+
+	tests := []struct {
+		note   string
+		module string
+	}{
+		{"membership on the lhs of `and`", `package test
+			import future.keywords.and
+			p { x in xs and y }`},
+		{"membership on the rhs of `and`", `package test
+			import future.keywords.and
+			p { y and x in xs }`},
+		{"membership on the rhs of `or`", `package test
+			import future.keywords.or
+			p { y or x in xs }`},
+		{"membership inside a not-body", `package test
+			import future.keywords.not
+			p { not { x in xs } }`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, v0)
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), hint) {
+				t.Errorf("expected hint %q, got: %v", hint, err)
+			}
+		})
+	}
+
+	// Unimported `and`/`or` get their own hint, not the `in` one.
+	t.Run("unimported and gets its own hint", func(t *testing.T) {
+		_, err := ParseModuleWithOpts("test.rego", "package test\np { x and y }", v0)
+		if err == nil {
+			t.Fatal("expected parse error")
+		}
+		exp := "(hint: `import future.keywords.and` for `x and y` expressions)"
+		if !strings.Contains(err.Error(), exp) {
+			t.Errorf("expected hint %q, got: %v", exp, err)
+		}
+	})
+}
+
+func TestInfixKeywordImportHint(t *testing.T) {
+	tests := []struct {
+		note    string
+		module  string
+		version RegoVersion
+		expHint string
+	}{
+		{
+			note:    "`and` is a future keyword in v1",
+			module:  "package test\np if { x and y }",
+			version: RegoV1,
+			expHint: "(hint: `import future.keywords.and` for `x and y` expressions)",
+		},
+		{
+			note:    "`or` is a future keyword in v1",
+			module:  "package test\np if { x or y }",
+			version: RegoV1,
+			expHint: "(hint: `import future.keywords.or` for `x or y` expressions)",
+		},
+		{
+			note:    "`and` after a braced operand",
+			module:  "package test\np if { {x} and y }",
+			version: RegoV1,
+			expHint: "(hint: `import future.keywords.and` for `x and y` expressions)",
+		},
+		{
+			note:    "`in` is a future keyword in v0",
+			module:  "package test\np { x in xs }",
+			version: RegoV0,
+			expHint: "(hint: `import future.keywords.in` for `x in xs` expressions)",
+		},
+		{
+			note:    "`and` is importable in v0 too",
+			module:  "package test\np { x and y }",
+			version: RegoV0,
+			expHint: "(hint: `import future.keywords.and` for `x and y` expressions)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, ParserOptions{RegoVersion: tc.version})
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), tc.expHint) {
+				t.Errorf("expected hint %q, got: %v", tc.expHint, err)
+			}
+		})
+	}
+
+	// An identifier that isn't a future keyword must not be hinted at.
+	t.Run("unrelated identifier gets no hint", func(t *testing.T) {
+		_, err := ParseModuleWithOpts("test.rego", "package test\np if { x y }", ParserOptions{RegoVersion: RegoV1})
+		if err == nil {
+			t.Fatal("expected parse error")
+		}
+		if strings.Contains(err.Error(), "hint") {
+			t.Errorf("expected no hint, got: %v", err)
+		}
+	})
+}
+
+func TestRuleHeadKeywordImportHint(t *testing.T) {
+	v0 := ParserOptions{RegoVersion: RegoV0}
+	ifHint := "(hint: `import future.keywords.if` for `p if { ... }` rules)"
+	containsHint := "(hint: `import future.keywords.contains` for `p contains x` rules)"
+
+	tests := []struct {
+		note    string
+		module  string
+		expHint string
+	}{
+		{"if, braced body", "package test\np if { true }", ifHint},
+		{"if, one-line body", "package test\np if true", ifHint},
+		{"contains", "package test\np contains x { x := 1 }", containsHint},
+		{"contains and if", "package test\np contains x if { x := 1 }", containsHint},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, v0)
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), tc.expHint) {
+				t.Errorf("expected hint %q, got: %v", tc.expHint, err)
+			}
+		})
+	}
+
+	// Both are legal rule names in v0, and an unrelated bad head isn't a hint.
+	noHint := []struct {
+		note   string
+		module string
+		expErr bool
+	}{
+		{"rule named if", "package test\nif := 1", false},
+		{"rule named contains", "package test\ncontains := 1", false},
+		{"genuinely bad rule head", "package test\n1", true},
+	}
+
+	for _, tc := range noHint {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, v0)
+			if !tc.expErr {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if strings.Contains(err.Error(), "hint") {
+				t.Errorf("expected no hint, got: %v", err)
+			}
+		})
+	}
+
+	// From v1 on the keywords are standard.
+	for _, module := range []string{
+		"package test\np if { true }",
+		"package test\np contains x if { x := 1 }",
+		"package test\nimport rego.v1\np if { true }",
+	} {
+		if _, err := ParseModuleWithOpts("test.rego", module, ParserOptions{RegoVersion: RegoV1}); err != nil {
+			t.Errorf("expected %q to parse in v1, got: %v", module, err)
+		}
+	}
+}
+
 func TestNestedExpressions(t *testing.T) {
 
 	n1 := IntNumberTerm(1)


### PR DESCRIPTION
Name the missing import in the parse error when `in`, `and`, `or`, `if` or `contains` is used without the keyword being imported.

Fixes: #4619