### PR TITLE
fix(topdown): bound regex template cache to prevent unbounded growth

### DIFF
--- a/v1/topdown/regex.go
+++ b/v1/topdown/regex.go
@@ -157,6 +157,7 @@ func getRegexp(bctx BuiltinContext, pat string) (*regexp.Regexp, error) {
 func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, error) {
 	regexpCacheLock.RLock()
 	re, ok := regexpCache[pat]
+	numCached := len(regexpCache)
 	regexpCacheLock.RUnlock()
 	if !ok {
 		var err error
@@ -165,6 +166,13 @@ func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, e
 			return nil, err
 		}
 		regexpCacheLock.Lock()
+		if numCached >= regexCacheMaxSize {
+			// Delete a (semi-)random key to make room for the new one.
+			for k := range regexpCache {
+				delete(regexpCache, k)
+				break
+			}
+		}
 		regexpCache[pat] = re
 		regexpCacheLock.Unlock()
 	}


### PR DESCRIPTION
Fixes #9087 by adding cache size bounds to getRegexpTemplate(), mirroring the logic already present in getRegexp().

The regex template cache was growing unboundedly when regex templates were used frequently, causing memory issues. This fix ensures the cache is properly bounded by the existing regexCacheMaxSize limit.