### PR TITLE
test/e2e: wait for diagnostic listeners before running tests

### DIFF
--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -854,7 +854,10 @@ func (rt *Runtime) Addrs() []string {
 // listening on (when in server mode). Returns an empty list if it hasn't
 // started listening.
 func (rt *Runtime) DiagnosticAddrs() []string {
-	if rt.server == nil {
+	rt.serverInitMtx.RLock()
+	defer rt.serverInitMtx.RUnlock()
+
+	if rt.serverStatus < ServerInitialized {
 		return nil
 	}
 

--- a/v1/test/e2e/testing.go
+++ b/v1/test/e2e/testing.go
@@ -309,7 +309,7 @@ func (t *TestRuntime) WaitForServer() error {
 	retries := 100 // 10 seconds before we give up
 	for range retries {
 		// First make sure it has started listening and we have an address
-		if t.URL() != "" {
+		if t.URL() != "" && t.diagnosticAddrsReady() {
 			// Then make sure it has started serving
 			err := t.HealthCheck(t.URL())
 			if err == nil {
@@ -320,6 +320,16 @@ func (t *TestRuntime) WaitForServer() error {
 		time.Sleep(delay)
 	}
 	return errors.New("API Server not ready in time")
+}
+
+// diagnosticAddrsReady reports whether every configured diagnostic address has
+// been bound. Listeners bind on their own goroutines, so the diagnostic one can
+// still be unbound once the main one is serving.
+func (t *TestRuntime) diagnosticAddrsReady() bool {
+	if t.Params.DiagnosticAddrs == nil {
+		return true
+	}
+	return len(t.Runtime.DiagnosticAddrs()) >= len(*t.Params.DiagnosticAddrs)
 }
 
 func (t *TestRuntime) WaitForServerStatus(status runtime.ServerStatus) error {


### PR DESCRIPTION
Listeners bind on their own goroutines and the runtime reports itself initialized without waiting for them, so WaitForServer could return while Runtime.DiagnosticAddrs() was still empty and panic the diagnostics tests.

TestServerWithDiagnosticAddrHealthCheck panicked on the Go Race Detector job for PR 9124: https://github.com/open-policy-agent/opa/actions/runs/33528247114/job/99926014485

```
--- FAIL: TestServerWithDiagnosticAddrHealthCheck (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
...
github.com/open-policy-agent/opa/v1/test/e2e/diagnostics.diagURL(0xc0006b4488)
    /src/v1/test/e2e/diagnostics/diagnostics_test.go:80 +0x192
github.com/open-policy-agent/opa/v1/test/e2e/diagnostics.TestServerWithDiagnosticAddrHealthCheck(0xc0006b4488)
    /src/v1/test/e2e/diagnostics/diagnostics_test.go:31 +0x2f
FAIL  github.com/open-policy-agent/opa/v1/test/e2e/diagnostics
```