### PR TITLE
Move Rita Zhang to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,6 @@ The following table lists OPA project maintainers and areas of expertise in alph
 | Ash Narkar | @ashutosh-narkar | anarkar4387@gmail.com | Apple | opa, opa-envoy-plugin | 2024-03-31       |
 | Charlie Egan | @charlieegan3 | opa@charlieegan3.com | Apple | opa | 2025-01-27 |
 | Max Smythe | @maxsmythe | smythe@google.com | Google | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2024-03-31       |
-| Rita Zhang | @ritazh | rita.z.zhang@gmail.com | Microsoft | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2026-01-30       |
 | Sertaç Özercan | @sozercan | sozercan@gmail.com | Microsoft | gatekeeper, gatekeeper-library, cert-controller, gatekeeper-external-data-provider | 2026-01-30       |
 | Jaydip Gabani | @JaydipGabani | gabanijaydip@gmail.com | Microsoft | frameworks/constraints, gatekeeper, gatekeeper-library, cert-controller | 2026-01-30       |
 | Stephan Renatus | @srenatus | stephan.renatus@gmail.com | Apple | opa | 2024-03-31       |
@@ -24,3 +23,4 @@ The following table lists OPA project maintainers and areas of expertise in alph
 * [Oren Shomron](https://github.com/shomron)
 * [Andrew Peabody](https://github.com/apeabody)
 * [Nilekh Chaudhari](https://github.com/nilekhc)
+* [Rita Zhang](https://github.com/ritazh)


### PR DESCRIPTION
### Why the changes in this PR are needed?

Keep the OPA maintainer roster current as Rita transitions from active maintainer to emeritus status.

### What are the changes in this PR?

Remove Rita Zhang from the active maintainers table and add her to the emeritus list.

### Notes to assist PR review:

No tests are needed because this change only updates project maintainer metadata.

### Further comments:

None.