### PR TITLE
ast: Use modern Go in place of custom compare code

### DIFF
--- a/v1/ast/compare.go
+++ b/v1/ast/compare.go
@@ -107,10 +107,9 @@ func Compare(a, b any) int {
 	case Var:
 		return VarCompare(a, b.(Var))
 	case Ref:
-		return termSliceCompare(a, b.(Ref))
+		return slices.CompareFunc(a, b.(Ref), TermValueCompare)
 	case *Array:
-		b := b.(*Array)
-		return termSliceCompare(a.elems, b.elems)
+		return slices.CompareFunc(a.elems, b.(*Array).elems, TermValueCompare)
 	case *lazyObj:
 		return Compare(a.force(), b)
 	case *object:
@@ -130,7 +129,7 @@ func Compare(a, b any) int {
 		b := b.(*SetComprehension)
 		return a.Compare(b)
 	case Call:
-		return termSliceCompare(a, b.(Call))
+		return slices.CompareFunc(a, b.(Call), TermValueCompare)
 	case *Expr:
 		return a.Compare(b.(*Expr))
 	case *SomeDecl:
@@ -150,7 +149,7 @@ func Compare(a, b any) int {
 	case *Rule:
 		return a.Compare(b.(*Rule))
 	case Args:
-		return termSliceCompare(a, b.(Args))
+		return slices.CompareFunc(a, b.(Args), TermValueCompare)
 	case *Import:
 		return a.Compare(b.(*Import))
 	case *Package:
@@ -247,52 +246,6 @@ func sortOrder(x any) int {
 	panic(fmt.Sprintf("illegal value: %T", x))
 }
 
-func rulesCompare(a, b []*Rule) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Compare(b[i]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	}
-	if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
-func termSliceCompare(a, b []*Term) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Value.Compare(b[i].Value); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	} else if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
-func withSliceCompare(a, b []*With) int {
-	minLen := min(len(b), len(a))
-	for i := range minLen {
-		if cmp := a[i].Compare(b[i]); cmp != 0 {
-			return cmp
-		}
-	}
-	if len(a) < len(b) {
-		return -1
-	} else if len(b) < len(a) {
-		return 1
-	}
-	return 0
-}
-
 func VarCompare(a, b Var) int {
 	if a == b {
 		return 0
@@ -304,6 +257,9 @@ func VarCompare(a, b Var) int {
 }
 
 func TermValueCompare(a, b *Term) int {
+	if a == b {
+		return 0
+	}
 	return a.Value.Compare(b.Value)
 }
 
@@ -329,7 +285,7 @@ func ValueEqual(a, b Value) bool {
 }
 
 func RefCompare(a, b Ref) int {
-	return termSliceCompare(a, b)
+	return slices.CompareFunc(a, b, TermValueCompare)
 }
 
 func RefEqual(a, b Ref) bool {

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -345,7 +345,7 @@ func (mod *Module) Compare(other *Module) int {
 	if cmp := slices.CompareFunc(mod.Annotations, other.Annotations, (*Annotations).Compare); cmp != 0 {
 		return cmp
 	}
-	return rulesCompare(mod.Rules, other.Rules)
+	return slices.CompareFunc(mod.Rules, other.Rules, (*Rule).Compare)
 }
 
 // Copy returns a deep copy of mod.
@@ -466,7 +466,7 @@ func (c *Comment) Equal(other *Comment) bool {
 // Compare returns an integer indicating whether pkg is less than, equal to,
 // or greater than other.
 func (pkg *Package) Compare(other *Package) int {
-	return termSliceCompare(pkg.Path, other.Path)
+	return slices.CompareFunc(pkg.Path, other.Path, TermValueCompare)
 }
 
 // Copy returns a deep copy of pkg.
@@ -821,19 +821,19 @@ func (head *Head) Compare(other *Head) int {
 	} else if !head.Assign && other.Assign {
 		return 1
 	}
-	if cmp := termSliceCompare(head.Args, other.Args); cmp != 0 {
+	if cmp := slices.CompareFunc(head.Args, other.Args, TermValueCompare); cmp != 0 {
 		return cmp
 	}
-	if cmp := termSliceCompare(head.Reference, other.Reference); cmp != 0 {
+	if cmp := slices.CompareFunc(head.Reference, other.Reference, TermValueCompare); cmp != 0 {
 		return cmp
 	}
 	if cmp := VarCompare(head.Name, other.Name); cmp != 0 {
 		return cmp
 	}
-	if cmp := Compare(head.Key, other.Key); cmp != 0 {
+	if cmp := TermValueCompare(head.Key, other.Key); cmp != 0 {
 		return cmp
 	}
-	return Compare(head.Value, other.Value)
+	return TermValueCompare(head.Value, other.Value)
 }
 
 // Copy returns a deep copy of head.
@@ -1075,7 +1075,7 @@ func (expr *Expr) Equal(other *Expr) bool {
 //
 // Otherwise, the expression terms are compared normally. If both expressions
 // have the same terms, the modifiers are compared.
-func (expr *Expr) Compare(other *Expr) int {
+func (expr *Expr) Compare(other *Expr) (c int) {
 	switch {
 	case expr == other:
 		return 0
@@ -1109,36 +1109,25 @@ func (expr *Expr) Compare(other *Expr) int {
 
 	switch t := expr.Terms.(type) {
 	case *Term:
-		if cmp := t.Value.Compare(other.Terms.(*Term).Value); cmp != 0 {
-			return cmp
-		}
+		c = TermValueCompare(t, other.Terms.(*Term))
 	case []*Term:
-		if cmp := termSliceCompare(t, other.Terms.([]*Term)); cmp != 0 {
-			return cmp
-		}
+		c = slices.CompareFunc(t, other.Terms.([]*Term), TermValueCompare)
 	case *SomeDecl:
-		if cmp := Compare(t, other.Terms.(*SomeDecl)); cmp != 0 {
-			return cmp
-		}
+		c = t.Compare(other.Terms.(*SomeDecl))
 	case *Every:
-		if cmp := Compare(t, other.Terms.(*Every)); cmp != 0 {
-			return cmp
-		}
+		c = t.Compare(other.Terms.(*Every))
 	case *Not:
-		if cmp := t.Compare(other.Terms.(*Not)); cmp != 0 {
-			return cmp
-		}
+		c = t.Compare(other.Terms.(*Not))
 	case *LogicalAnd:
-		if cmp := Compare(t, other.Terms.(*LogicalAnd)); cmp != 0 {
-			return cmp
-		}
+		c = t.Compare(other.Terms.(*LogicalAnd))
 	case *LogicalOr:
-		if cmp := Compare(t, other.Terms.(*LogicalOr)); cmp != 0 {
-			return cmp
-		}
+		c = t.Compare(other.Terms.(*LogicalOr))
 	}
 
-	return withSliceCompare(expr.With, other.With)
+	if c == 0 {
+		c = slices.CompareFunc(expr.With, other.With, (*With).Compare)
+	}
+	return c
 }
 
 func (expr *Expr) sortOrder() int {
@@ -1206,9 +1195,7 @@ func (expr *Expr) Hash() int {
 	case *SomeDecl:
 		s += ts.Hash()
 	case []*Term:
-		for _, t := range ts {
-			s += t.Value.Hash()
-		}
+		s += termSliceHash(ts)
 	case *Term:
 		s += ts.Value.Hash()
 	case *LogicalAnd:
@@ -1467,7 +1454,7 @@ func (d *SomeDecl) Copy() *SomeDecl {
 // Compare returns an integer indicating whether d is less than, equal to, or
 // greater than other.
 func (d *SomeDecl) Compare(other *SomeDecl) int {
-	return termSliceCompare(d.Symbols, other.Symbols)
+	return slices.CompareFunc(d.Symbols, other.Symbols, TermValueCompare)
 }
 
 // Hash returns a hash code of d.
@@ -1515,7 +1502,7 @@ func (q *Every) Compare(other *Every) int {
 		{q.Value, other.Value},
 		{q.Domain, other.Domain},
 	} {
-		if d := Compare(terms[0], terms[1]); d != 0 {
+		if d := TermValueCompare(terms[0], terms[1]); d != 0 {
 			return d
 		}
 	}
@@ -1695,18 +1682,19 @@ func (w *With) Equal(other *With) bool {
 // Compare returns an integer indicating whether w is less than, equal to, or
 // greater than other.
 func (w *With) Compare(other *With) int {
+	if w == other {
+		return 0
+	}
 	if w == nil {
-		if other == nil {
-			return 0
-		}
 		return -1
-	} else if other == nil {
+	}
+	if other == nil {
 		return 1
 	}
-	if cmp := w.Target.Value.Compare(other.Target.Value); cmp != 0 {
+	if cmp := TermValueCompare(w.Target, other.Target); cmp != 0 {
 		return cmp
 	}
-	return w.Value.Value.Compare(other.Value.Value)
+	return TermValueCompare(w.Value, other.Value)
 }
 
 // Copy returns a deep copy of w.
@@ -1776,6 +1764,12 @@ func Copy(x any) any {
 		return x.Copy()
 	case *ObjectComprehension:
 		return x.Copy()
+	case *LogicalAnd:
+		return x.Copy()
+	case *LogicalOr:
+		return x.Copy()
+	case *TemplateString:
+		return x.Copy()
 	case Set:
 		return x.Copy()
 	case *object:
@@ -1816,12 +1810,7 @@ func (rs *RuleSet) Add(rule *Rule) {
 
 // Contains returns true if rs contains rule.
 func (rs RuleSet) Contains(rule *Rule) bool {
-	for i := range rs {
-		if rs[i].Equal(rule) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(rs, rule.Equal)
 }
 
 // Diff returns a new RuleSet containing rules in rs that are not in other.
@@ -1842,10 +1831,7 @@ func (rs RuleSet) Equal(other RuleSet) bool {
 
 // Merge returns a ruleset containing the union of rules from rs an other.
 func (rs RuleSet) Merge(other RuleSet) RuleSet {
-	result := NewRuleSet()
-	for i := range rs {
-		result.Add(rs[i])
-	}
+	result := NewRuleSet(rs...)
 	for i := range other {
 		result.Add(other[i])
 	}

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1243,7 +1243,7 @@ func (ref Ref) Equal(other Value) bool {
 // or greater than other.
 func (ref Ref) Compare(other Value) int {
 	if o, ok := other.(Ref); ok {
-		return termSliceCompare(ref, o)
+		return slices.CompareFunc(ref, o, TermValueCompare)
 	}
 	return valueTypeCompare(ref, other)
 }
@@ -1503,7 +1503,7 @@ func (arr *Array) Equal(other Value) bool {
 // or greater than other.
 func (arr *Array) Compare(other Value) int {
 	if b, ok := other.(*Array); ok {
-		return termSliceCompare(arr.elems, b.elems)
+		return slices.CompareFunc(arr.elems, b.elems, TermValueCompare)
 	}
 
 	return valueTypeCompare(arr, other)
@@ -1655,10 +1655,11 @@ func (arr *Array) Foreach(f func(*Term)) {
 
 // Append appends a term to arr, returning the appended array.
 func (arr *Array) Append(v *Term) *Array {
+	vhs := v.Value.Hash()
 	cpy := *arr
 	cpy.elems = append(arr.elems, v)
-	cpy.hashs = append(arr.hashs, v.Value.Hash())
-	cpy.hash = arr.hash + v.Value.Hash()
+	cpy.hashs = append(arr.hashs, vhs)
+	cpy.hash += vhs
 	cpy.ground = arr.ground && v.IsGround()
 	return &cpy
 }
@@ -2970,7 +2971,7 @@ func (c Call) Copy() Call {
 // or greater than other.
 func (c Call) Compare(other Value) int {
 	if oc, ok := other.(Call); ok {
-		return termSliceCompare(c, oc)
+		return slices.CompareFunc(c, oc, TermValueCompare)
 	}
 	return valueTypeCompare(c, other)
 }
@@ -3058,18 +3059,6 @@ func termSliceCopy(a []*Term) []*Term {
 		deepCopyTermValue(cpy[i]) // deep copy container Values in-place
 	}
 	return cpy
-}
-
-func termSliceEqual(a, b []*Term) bool {
-	if len(a) == len(b) {
-		for i := range a {
-			if !a[i].Equal(b[i]) {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 func termSliceHash(a []*Term) int {

--- a/v1/ast/term_test.go
+++ b/v1/ast/term_test.go
@@ -178,7 +178,8 @@ func TestObjectSetOperations(t *testing.T) {
 	MustParseTerm(`["c", "d", "q"]`).Value.(*Array).Foreach(func(t *Term) {
 		expectedTerms = append(expectedTerms, t)
 	})
-	if len(r2) != 1 || !termSliceEqual(r2[0][:], expectedTerms) {
+
+	if len(r2) != 1 || !slices.EqualFunc(r2[0][:], expectedTerms, (*Term).Equal) {
 		t.Errorf(`Expected a.Intersect(b) to equal [["a", "d", "q"]] but got: %v`, r2)
 	}
 
@@ -1166,7 +1167,7 @@ func TestArrayOperations(t *testing.T) {
 			results = nil
 			tc.iterator(arr)
 
-			if !termSliceEqual(results, expected) {
+			if !slices.EqualFunc(results, expected, (*Term).Equal) {
 				t.Errorf("Expected iteration to return %v but got %v", expected, results)
 			}
 		})
@@ -1652,7 +1653,7 @@ func TestLazyObjectKeys(t *testing.T) {
 	})
 	act := x.Keys()
 	exp := []*Term{StringTerm("a"), StringTerm("b"), StringTerm("c")}
-	if !termSliceEqual(exp, act) {
+	if !slices.EqualFunc(exp, act, (*Term).Equal) {
 		t.Errorf("expected Keys() %v, got %v", exp, act)
 	}
 	assertForced(t, x, false)
@@ -1670,7 +1671,7 @@ func TestLazyObjectKeysIterator(t *testing.T) {
 		act = append(act, k)
 	}
 	exp := []*Term{StringTerm("a"), StringTerm("b"), StringTerm("c")}
-	if !termSliceEqual(exp, act) {
+	if !slices.EqualFunc(exp, act, (*Term).Equal) {
 		t.Errorf("expected Keys() %v, got %v", exp, act)
 	}
 	assertForced(t, x, false)


### PR DESCRIPTION
This removes the last custom code for doing comparisons on slices of various AST types. All in favor of using `slices.CompareFunc` and other niceties that weren't available when most of this code was written.

Also a few more fixes, like adding recently added AST types to the generic Copy() function which is used by the formatter to ensure not rewriting the input module.