### PR TITLE
chore: fix typos in comments and one error message

### DIFF
--- a/ast/transform.go
+++ b/ast/transform.go
@@ -30,7 +30,7 @@ func TransformVars(x any, f func(Var) (Value, error)) (any, error) {
 	return v1.TransformVars(x, f)
 }
 
-// TransformComprehensions calls the functio nf on all comprehensions under x.
+// TransformComprehensions calls the function nf on all comprehensions under x.
 func TransformComprehensions(x any, f func(any) (Value, error)) (any, error) {
 	return v1.TransformComprehensions(x, f)
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -2590,7 +2590,7 @@ func dont() ([][]*ast.Rule, []ir.Operand, int, bool) {
 
 // optimizeLookup returns a set of rulesets and required statements planning
 // the locals (strings) needed with the used local variables, and the index
-// into ref's parth that is still to be planned; if the passed ref's vars
+// into ref's path that is still to be planned; if the passed ref's vars
 // allow for optimization using CallDynamicStmt.
 //
 // It's possible if all of these conditions hold:

--- a/internal/rego/opa/engine.go
+++ b/internal/rego/opa/engine.go
@@ -26,7 +26,7 @@ func (*errEngineNotFound) Lines() []string {
 	}
 }
 
-// Engine repesents a factory for instances of EvalEngine implementations
+// Engine represents a factory for instances of EvalEngine implementations
 type Engine interface {
 	New() EvalEngine
 }

--- a/internal/wasm/constant/constant.go
+++ b/internal/wasm/constant/constant.go
@@ -60,7 +60,7 @@ const ElementTypeAnyFunc byte = 0x70
 // BlockTypeEmpty represents a block type.
 const BlockTypeEmpty byte = 0x40
 
-// WASM global varialbe mutability flag.
+// WASM global variable mutability flag.
 const (
 	Const byte = iota
 	Mutable

--- a/internal/wasm/instruction/instruction.go
+++ b/internal/wasm/instruction/instruction.go
@@ -14,7 +14,7 @@ import (
 type NoImmediateArgs struct {
 }
 
-// ImmediateArgs returns the immedate arguments of an instruction.
+// ImmediateArgs returns the immediate arguments of an instruction.
 func (NoImmediateArgs) ImmediateArgs() []any {
 	return nil
 }

--- a/internal/wasm/instruction/parametric.go
+++ b/internal/wasm/instruction/parametric.go
@@ -8,7 +8,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/wasm/opcode"
 )
 
-// Drop reprsents a WASM drop instruction.
+// Drop represents a WASM drop instruction.
 type Drop struct {
 	NoImmediateArgs
 }
@@ -18,7 +18,7 @@ func (Drop) Op() opcode.Opcode {
 	return opcode.Drop
 }
 
-// Select reprsents a WASM select instruction.
+// Select represents a WASM select instruction.
 type Select struct {
 	NoImmediateArgs
 }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -58,7 +58,7 @@ func GetBundleDirectoryLoaderFS(fsys fs.FS, path string, filter Filter) (bundle.
 	return v1.GetBundleDirectoryLoaderFS(fsys, path, filter)
 }
 
-// FilteredPaths is the same as FilterPathsFS using the current diretory file
+// FilteredPaths is the same as FilterPathsFS using the current directory file
 // system
 func FilteredPaths(paths []string, filter Filter) ([]string, error) {
 	return v1.FilteredPaths(paths, filter)

--- a/rego/rego.go
+++ b/rego/rego.go
@@ -345,7 +345,7 @@ func ShallowInlining(yes bool) func(r *Rego) {
 	return v1.ShallowInlining(yes)
 }
 
-// SkipPartialNamespace disables namespacing of partial evalution results for support
+// SkipPartialNamespace disables namespacing of partial evaluation results for support
 // rules generated from policy. Synthetic support rules are still namespaced.
 func SkipPartialNamespace(yes bool) func(r *Rego) {
 	return v1.SkipPartialNamespace(yes)

--- a/server/identifier/tls.go
+++ b/server/identifier/tls.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/open-policy-agent/opa/v1/server/identifier"
 )
 
-// TLSBased extracts the CN of the client's TLS ceritificate
+// TLSBased extracts the CN of the client's TLS certificate
 type TLSBased = v1.TLSBased
 
 // NewTLSBased returns a new TLSBased object.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -19,7 +19,7 @@ type Store = v1.Store
 // generic MakeDir functionality in storage.MakeDir
 type MakeDirer = v1.MakeDirer
 
-// NonEmptyer allows a store implemention to override NonEmpty())
+// NonEmptyer allows a store implementation to override NonEmpty())
 type NonEmptyer = v1.NonEmptyer
 
 // TransactionParams describes a new transaction.

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -788,7 +788,7 @@ func (i *refindices) resolveRefHead(rule *Rule, args []*Term, ref Ref) Ref {
 //	__local2__ = <something>
 //
 // This what builtin calls involving refs are rewritten to, so it is used
-// for var -> ref lookup when buiding the RI for glob.match or `v in col`.
+// for var -> ref lookup when building the RI for glob.match or `v in col`.
 //
 // For convenience, we also resolve function arg vars here.
 //

--- a/v1/ast/strings.go
+++ b/v1/ast/strings.go
@@ -18,7 +18,7 @@ func TypeName(x any) string {
 }
 
 // ValueName returns a human readable name for the AST Value type.
-// This is preferrable over calling TypeName when the argument is known to be
+// This is preferable over calling TypeName when the argument is known to be
 // a Value, as this doesn't require reflection (= heap allocations).
 func ValueName(x Value) string {
 	switch x.(type) {

--- a/v1/loader/loader.go
+++ b/v1/loader/loader.go
@@ -366,7 +366,7 @@ func GetBundleDirectoryLoaderFS(fsys fs.FS, path string, filter Filter) (bundle.
 	return bundleLoader, fi.IsDir(), nil
 }
 
-// FilteredPaths is the same as FilterPathsFS using the current diretory file
+// FilteredPaths is the same as FilterPathsFS using the current directory file
 // system
 func FilteredPaths(paths []string, filter Filter) ([]string, error) {
 	return FilteredPathsFS(nil, paths, filter)

--- a/v1/plugins/plugins.go
+++ b/v1/plugins/plugins.go
@@ -1001,7 +1001,7 @@ func (m *Manager) Reconfigure(newCfg *config.Config) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	// don't overwrite existing labels, only allow additions - always based on the boostrap config
+	// don't overwrite existing labels, only allow additions - always based on the bootstrap config
 	if config.Labels == nil {
 		config.Labels = m.bootstrapConfigLabels
 	} else {

--- a/v1/rego/compile/compile.go
+++ b/v1/rego/compile/compile.go
@@ -127,7 +127,7 @@ func New(opts ...CompileOption) *Compile {
 	c.regoOpts = append(c.regoOpts,
 		rego.Metrics(c.metrics),
 		// We require evaluating non-det builtins for the translated targets:
-		// We're not able to meaningfully tanslate things like http.send, sql.send, or
+		// We're not able to meaningfully translate things like http.send, sql.send, or
 		// io.jwt.decode_verify into SQL or UCAST, so we try to eval them out where possible.
 		rego.NondeterministicBuiltins(true),
 	)

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -1032,7 +1032,7 @@ func ShallowInlining(yes bool) func(r *Rego) {
 	}
 }
 
-// SkipPartialNamespace disables namespacing of partial evalution results for support
+// SkipPartialNamespace disables namespacing of partial evaluation results for support
 // rules generated from policy. Synthetic support rules are still namespaced.
 func SkipPartialNamespace(yes bool) func(r *Rego) {
 	return func(r *Rego) {

--- a/v1/server/identifier/tls.go
+++ b/v1/server/identifier/tls.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-// TLSBased extracts the CN of the client's TLS ceritificate
+// TLSBased extracts the CN of the client's TLS certificate
 type TLSBased struct {
 	inner http.Handler
 }

--- a/v1/storage/interface.go
+++ b/v1/storage/interface.go
@@ -49,7 +49,7 @@ type MakeDirer interface {
 	MakeDir(context.Context, Transaction, Path) error
 }
 
-// NonEmptyer allows a store implemention to override NonEmpty())
+// NonEmptyer allows a store implementation to override NonEmpty())
 type NonEmptyer interface {
 	NonEmpty(context.Context, Transaction) func([]string) (bool, error)
 }

--- a/v1/storage/internal/ptr/ptr.go
+++ b/v1/storage/internal/ptr/ptr.go
@@ -53,8 +53,8 @@ func ValuePtr(data ast.Value, path storage.Path) (ast.Value, error) {
 			// Note(anders):
 			// This term is only created for the lookup, which is not great — especially
 			// considering the path likely was converted from a ref, where we had all
-			// the terms available already! Without chaging the storage API, our options
-			// for performant lookups are limitied to using interning or a pool. Prefer
+			// the terms available already! Without changing the storage API, our options
+			// for performant lookups are limited to using interning or a pool. Prefer
 			// interning when possible, as that is zero alloc. Using the pool avoids at
 			// least allocating a new term for every lookup, but still requires an alloc
 			// for the string Value.

--- a/v1/storage/path.go
+++ b/v1/storage/path.go
@@ -80,7 +80,7 @@ func NewPathForRef(ref ast.Ref) (path Path, err error) {
 	return path, nil
 }
 
-// Compare performs lexigraphical comparison on p and other and returns -1 if p
+// Compare performs lexicographical comparison on p and other and returns -1 if p
 // is less than other, 0 if p is equal to other, or 1 if p is greater than
 // other.
 func (p Path) Compare(other Path) (cmp int) {

--- a/v1/topdown/cache.go
+++ b/v1/topdown/cache.go
@@ -65,7 +65,7 @@ func (c *virtualCache) Pop() {
 }
 
 // Returns the resolved value of the AST term and a flag indicating if the value
-// should be interpretted as undefined:
+// should be interpreted as undefined:
 //
 //	nil, true indicates the ref is undefined
 //	ast.Term, false indicates the ref is defined

--- a/v1/topdown/graphql.go
+++ b/v1/topdown/graphql.go
@@ -47,7 +47,7 @@ func parseQuery(query string) (*gqlast.QueryDocument, error) {
 }
 
 // Validates a GraphQL query against a schema, and returns an error.
-// In this case, we get a wrappered error list type, and pluck out
+// In this case, we get a wrapped error list type, and pluck out
 // just the first error message in the list.
 func validateQuery(schema *gqlast.Schema, query *gqlast.QueryDocument) error {
 	// Validate the query against the schema, erroring if there's an issue.

--- a/v1/topdown/tokens.go
+++ b/v1/topdown/tokens.go
@@ -600,7 +600,7 @@ func timeFromValue(value ast.Value) (float64, error) {
 	}
 	timeFloat, ok := time.Float64()
 	if !ok {
-		return 0, errors.New("token time constraint: unvalid float64")
+		return 0, errors.New("token time constraint: invalid float64")
 	}
 	if timeFloat < 0 {
 		return 0, errors.New("token time constraint: must not be negative")

--- a/v1/topdown/walk.go
+++ b/v1/topdown/walk.go
@@ -34,7 +34,7 @@ func walk(filter, path *ast.Array, input *ast.Term, iter func(*ast.Term) error) 
 			pathCopy := copyShallow(path)
 
 			// TODO(ae): I'd *really* like these terms to be retrieved from a sync.Pool, and
-			// returned after iter is called. However, all my atttempts to do this have failed
+			// returned after iter is called. However, all my attempts to do this have failed
 			// as there seems to be something holding on to these references after the call,
 			// leading to modifications that entirely alter the results. Perhaps this is not
 			// possible to do, but if it is,it would be a huge performance win.


### PR DESCRIPTION
Fixes a set of spelling mistakes found with `codespell`.

All changes are in doc comments except one user-facing error string in `v1/topdown/tokens.go` ("unvalid float64" -> "invalid float64"), which is not asserted by any test.

Identifiers and third-party vendored sources (`wasm/src/re2`, `wasm/src/libmpdec`, `internal/gojsonschema`) were left untouched. No behaviour changes; `go build ./...` passes.