### PR TITLE
topdown: hoist enumerate callbacks out of the loop

### DIFF
--- a/v1/topdown/enumerate_bench_test.go
+++ b/v1/topdown/enumerate_bench_test.go
@@ -7,6 +7,7 @@ package topdown
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -227,5 +228,77 @@ premium_by_dept[dept] := users if {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func wideObject(n int) *ast.Term {
+	items := make([][2]*ast.Term, n)
+	for i := range n {
+		items[i] = [2]*ast.Term{ast.StringTerm(fmt.Sprintf("k%d", i)), ast.InternedTerm(i)}
+	}
+	return ast.ObjectTerm(items...)
+}
+
+// BenchmarkEnumerateInputObject exercises evalTerm.enumerate's ast.Object case,
+// where the cost per key is dominated by the callback handed to biunify.
+func BenchmarkEnumerateInputObject(b *testing.B) {
+	compiler := ast.MustCompileModules(map[string]string{
+		"test.rego": `package test
+
+total := c if { c := count([v | some _, v in input.obj]) }`,
+	})
+	query := ast.MustParseBody(`data.test.total`)
+
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			input := ast.ObjectTerm(ast.Item(ast.StringTerm("obj"), wideObject(n)))
+
+			b.ReportAllocs()
+
+			for b.Loop() {
+				q := NewQuery(query).
+					WithCompiler(compiler).
+					WithInput(input)
+
+				if _, err := q.Run(b.Context()); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkEnumerateInputSet exercises evalTerm.enumerate's ast.Set case.
+func BenchmarkEnumerateInputSet(b *testing.B) {
+	compiler := ast.MustCompileModules(map[string]string{
+		"test.rego": `package test
+
+hits contains v if {
+	some v in input.s
+	v > 5
+}`,
+	})
+	query := ast.MustParseBody(`data.test.hits`)
+
+	for _, n := range []int{100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			elems := make([]*ast.Term, n)
+			for i := range n {
+				elems[i] = ast.InternedTerm(i)
+			}
+			input := ast.ObjectTerm(ast.Item(ast.StringTerm("s"), ast.SetTerm(elems...)))
+
+			b.ReportAllocs()
+
+			for b.Loop() {
+				q := NewQuery(query).
+					WithCompiler(compiler).
+					WithInput(input)
+
+				if _, err := q.Run(b.Context()); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -2787,6 +2787,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 	// Use method value to avoid closure allocation.
 	// Create once and reuse for both doc and virtual doc enumeration.
 	en := enumerateNext{iter: iter, e: &e, key: nil}
+	call := en.call
 
 	if doc != nil {
 		switch doc := doc.(type) {
@@ -2794,7 +2795,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 			for i := range doc.Len() {
 				k := ast.InternedTerm(i)
 				en.key = k
-				err := e.e.biunify(k, e.ref[e.pos], e.bindings, e.bindings, en.call)
+				err := e.e.biunify(k, e.ref[e.pos], e.bindings, e.bindings, call)
 
 				if err := dc.handleErr(err); err != nil {
 					return err
@@ -2804,7 +2805,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 			ki := doc.KeysIterator()
 			for k, more := ki.Next(); more; k, more = ki.Next() {
 				en.key = k
-				err := e.e.biunify(k, e.ref[e.pos], e.bindings, e.bindings, en.call)
+				err := e.e.biunify(k, e.ref[e.pos], e.bindings, e.bindings, call)
 				if err := dc.handleErr(err); err != nil {
 					return err
 				}
@@ -2813,7 +2814,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 			// Use Slice() to avoid closure allocation in Iter()
 			for _, elem := range doc.Slice() {
 				en.key = elem
-				err := e.e.biunify(elem, e.ref[e.pos], e.bindings, e.bindings, en.call)
+				err := e.e.biunify(elem, e.ref[e.pos], e.bindings, e.bindings, call)
 				if err := dc.handleErr(err); err != nil {
 					return err
 				}
@@ -2840,7 +2841,7 @@ func (e evalTree) enumerate(iter unifyIterator) error {
 		}
 
 		en.key = key
-		if err := e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, en.call); err != nil {
+		if err := e.e.biunify(key, e.ref[e.pos], e.bindings, e.bindings, call); err != nil {
 			return err
 		}
 	}
@@ -4093,6 +4094,20 @@ func (e evalTerm) next(iter unifyIterator, plugged *ast.Term) error {
 	return cpy.eval(iter)
 }
 
+// evalTermNext is the evalTerm counterpart of enumerateNext: it lets the
+// object/set enumeration loops pass a method value to biunify instead of a
+// function literal, which would escape to the heap on every iteration.
+// evalTerm is held by value so call() doesn't chase a second pointer.
+type evalTermNext struct {
+	e    evalTerm
+	iter unifyIterator
+	key  *ast.Term
+}
+
+func (en *evalTermNext) call() error {
+	return en.e.next(en.iter, en.e.termbindings.Plug(en.key))
+}
+
 func (e evalTerm) enumerate(iter unifyIterator) error {
 	var deferredEe *deferredEarlyExitError
 	handleErr := func(err error) error {
@@ -4137,10 +4152,14 @@ func (e evalTerm) enumerate(iter unifyIterator) error {
 			}
 		}
 	case ast.Object:
-		for _, k := range v.Keys() {
-			err := e.e.biunify(k, e.ref[e.pos], e.termbindings, e.bindings, func() error {
-				return e.next(iter, e.termbindings.Plug(k))
-			})
+		// Bind the method value once, outside the loop: a func literal — or a method
+		// value materialized per iteration — escapes to the heap on every key.
+		en := evalTermNext{iter: iter, e: e}
+		call := en.call
+		ki := v.KeysIterator()
+		for k, more := ki.Next(); more; k, more = ki.Next() {
+			en.key = k
+			err := e.e.biunify(k, e.ref[e.pos], e.termbindings, e.bindings, call)
 			if err != nil {
 				if err := handleErr(err); err != nil {
 					return err
@@ -4148,10 +4167,11 @@ func (e evalTerm) enumerate(iter unifyIterator) error {
 			}
 		}
 	case ast.Set:
+		en := evalTermNext{iter: iter, e: e}
+		call := en.call
 		for _, elem := range v.Slice() {
-			err := e.e.biunify(elem, e.ref[e.pos], e.termbindings, e.bindings, func() error {
-				return e.next(iter, e.termbindings.Plug(elem))
-			})
+			en.key = elem
+			err := e.e.biunify(elem, e.ref[e.pos], e.termbindings, e.bindings, call)
 			if err != nil {
 				if err := handleErr(err); err != nil {
 					return err

--- a/v1/topdown/topdown_bench_test.go
+++ b/v1/topdown/topdown_bench_test.go
@@ -89,6 +89,10 @@ func BenchmarkObjectIteration(b *testing.B) {
 	}
 }
 
+// NOTE(sr): the modules passed here all end in `main if { fixture[i] }`, which
+// early-exits after the first binding of i. Despite the "Iteration" names, the
+// callers measure building fixture, not enumerating it. See
+// BenchmarkEnumerateInputObject for a benchmark that enumerates every element.
 func benchmarkIteration(b *testing.B, module string) {
 	p := ast.MustParseBody("data.test.main")
 	c := ast.MustCompileModules(map[string]string{"test.rego": module})


### PR DESCRIPTION
A method value passed as a unifyIterator escapes, so materializing it per iteration allocated once per key -- the same trap the existing enumerateNext in evalTree.enumerate fell into. Bind it once outside the loop instead, and drop the Keys() slice in favor of KeysIterator().

The existing ObjectIteration/SetIteration benchmarks don't cover this: their `main if { fixture[i] }` early-exits after the first key. Both changed by exactly one alloc here, while LargeJSON -- which enumerates all 100 keys of a base document object -- changed by exactly 99. Added two benchmarks that enumerate without early exit; LargeJSON is included below as the pre-existing evalTree.enumerate case.

```
goos: darwin
goarch: arm64
pkg: github.com/open-policy-agent/opa/v1/topdown
cpu: Apple M4 Max

                             │     old      │                new                  │
                             │    sec/op    │    sec/op     vs base               │
EnumerateInputObject/10-16     5.472µ ± 23%   5.705µ ± 25%  +4.28% (p=0.026 n=30)
EnumerateInputObject/100-16    15.52µ ± 13%   16.28µ ± 11%       ~ (p=0.242 n=30)
EnumerateInputObject/1000-16   95.79µ ±  3%   87.81µ ±  7%  -8.33% (p=0.000 n=30)
EnumerateInputSet/100-16       26.54µ ±  2%   27.88µ ±  3%  +5.01% (p=0.007 n=30)
EnumerateInputSet/1000-16      260.1µ ±  1%   275.9µ ±  2%  +6.09% (p=0.004 n=30)
LargeJSON-16                   40.41µ ±  1%   39.93µ ±  2%       ~ (p=0.853 n=30)
geomean                        36.25µ         36.85µ        +1.66%

                             │      old      │                 new                  │
                             │     B/op      │     B/op      vs base                │
EnumerateInputObject/10-16      4.197Ki ± 0%   3.861Ki ± 0%   -8.00% (p=0.000 n=30)
EnumerateInputObject/100-16    10.512Ki ± 0%   6.533Ki ± 0%  -37.85% (p=0.000 n=30)
EnumerateInputObject/1000-16    68.23Ki ± 0%   28.83Ki ± 0%  -57.74% (p=0.000 n=30)
EnumerateInputSet/100-16        24.85Ki ± 0%   21.75Ki ± 0%  -12.45% (p=0.000 n=30)
EnumerateInputSet/1000-16       242.7Ki ± 0%   211.3Ki ± 0%  -12.91% (p=0.000 n=30)
LargeJSON-16                    46.10Ki ± 0%   44.56Ki ± 0%   -3.36% (p=0.000 n=30)
geomean                         30.70Ki        23.03Ki       -24.99%

                             │     old      │                new                  │
                             │  allocs/op   │  allocs/op   vs base                │
EnumerateInputObject/10-16       85.00 ± 0%    76.00 ± 0%  -10.59% (p=0.000 n=30)
EnumerateInputObject/100-16     178.00 ± 0%    79.00 ± 0%  -55.62% (p=0.000 n=30)
EnumerateInputObject/1000-16   1084.00 ± 0%    85.00 ± 0%  -92.16% (p=0.000 n=30)
EnumerateInputSet/100-16         578.0 ± 0%    479.0 ± 0%  -17.13% (p=0.000 n=30)
EnumerateInputSet/1000-16       5.093k ± 0%   4.094k ± 0%  -19.62% (p=0.000 n=30)
LargeJSON-16                     860.0 ± 0%    761.0 ± 0%  -11.51% (p=0.000 n=30)
geomean                          588.5         302.2       -48.65%
```