### PR TITLE
ast: emphasize top-most differing types in type errors

### DIFF
--- a/v1/ast/check.go
+++ b/v1/ast/check.go
@@ -1172,10 +1172,48 @@ type ArgErrDetail struct {
 
 // Lines returns the string representation of the detail.
 func (d *ArgErrDetail) Lines() []string {
-	lines := make([]string, 2)
-	lines[0] = "have: " + formatArgs(d.Have)
-	lines[1] = "want: " + d.Want.String()
-	return lines
+	have := "have: " + formatArgs(d.Have)
+	want := "want: " + d.Want.String()
+
+	if !tooWideForTypeErr(have, want) {
+		return []string{have, want}
+	}
+
+	// Positions that only exist on one side, as is the case for arity errors,
+	// have nothing to be compared against, and are collapsed to their outermost
+	// type constructor.
+	haveArgs := make([]string, len(d.Have))
+	for i := range d.Have {
+		haveArgs[i] = elideType(d.Have[i])
+	}
+	wantArgs := make([]string, len(d.Want.Args))
+	for i := range d.Want.Args {
+		wantArgs[i] = elideType(d.Want.Args[i])
+	}
+
+	for i := range min(len(haveArgs), len(wantArgs)) {
+		haveArgs[i], wantArgs[i] = diffArg(d.Have[i], d.Want.Args[i])
+	}
+
+	if d.Want.Variadic != nil {
+		wantArgs = append(wantArgs, elideType(d.Want.Variadic)+"...")
+	}
+
+	return []string{
+		"have: (" + strings.Join(haveArgs, ", ") + ")",
+		"want: (" + strings.Join(wantArgs, ", ") + ")",
+	}
+}
+
+// diffArg renders an actual and an expected argument type side by side. The two
+// are only diffed if they are actually in conflict: an argument that the
+// function would have accepted is not what the error is about, and expanding it
+// is what makes these messages unreadable in the first place.
+func diffArg(have, want types.Type) (string, string) {
+	if have != nil && want != nil && unifies(unwrapNamedType(have), unwrapNamedType(want)) {
+		return elideType(have), elideType(want)
+	}
+	return sprintDiff(have, want)
 }
 
 func (d *ArgErrDetail) nilType() bool {
@@ -1195,10 +1233,15 @@ func (a *UnificationErrDetail) nilType() bool {
 
 // Lines returns the string representation of the detail.
 func (a *UnificationErrDetail) Lines() []string {
-	lines := make([]string, 2)
-	lines[0] = fmt.Sprint("left  : ", types.Sprint(a.Left))
-	lines[1] = fmt.Sprint("right : ", types.Sprint(a.Right))
-	return lines
+	leftLine := "left  : " + types.Sprint(a.Left)
+	rightLine := "right : " + types.Sprint(a.Right)
+
+	if !tooWideForTypeErr(leftLine, rightLine) {
+		return []string{leftLine, rightLine}
+	}
+
+	left, right := sprintDiff(a.Left, a.Right)
+	return []string{"left  : " + left, "right : " + right}
 }
 
 // RefErrUnsupportedDetail describes an undefined reference error where the

--- a/v1/ast/check_elide.go
+++ b/v1/ast/check_elide.go
@@ -1,0 +1,395 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/open-policy-agent/opa/v1/types"
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+const (
+	typeElision = "..."
+
+	// maxTypeErrLineWidth is the width above which a type error detail line is
+	// re-rendered with nested type information elided. Details that already fit
+	// are left alone: eliding them would drop information without buying any
+	// readability.
+	maxTypeErrLineWidth = 80
+
+	// maxElidedTypeWidth is the width above which a type that is not itself the
+	// subject of the mismatch is collapsed to its outermost constructor.
+	maxElidedTypeWidth = 32
+
+	// maxTypeDiffDepth bounds the parallel walk so that deeply nested types
+	// cannot produce an unreadable message, or, for cyclic types, no message.
+	maxTypeDiffDepth = 8
+)
+
+// sprintDiff returns the string representations of a and b, keeping only the
+// structure that is needed to see how the two differ. Sub-types that are equal
+// on both sides are collapsed to their outermost type constructor, and object
+// properties and any-members that are equal on both sides are dropped
+// altogether. An ellipsis marks everything that was left out.
+func sprintDiff(a, b types.Type) (string, string) {
+	return diffTypes(a, b, 0)
+}
+
+// sprintElided returns the string representation of t with any type information
+// nested more than depth levels below t replaced by an ellipsis. A depth of zero
+// keeps the outermost type constructor only; a negative depth renders t in full,
+// exactly as types.Sprint does.
+func sprintElided(t types.Type, depth int) string {
+	if depth < 0 {
+		return types.Sprint(t)
+	}
+
+	switch t := t.(type) {
+	case nil:
+		return types.Sprint(t)
+	case *types.NamedType:
+		// A name is not a level of nesting, so depth is passed through.
+		return t.Name + ": " + sprintElided(t.Type, depth)
+	case *types.Set:
+		if depth == 0 {
+			return "set[" + typeElision + "]"
+		}
+		return "set[" + sprintElided(t.Of(), depth-1) + "]"
+	case *types.Array:
+		static := make([]string, 0, t.Len())
+		if depth == 0 && t.Len() > 0 {
+			static = append(static, typeElision)
+		} else {
+			for i := range t.Len() {
+				static = append(static, sprintElided(t.Select(i), depth-1))
+			}
+		}
+		var dynamic string
+		if dyn := t.Dynamic(); dyn != nil {
+			if depth == 0 {
+				dynamic = typeElision
+			} else {
+				dynamic = sprintElided(dyn, depth-1)
+			}
+		}
+		return sprintArray(static, dynamic)
+	case *types.Object:
+		props := t.StaticProperties()
+		static := make([]string, 0, len(props))
+		if depth == 0 && len(props) > 0 {
+			static = append(static, typeElision)
+		} else {
+			for _, p := range props {
+				static = append(static, sprintProperty(p.Key, sprintElided(p.Value, depth-1)))
+			}
+		}
+		var dynamic string
+		if dyn := t.DynamicProperties(); dyn != nil {
+			if depth == 0 {
+				dynamic = typeElision
+			} else {
+				dynamic = sprintElided(dyn.Key, depth-1) + ": " + sprintElided(dyn.Value, depth-1)
+			}
+		}
+		return sprintObject(static, dynamic)
+	case types.Any:
+		if len(t) == 0 {
+			return t.String()
+		}
+		if depth == 0 {
+			return sprintAny([]string{typeElision})
+		}
+		of := make([]string, len(t))
+		for i := range t {
+			of[i] = sprintElided(t[i], depth-1)
+		}
+		return sprintAny(of)
+	case *types.Function:
+		args := t.FuncArgs()
+		params := make([]string, 0, len(args.Args)+1)
+		if depth == 0 {
+			if len(args.Args) > 0 || args.Variadic != nil {
+				params = append(params, typeElision)
+			}
+			if t.Result() == nil {
+				return sprintFunction(params, types.Sprint(nil))
+			}
+			return sprintFunction(params, typeElision)
+		}
+		for i := range args.Args {
+			params = append(params, sprintElided(args.Args[i], depth-1))
+		}
+		if args.Variadic != nil {
+			params = append(params, sprintElided(args.Variadic, depth-1)+"...")
+		}
+		return sprintFunction(params, sprintElided(t.Result(), depth-1))
+	default:
+		// Scalars, and recursive types, which are rendered by name only.
+		return t.String()
+	}
+}
+
+// elideType collapses t to its outermost type constructor, unless it is short
+// enough that spelling it out costs nothing.
+func elideType(t types.Type) string {
+	if full := types.Sprint(t); utf8.RuneCountInString(full) <= maxElidedTypeWidth {
+		return full
+	}
+	return sprintElided(t, 0)
+}
+
+func unwrapNamedType(t types.Type) types.Type {
+	if n, ok := t.(*types.NamedType); ok {
+		return n.Type
+	}
+	return t
+}
+
+// typesEqual reports whether a and b would render identically. Comparing the
+// rendered form, rather than the type structure, keeps this safe for recursive
+// types, which render as a name rather than as their unrolled definition.
+func typesEqual(a, b types.Type) bool {
+	return types.Sprint(a) == types.Sprint(b)
+}
+
+func diffTypes(a, b types.Type, depth int) (string, string) {
+	// A name is not a level of nesting, so depth is passed through.
+	if n, ok := a.(*types.NamedType); ok {
+		left, right := diffTypes(n.Type, b, depth)
+		return n.Name + ": " + left, right
+	}
+	if n, ok := b.(*types.NamedType); ok {
+		left, right := diffTypes(a, n.Type, depth)
+		return left, n.Name + ": " + right
+	}
+
+	if depth >= maxTypeDiffDepth || a == nil || b == nil || typesEqual(a, b) {
+		return elideType(a), elideType(b)
+	}
+
+	switch a := a.(type) {
+	case *types.Set:
+		if b, ok := b.(*types.Set); ok {
+			left, right := diffTypes(a.Of(), b.Of(), depth+1)
+			return "set[" + left + "]", "set[" + right + "]"
+		}
+	case *types.Array:
+		if b, ok := b.(*types.Array); ok {
+			return diffArrays(a, b, depth)
+		}
+	case *types.Object:
+		if b, ok := b.(*types.Object); ok {
+			return diffObjects(a, b, depth)
+		}
+	case types.Any:
+		if b, ok := b.(types.Any); ok {
+			return diffAnys(a, b)
+		}
+	case *types.Function:
+		if b, ok := b.(*types.Function); ok && a.Arity() == b.Arity() {
+			return diffFunctions(a, b, depth)
+		}
+	}
+
+	// The outermost type constructors already differ, which is all the reader
+	// needs to see.
+	return elideType(a), elideType(b)
+}
+
+func diffArrays(a, b *types.Array, depth int) (string, string) {
+	if a.Len() != b.Len() || (a.Dynamic() == nil) != (b.Dynamic() == nil) {
+		// Element types are still shown so that it is clear which of the two is
+		// the longer, or which one has a dynamic tail.
+		return sprintElided(a, 1), sprintElided(b, 1)
+	}
+
+	// Array elements are positional, so equal ones are collapsed rather than
+	// dropped, keeping the two renderings aligned.
+	left := make([]string, 0, a.Len())
+	right := make([]string, 0, b.Len())
+	for i := range a.Len() {
+		l, r := diffTypes(a.Select(i), b.Select(i), depth+1)
+		left = append(left, l)
+		right = append(right, r)
+	}
+
+	var dynLeft, dynRight string
+	if a.Dynamic() != nil {
+		dynLeft, dynRight = diffTypes(a.Dynamic(), b.Dynamic(), depth+1)
+	}
+
+	return sprintArray(left, dynLeft), sprintArray(right, dynRight)
+}
+
+func diffObjects(a, b *types.Object, depth int) (string, string) {
+	aProps, bProps := a.StaticProperties(), b.StaticProperties()
+
+	var left, right []string
+	var elided bool
+
+	// Static properties are sorted by key on both sides, so they can be walked in
+	// parallel. Those that are equal say nothing about why the two types were
+	// reported together, and are dropped.
+	i, j := 0, 0
+	for i < len(aProps) || j < len(bProps) {
+		switch {
+		case j == len(bProps):
+			left = append(left, sprintProperty(aProps[i].Key, elideType(aProps[i].Value)))
+			i++
+		case i == len(aProps):
+			right = append(right, sprintProperty(bProps[j].Key, elideType(bProps[j].Value)))
+			j++
+		default:
+			switch util.Compare(aProps[i].Key, bProps[j].Key) {
+			case -1:
+				left = append(left, sprintProperty(aProps[i].Key, elideType(aProps[i].Value)))
+				i++
+			case 1:
+				right = append(right, sprintProperty(bProps[j].Key, elideType(bProps[j].Value)))
+				j++
+			default:
+				if typesEqual(aProps[i].Value, bProps[j].Value) {
+					elided = true
+				} else {
+					l, r := diffTypes(aProps[i].Value, bProps[j].Value, depth+1)
+					left = append(left, sprintProperty(aProps[i].Key, l))
+					right = append(right, sprintProperty(bProps[j].Key, r))
+				}
+				i++
+				j++
+			}
+		}
+	}
+
+	aDyn, bDyn := a.DynamicProperties(), b.DynamicProperties()
+	var dynLeft, dynRight string
+	switch {
+	case aDyn != nil && bDyn != nil:
+		keyLeft, keyRight := diffTypes(aDyn.Key, bDyn.Key, depth+1)
+		valLeft, valRight := diffTypes(aDyn.Value, bDyn.Value, depth+1)
+		dynLeft, dynRight = keyLeft+": "+valLeft, keyRight+": "+valRight
+	case aDyn != nil:
+		dynLeft = elideType(aDyn.Key) + ": " + elideType(aDyn.Value)
+	case bDyn != nil:
+		dynRight = elideType(bDyn.Key) + ": " + elideType(bDyn.Value)
+	}
+
+	return sprintObject(withElision(left, elided), dynLeft), sprintObject(withElision(right, elided), dynRight)
+}
+
+func diffAnys(a, b types.Any) (string, string) {
+	// The members of an Any are unordered as far as the reader is concerned, so
+	// those that appear on both sides are dropped rather than collapsed.
+	left := make([]string, 0, len(a))
+	right := make([]string, 0, len(b))
+	var elided bool
+
+	for _, tpe := range a {
+		if containsType(b, tpe) {
+			elided = true
+		} else {
+			left = append(left, elideType(tpe))
+		}
+	}
+	for _, tpe := range b {
+		if !containsType(a, tpe) {
+			right = append(right, elideType(tpe))
+		}
+	}
+
+	return sprintAny(withElision(left, elided)), sprintAny(withElision(right, elided))
+}
+
+func diffFunctions(a, b *types.Function, depth int) (string, string) {
+	aArgs, bArgs := a.FuncArgs(), b.FuncArgs()
+
+	left := make([]string, 0, len(aArgs.Args)+1)
+	right := make([]string, 0, len(bArgs.Args)+1)
+	for i := range aArgs.Args {
+		l, r := diffTypes(aArgs.Args[i], bArgs.Args[i], depth+1)
+		left = append(left, l)
+		right = append(right, r)
+	}
+	switch {
+	case aArgs.Variadic != nil && bArgs.Variadic != nil:
+		l, r := diffTypes(aArgs.Variadic, bArgs.Variadic, depth+1)
+		left = append(left, l+"...")
+		right = append(right, r+"...")
+	case aArgs.Variadic != nil:
+		left = append(left, elideType(aArgs.Variadic)+"...")
+	case bArgs.Variadic != nil:
+		right = append(right, elideType(bArgs.Variadic)+"...")
+	}
+
+	resLeft, resRight := diffTypes(a.Result(), b.Result(), depth+1)
+	return sprintFunction(left, resLeft), sprintFunction(right, resRight)
+}
+
+func containsType(haystack types.Any, needle types.Type) bool {
+	for _, tpe := range haystack {
+		if typesEqual(tpe, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func withElision(parts []string, elided bool) []string {
+	if !elided {
+		return parts
+	}
+	return append(parts, typeElision)
+}
+
+func sprintProperty(key any, value string) string {
+	return fmt.Sprintf("%v: %v", key, value)
+}
+
+func sprintArray(static []string, dynamic string) string {
+	return sprintComposite("array", static, dynamic)
+}
+
+func sprintObject(static []string, dynamic string) string {
+	return sprintComposite("object", static, dynamic)
+}
+
+func sprintComposite(prefix string, static []string, dynamic string) string {
+	sb := strings.Builder{}
+	sb.WriteString(prefix)
+	if len(static) > 0 {
+		sb.WriteString("<")
+		sb.WriteString(strings.Join(static, ", "))
+		sb.WriteString(">")
+	}
+	if dynamic != "" {
+		sb.WriteString("[")
+		sb.WriteString(dynamic)
+		sb.WriteString("]")
+	}
+	return sb.String()
+}
+
+func sprintAny(of []string) string {
+	if len(of) == 0 {
+		return "any"
+	}
+	return "any<" + strings.Join(of, ", ") + ">"
+}
+
+func sprintFunction(args []string, result string) string {
+	return "(" + strings.Join(args, ", ") + ") => " + result
+}
+
+func tooWideForTypeErr(lines ...string) bool {
+	for _, line := range lines {
+		if utf8.RuneCountInString(line) > maxTypeErrLineWidth {
+			return true
+		}
+	}
+	return false
+}

--- a/v1/ast/check_elide_test.go
+++ b/v1/ast/check_elide_test.go
@@ -1,0 +1,364 @@
+// Copyright 2025 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/types"
+)
+
+func objType(props ...*types.StaticProperty) *types.Object {
+	return types.NewObject(props, nil)
+}
+
+func staticProp(key string, tpe types.Type) *types.StaticProperty {
+	return types.NewStaticProperty(key, tpe)
+}
+
+func TestSprintElided(t *testing.T) {
+	t.Parallel()
+
+	user := objType(staticProp("name", types.S), staticProp("roles", types.NewSet(types.S)))
+
+	tests := []struct {
+		note  string
+		tpe   types.Type
+		depth int
+		exp   string
+	}{
+		{"nil", nil, 0, "???"},
+		{"scalar", types.S, 0, "string"},
+		{"set", types.NewSet(types.S), 0, "set[...]"},
+		{"set, one level", types.NewSet(types.S), 1, "set[string]"},
+		{"empty any", types.A, 0, "any"},
+		{"any", types.NewAny(types.S, types.N), 0, "any<...>"},
+		{"any, one level", types.NewAny(types.S, types.N), 1, "any<number, string>"},
+		{"static array", types.NewArray([]types.Type{types.S, types.N}, nil), 0, "array<...>"},
+		{"dynamic array", types.NewArray(nil, types.S), 0, "array[...]"},
+		{"array with tail", types.NewArray([]types.Type{types.S}, types.N), 0, "array<...>[...]"},
+		{"array with tail, one level", types.NewArray([]types.Type{types.S}, types.N), 1, "array<string>[number]"},
+		{"static object", user, 0, "object<...>"},
+		{"static object, one level", user, 1, "object<name: string, roles: set[...]>"},
+		{"static object, two levels", user, 2, "object<name: string, roles: set[string]>"},
+		{"dynamic object", types.NewObject(nil, types.NewDynamicProperty(types.S, types.A)), 0, "object[...]"},
+		{"named", types.Named("collection", types.NewSet(types.S)), 0, "collection: set[...]"},
+		{"function", types.NewFunction(types.Args(types.S), types.B), 0, "(...) => ..."},
+		{"function, one level", types.NewFunction(types.Args(types.S), types.B), 1, "(string) => boolean"},
+		{"void function", types.NewFunction(types.Args(types.S), nil), 0, "(...) => ???"},
+		{"nullary function", types.NewFunction(nil, types.B), 0, "() => ..."},
+		{"unelided object", user, -1, types.Sprint(user)},
+		{"unelided nil", nil, -1, "???"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+			if act := sprintElided(tc.tpe, tc.depth); act != tc.exp {
+				t.Errorf("expected %q, got %q", tc.exp, act)
+			}
+		})
+	}
+}
+
+func TestSprintElidedMatchesSprint(t *testing.T) {
+	t.Parallel()
+
+	for _, tpe := range []types.Type{
+		nil,
+		types.Nl, types.B, types.N, types.S, types.A,
+		types.NewAny(types.S, types.N),
+		types.NewSet(types.S),
+		types.NewSet(nil),
+		types.NewArray([]types.Type{types.S, types.N}, types.B),
+		types.NewArray(nil, nil),
+		types.NewObject(nil, nil),
+		objType(staticProp("a", types.NewSet(types.NewArray(nil, types.S)))),
+		types.NewObject([]*types.StaticProperty{staticProp("a", types.S)}, types.NewDynamicProperty(types.S, types.N)),
+		types.NewFunction(types.Args(types.S, types.N), types.B),
+		types.NewVariadicFunction(types.Args(types.S), types.N, nil),
+		types.Named("x", types.NewSet(types.S)),
+		types.NewRecursive("#/$defs/node", types.NewObject(nil, nil)),
+	} {
+		if exp, act := types.Sprint(tpe), sprintElided(tpe, 32); exp != act {
+			t.Errorf("expected %q, got %q", exp, act)
+		}
+	}
+}
+
+func TestSprintDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		note              string
+		a, b              types.Type
+		expLeft, expRight string
+	}{
+		{
+			note:     "small operands are kept even when the constructors differ",
+			a:        types.NewSet(types.S),
+			b:        objType(staticProp("a", types.S)),
+			expLeft:  "set[string]",
+			expRight: "object<a: string>",
+		},
+		{
+			note:     "large operands with different constructors are collapsed",
+			a:        types.NewSet(objType(staticProp("action", types.NewSet(types.S)), staticProp("object", types.S))),
+			b:        objType(staticProp("action", types.NewSet(types.S)), staticProp("object", types.S)),
+			expLeft:  "set[...]",
+			expRight: "object<...>",
+		},
+		{
+			note:     "the differing member of a set is kept",
+			a:        types.NewSet(types.S),
+			b:        types.NewSet(types.N),
+			expLeft:  "set[string]",
+			expRight: "set[number]",
+		},
+		{
+			note: "object properties that are equal on both sides are dropped",
+			a: objType(staticProp("age", types.N), staticProp("name", types.S),
+				staticProp("manager", objType(staticProp("age", types.N), staticProp("name", types.S)))),
+			b: objType(staticProp("age", types.N), staticProp("name", types.S),
+				staticProp("manager", objType(staticProp("age", types.S), staticProp("name", types.S)))),
+			expLeft:  "object<manager: object<age: number, ...>, ...>",
+			expRight: "object<manager: object<age: string, ...>, ...>",
+		},
+		{
+			note:     "object properties missing on one side are kept",
+			a:        objType(staticProp("age", types.N), staticProp("name", types.S)),
+			b:        objType(staticProp("name", types.S)),
+			expLeft:  "object<age: number, ...>",
+			expRight: "object<...>",
+		},
+		{
+			note:     "dynamic object properties are diffed",
+			a:        types.NewObject(nil, types.NewDynamicProperty(types.S, types.N)),
+			b:        types.NewObject(nil, types.NewDynamicProperty(types.S, types.B)),
+			expLeft:  "object[string: number]",
+			expRight: "object[string: boolean]",
+		},
+		{
+			note:     "array elements are kept in place",
+			a:        types.NewArray([]types.Type{types.S, types.N}, nil),
+			b:        types.NewArray([]types.Type{types.S, types.B}, nil),
+			expLeft:  "array<string, number>",
+			expRight: "array<string, boolean>",
+		},
+		{
+			note:     "arrays of different length are not diffed element-wise",
+			a:        types.NewArray([]types.Type{types.S}, nil),
+			b:        types.NewArray([]types.Type{types.S, types.N}, nil),
+			expLeft:  "array<string>",
+			expRight: "array<string, number>",
+		},
+		{
+			note:     "any members that are common to both sides are dropped",
+			a:        types.NewAny(types.S, types.N, types.B),
+			b:        types.NewAny(types.S, types.N),
+			expLeft:  "any<boolean, ...>",
+			expRight: "any<...>",
+		},
+		{
+			note:     "the unknown type is reported as such",
+			a:        nil,
+			b:        types.NewSet(types.A),
+			expLeft:  "???",
+			expRight: "set[any]",
+		},
+		{
+			note:     "argument names are kept",
+			a:        types.S,
+			b:        types.Named("collection", types.NewSet(types.S)),
+			expLeft:  "string",
+			expRight: "collection: set[string]",
+		},
+		{
+			note:     "equal types are collapsed",
+			a:        objType(staticProp("a", types.S)),
+			b:        objType(staticProp("a", types.S)),
+			expLeft:  "object<a: string>",
+			expRight: "object<a: string>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+			left, right := sprintDiff(tc.a, tc.b)
+			if left != tc.expLeft || right != tc.expRight {
+				t.Errorf("expected (%q, %q), got (%q, %q)", tc.expLeft, tc.expRight, left, right)
+			}
+		})
+	}
+}
+
+func TestSprintDiffTerminates(t *testing.T) {
+	t.Parallel()
+
+	node := types.NewRecursive("#/$defs/node", nil)
+	node.SetType(objType(staticProp("child", node), staticProp("value", types.S)))
+
+	other := objType(staticProp("child", node), staticProp("value", types.N))
+
+	if left, right := sprintDiff(node.Unwrap(), other); left == "" || right == "" {
+		t.Fatalf("expected non-empty renderings, got (%q, %q)", left, right)
+	}
+}
+
+func TestArgErrDetailLines(t *testing.T) {
+	t.Parallel()
+
+	acl := objType(staticProp("action", types.NewSet(types.S)), staticProp("object", types.S))
+
+	tests := []struct {
+		note string
+		have []types.Type
+		want types.FuncArgs
+		exp  []string
+	}{
+		{
+			note: "narrow detail is not elided",
+			have: []types.Type{types.N, types.S},
+			want: types.FuncArgs{Args: []types.Type{types.S, types.S}},
+			exp: []string{
+				"have: (number, string)",
+				"want: (string, string)",
+			},
+		},
+		{
+			// https://github.com/open-policy-agent/opa/issues/499
+			note: "compatible arguments are collapsed",
+			have: []types.Type{types.NewSet(acl), acl, nil},
+			want: types.FuncArgs{Args: []types.Type{types.SetOfAny, types.SetOfAny, types.SetOfAny}},
+			exp: []string{
+				"have: (set[...], object<...>, ???)",
+				"want: (set[any], set[any], set[any])",
+			},
+		},
+		{
+			note: "arity errors keep unpaired arguments",
+			have: []types.Type{types.NewSet(acl), acl, types.S},
+			want: types.FuncArgs{Args: []types.Type{types.SetOfAny}},
+			exp: []string{
+				"have: (set[...], object<...>, string)",
+				"want: (set[any])",
+			},
+		},
+		{
+			note: "variadic arguments are kept",
+			have: []types.Type{types.NewSet(acl), acl},
+			want: types.FuncArgs{Args: []types.Type{types.SetOfAny}, Variadic: types.A},
+			exp: []string{
+				"have: (set[...], object<...>)",
+				"want: (set[any], any...)",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+			d := &ArgErrDetail{Have: tc.have, Want: tc.want}
+			if act := d.Lines(); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected\n\n%v\n\ngot\n\n%v", tc.exp, act)
+			}
+		})
+	}
+}
+
+func TestUnificationErrDetailLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		note        string
+		left, right types.Type
+		exp         []string
+	}{
+		{
+			note:  "narrow detail is not elided",
+			left:  objType(staticProp("age", types.N), staticProp("name", types.S)),
+			right: objType(staticProp("name", types.S)),
+			exp: []string{
+				"left  : object<age: number, name: string>",
+				"right : object<name: string>",
+			},
+		},
+		{
+			note: "only the differing property is kept",
+			left: objType(staticProp("age", types.N), staticProp("name", types.S), staticProp("roles", types.NewSet(types.S)),
+				staticProp("manager", objType(staticProp("age", types.N), staticProp("name", types.S)))),
+			right: objType(staticProp("age", types.N), staticProp("name", types.S), staticProp("roles", types.NewSet(types.S)),
+				staticProp("manager", objType(staticProp("age", types.S), staticProp("name", types.S)))),
+			exp: []string{
+				"left  : object<manager: object<age: number, ...>, ...>",
+				"right : object<manager: object<age: string, ...>, ...>",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+			d := &UnificationErrDetail{Left: tc.left, Right: tc.right}
+			if act := d.Lines(); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected\n\n%v\n\ngot\n\n%v", tc.exp, act)
+			}
+		})
+	}
+}
+
+func TestTypeErrorElisionCompile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		note   string
+		module string
+		exp    string
+	}{
+		{
+			note: "union of a set and an object",
+			module: `package test
+
+acl := {"action": {"read"}, "object": "doc"}
+
+r := {acl} | acl
+`,
+			exp: `rego_type_error: or: invalid argument(s)
+	have: (set[...], object<...>, ???)
+	want: (x: set[any], y: set[any], z: set[any])`,
+		},
+		{
+			note: "wide object passed where a collection of strings is expected",
+			module: `package test
+
+x := {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 10}
+
+y := concat(", ", x)
+`,
+			exp: `rego_type_error: concat: invalid argument(s)
+	have: (string, object<...>, ???)
+	want: (delimiter: string, collection: any<array[string], set[string]>, output: string)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewCompiler()
+			c.Compile(map[string]*Module{"test.rego": MustParseModule(tc.module)})
+
+			if !c.Failed() {
+				t.Fatal("expected compilation to fail")
+			}
+			if act := c.Errors.Error(); !strings.Contains(act, tc.exp) {
+				t.Fatalf("expected error to contain\n\n%s\n\ngot\n\n%s", tc.exp, act)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Where the two sides of a type error agree, the shared structure is replaced with an ellipsis, leaving only the part actually in conflict.

Fixes: #499
