### PR TITLE
ast: clear the term cache when a brace operand guess is abandoned

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -1223,6 +1223,7 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 	// binary. Otherwise, restore and fall through to regular handling.
 	if p.s.tok == tokens.LBrace && p.logicalKeywordsActive() {
 		s := p.save()
+		cache := p.cache.m
 		braceOffset := p.s.loc.Offset
 		bodyLoc := p.s.Loc()
 		p.scan()
@@ -1244,6 +1245,7 @@ func (p *Parser) parseLiteral() (expr *Expr) {
 			}
 		}
 		p.restore(s)
+		p.cache.m = cache
 	}
 
 	// LHS/whole parenthesized group at statement start: `(a or b)`,

--- a/v1/ast/parser_logical_test.go
+++ b/v1/ast/parser_logical_test.go
@@ -2183,6 +2183,46 @@ func TestParseLogical_BraceLedOperandScope(t *testing.T) {
 	}
 }
 
+func TestParseLogical_BraceLedOperandKeepsAbandonedErrorsOut(t *testing.T) {
+	opts := logicalParserOpts("in", "if", "contains", "every")
+
+	// A statement-leading `{` is speculatively read as an and/or operand body, where
+	// `|` is the set-union operator. When the body opens with a keyword that cannot
+	// start a term the union reading fails and records an error, and the statement is
+	// then re-read as a comprehension. That error belongs to the abandoned attempt and
+	// must not be reported against input that parses.
+	tests := []struct {
+		note  string
+		input string
+		exp   *Expr
+	}{
+		{
+			note:  "some ... in on its own line",
+			input: "{\ny |\n\tsome y in xs\n}",
+			exp: NewExpr(SetComprehensionTerm(VarTerm("y"), NewBody(&Expr{
+				Terms: &SomeDecl{
+					Symbols: []*Term{Member.Call(VarTerm("y"), VarTerm("xs"))},
+				},
+			}))),
+		},
+		{
+			note:  "every on its own line",
+			input: "{\ny |\n\tevery v in xs { v == 1 }\n}",
+			exp: NewExpr(SetComprehensionTerm(VarTerm("y"), NewBody(NewExpr(&Every{
+				Value:  VarTerm("v"),
+				Domain: VarTerm("xs"),
+				Body:   NewBody(Equal.Expr(VarTerm("v"), NumberTerm("1"))),
+			})))),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			assertParseOneExpr(t, tc.note, tc.input, tc.exp, opts)
+		})
+	}
+}
+
 func TestParseLogical_EmptyBraceOperand(t *testing.T) {
 	opts := logicalParserOpts("not")
 


### PR DESCRIPTION
With `and`/`or` enabled, a statement starting with `{` is first read as an operand body, and any terms cached during that attempt remember the errors it ran into. The successful re-read then reused those cached terms, reporting stale errors against code that parses fine.

Ran into this problem when trying to bump Regal to v1.20: https://github.com/open-policy-agent/regal/pull/2089, specifically these lines: https://github.com/sspaink/regal/blob/main/build/do.rq#L314-L316 which failed to parse with v1.20
