### PR TITLE
compiler: HasherMap returned by getExports never used

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2106,30 +2106,17 @@ func (c *Compiler) err(errs ...*Error) bool { // returns if we should continue
 	return !isLimitReachedInThisCall // Return false if the limit was reached, true otherwise.
 }
 
-func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
-	rules := util.NewHasherMap[Ref, []Ref](RefEqual)
-
+func (c *Compiler) getExport(pkg Ref) []Ref {
+	var refs []Ref
 	for _, name := range c.sorted {
-		for _, rule := range c.Modules[name].Rules {
-			hashMapAdd(rules, c.Modules[name].Package.Path, rule.Head.Ref().GroundPrefix())
+		if RefEqual(pkg, c.Modules[name].Package.Path) {
+			refs = slices.Grow(refs, len(c.Modules[name].Rules))
+			for _, rule := range c.Modules[name].Rules {
+				refs = append(refs, rule.Head.Ref().GroundPrefix())
+			}
 		}
 	}
-
-	return rules
-}
-
-func hashMapAdd(rules *util.HasherMap[Ref, []Ref], pkg, rule Ref) {
-	prev, ok := rules.Get(pkg)
-	if !ok {
-		rules.Put(pkg, []Ref{rule})
-		return
-	}
-	for _, p := range prev {
-		if p.Equal(rule) {
-			return
-		}
-	}
-	rules.Put(pkg, append(prev, rule))
+	return refs
 }
 
 func (c *Compiler) GetAnnotationSet() *AnnotationSet {
@@ -2215,15 +2202,9 @@ func (c *Compiler) moduleIsRegoV1Compatible(mod *Module) bool {
 //
 // The reference "c.d.e" would be resolved to "data.a.b.c.d.e".
 func (c *Compiler) resolveAllRefs() {
-	rules := c.getExports()
-
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		var ruleExports []Ref
-		if x, ok := rules.Get(mod.Package.Path); ok {
-			ruleExports = x
-		}
-
+		ruleExports := c.getExport(mod.Package.Path)
 		globals := getGlobals(mod.Package, ruleExports, mod.Imports)
 
 		WalkRules(mod, func(rule *Rule) bool {
@@ -3798,12 +3779,7 @@ func (qc *queryCompiler) resolveRefs(qctx *QueryContext, body Body) (Body, error
 			pkg = emptyPackage
 		}
 		if pkg != nil {
-			var ruleExports []Ref
-			rules := qc.compiler.getExports()
-			if exist, ok := rules.Get(pkg.Path); ok {
-				ruleExports = exist
-			}
-
+			ruleExports := qc.compiler.getExport(pkg.Path)
 			globals = getGlobals(qctx.Package, ruleExports, qctx.Imports)
 			qctx.Imports = nil
 		}

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -302,7 +302,7 @@ func TestModuleTree(t *testing.T) {
 	}
 }
 
-func TestCompilerGetExports(t *testing.T) {
+func TestCompilerGetExport(t *testing.T) {
 	tests := []struct {
 		note    string
 		modules []*Module
@@ -409,16 +409,14 @@ func TestCompilerGetExports(t *testing.T) {
 		// TODO(sr): add multi-val rule, and ref-with-var single-value rule.
 	}
 
-	hashMap := func(ms map[string][]string) *util.HasherMap[Ref, []Ref] {
-		rules := util.NewHasherMap[Ref, []Ref](RefEqual)
-		for r, rs := range ms {
-			refs := make([]Ref, len(rs))
-			for i := range rs {
-				refs[i] = toRef(rs[i])
-			}
-			rules.Put(MustParseRef(r), refs)
+	toRef := func(s string) Ref {
+		switch x := MustParseTerm(s).Value.(type) {
+		case Var:
+			return Ref{NewTerm(x)}
+		case Ref:
+			return x
 		}
-		return rules
+		panic("unreachable")
 	}
 
 	for _, tc := range tests {
@@ -428,31 +426,15 @@ func TestCompilerGetExports(t *testing.T) {
 				c.Modules[strconv.Itoa(i)] = m
 				c.sorted = append(c.sorted, strconv.Itoa(i))
 			}
-			if exp, act := hashMap(tc.exports), c.getExports(); !refMapEqual(exp, act) {
-				t.Errorf("expected %v, got %v", exp, act)
+			for path, exports := range tc.exports {
+				got := c.getExport(toRef(path))
+				exp := util.Map(exports, toRef)
+
+				if !slices.EqualFunc(exp, got, RefEqual) {
+					t.Errorf("expected %v, got %v", exp, got)
+				}
 			}
 		})
-	}
-}
-
-func refMapEqual(a, b *util.HasherMap[Ref, []Ref]) bool {
-	if a.Len() != b.Len() {
-		return false
-	}
-	return !a.Iter(func(k Ref, v []Ref) bool {
-		v2, ok := b.Get(k)
-		return !ok || !slices.EqualFunc(v, v2, RefEqual)
-	})
-}
-
-func toRef(s string) Ref {
-	switch t := MustParseTerm(s).Value.(type) {
-	case Var:
-		return Ref{NewTerm(t)}
-	case Ref:
-		return t
-	default:
-		panic("unreachable")
 	}
 }
 


### PR DESCRIPTION
Another find from poking the compiler. The `getExports` method of the compiler created a fairly expensive map which wasn't ever used for anything else than single path lookups. Since the compiler currently never does the same lookup twice, there's no point in creating and preloading a rather expensive map. This renames `getExports` -> `getExport` which does lookups on request.