### PR TITLE
Avoid pointer escape in GenericTransformer

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -3590,7 +3590,7 @@ func (c *Compiler) rewriteWithModifiers() {
 	f := newEqualityFactory(c.localvargen)
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		t := NewGenericTransformer(func(x any) (any, error) {
+		t := GenericTransformer{f: func(x any) (any, error) {
 			body, ok := x.(Body)
 			if !ok {
 				return x, nil
@@ -3601,7 +3601,7 @@ func (c *Compiler) rewriteWithModifiers() {
 			}
 
 			return body, nil
-		})
+		}}
 		_, _ = Transform(t, mod) // ignore error
 	}
 }
@@ -6010,7 +6010,7 @@ func rewriteComprehensionTerms(f *equalityFactory, node any) (any, error) {
 func rewriteEquals(x any) (modified bool) {
 	// Note: can't use Interned.Refs.Equality here as this may be mutated
 	unifyOp := Equality.Ref()
-	t := NewGenericTransformer(func(x any) (any, error) {
+	t := GenericTransformer{f: func(x any) (any, error) {
 		if x, ok := x.(*Expr); ok && x.IsCall() {
 			operator := x.Operator()
 			if operator.Equal(Interned.Refs.Equal) && len(x.Operands()) == 2 {
@@ -6019,7 +6019,7 @@ func rewriteEquals(x any) (modified bool) {
 			}
 		}
 		return x, nil
-	})
+	}}
 	_, _ = Transform(t, x) // ignore error
 	return modified
 }

--- a/v1/ast/transform.go
+++ b/v1/ast/transform.go
@@ -260,14 +260,10 @@ func Transform(t Transformer, x any) (any, error) {
 			y.set(i, v)
 		}
 		return y, nil
-	case Set:
-		y, err = y.Map(func(term *Term) (*Term, error) {
+	case *set:
+		return y.Map(func(term *Term) (*Term, error) {
 			return transformTerm(t, term)
 		})
-		if err != nil {
-			return nil, err
-		}
-		return y, nil
 	case *ArrayComprehension:
 		if y.Term, err = transformTerm(t, y.Term); err != nil {
 			return nil, err
@@ -322,29 +318,29 @@ func Transform(t Transformer, x any) (any, error) {
 
 // TransformRefs calls the function f on all references under x.
 func TransformRefs(x any, f func(Ref) (Value, error)) (any, error) {
-	t := NewGenericTransformer(func(x any) (any, error) {
+	t := GenericTransformer{f: func(x any) (any, error) {
 		if r, ok := x.(Ref); ok {
 			return f(r)
 		}
 		return x, nil
-	})
+	}}
 	return Transform(t, x)
 }
 
 // TransformVars calls the function f on all vars under x.
 func TransformVars(x any, f func(Var) (Value, error)) (any, error) {
-	t := NewGenericTransformer(func(x any) (any, error) {
+	t := GenericTransformer{f: func(x any) (any, error) {
 		if v, ok := x.(Var); ok {
 			return f(v)
 		}
 		return x, nil
-	})
+	}}
 	return Transform(t, x)
 }
 
 // TransformComprehensions calls the function f on all comprehensions under x.
 func TransformComprehensions(x any, f func(any) (Value, error)) (any, error) {
-	t := NewGenericTransformer(func(x any) (any, error) {
+	t := GenericTransformer{f: func(x any) (any, error) {
 		switch x := x.(type) {
 		case *ArrayComprehension:
 			return f(x)
@@ -354,7 +350,7 @@ func TransformComprehensions(x any, f func(any) (Value, error)) (any, error) {
 			return f(x)
 		}
 		return x, nil
-	})
+	}}
 	return Transform(t, x)
 }
 
@@ -367,13 +363,11 @@ type GenericTransformer struct {
 // NewGenericTransformer returns a new GenericTransformer that will transform
 // AST nodes using the function f.
 func NewGenericTransformer(f func(x any) (any, error)) *GenericTransformer {
-	return &GenericTransformer{
-		f: f,
-	}
+	return &GenericTransformer{f: f}
 }
 
 // Transform calls the function f on the GenericTransformer.
-func (t *GenericTransformer) Transform(x any) (any, error) {
+func (t GenericTransformer) Transform(x any) (any, error) {
 	return t.f(x)
 }
 


### PR DESCRIPTION
The generic transformer doesn't need a pointer / pointer receiver. Since non-pointer receivers still apply to pointers, this should not impact existing code, if such code should exist outside of the project (unlikely).

This has little impact on anything, rather about using the right type for the job.