### PR TITLE
tracing: add distributed_tracing.exclude_paths

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -84,6 +84,8 @@ distributed_tracing:
   service_name: opa
   sample_percentage: 50
   encryption: "off"
+  exclude_paths:
+    - /health**
   resource:
     service_namespace: "my-namespace"
     service_version: "1.1"
@@ -934,26 +936,27 @@ that requires GraphQL schemas.
 
 Distributed tracing represents the configuration of the OpenTelemetry Tracing.
 
-| Field                                                                    | Type      | Required                                                                                   | Description                                                                                                |
-| ------------------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `distributed_tracing.type`                                               | `string`  | No                                                                                         | Setting this to "grpc" enables distributed tracing with an gRPC endpoint; or "http" with an HTTP endpoint. |
-| `distributed_tracing.address`                                            | `string`  | No (default: `localhost:4317` if `type` is `grpc` or `localhost:4318` if `type` is `http`) | Address of the OpenTelemetry Collector gRPC or HTTP endpoint.                                              |
-| `distributed_tracing.service_name`                                       | `string`  | No (default: `opa`)                                                                        | Logical name of the service.                                                                               |
-| `distributed_tracing.sample_percentage`                                  | `float64` | No (default: `100`)                                                                        | Percentage of traces that are sampled and exported.                                                        |
-| `distributed_tracing.encryption`                                         | `string`  | No (default: `off`)                                                                        | Configures TLS.                                                                                            |
-| `distributed_tracing.allow_insecure_tls`                                 | `bool`    | No (default: `false`)                                                                      | Allow insecure TLS.                                                                                        |
-| `distributed_tracing.tls_ca_cert_file`                                   | `string`  | No                                                                                         | The path to the root CA certificate.                                                                       |
-| `distributed_tracing.tls_cert_file`                                      | `string`  | No (unless `encryption` equals `mtls`)                                                     | The path to the client certificate to authenticate with.                                                   |
-| `distributed_tracing.tls_private_key_file`                               | `string`  | No (unless `tls_cert_file` provided)                                                       | The path to the private key of the client certificate.                                                     |
-| `distributed_tracing.resource.service_version`                           | `string`  | No                                                                                         | Service version                                                                                            |
-| `distributed_tracing.resource.service_instance_id`                       | `string`  | No                                                                                         | Service instance id                                                                                        |
-| `distributed_tracing.resource.service_namespace`                         | `string`  | No                                                                                         | Service namespace                                                                                          |
-| `distributed_tracing.resource.deployment_environment`                    | `string`  | No                                                                                         | Deployment environment name                                                                                |
-| `distributed_tracing.batch_span_processor_options.blocking`              | `bool`    | No (default: `false`)                                                                      | Wait for span batch enqueue operations to succeed instead of dropping data when the queue is full.         |
-| `distributed_tracing.batch_span_processor_options.batch_timeout_ms`      | `int`     | No (default: `5000`)                                                                       | The maximum duration for constructing a batch in milliseconds.                                             |
-| `distributed_tracing.batch_span_processor_options.export_timeout_ms`     | `int`     | No (default: `30000`)                                                                      | The maximum duration for exporting spans in milliseconds.                                                  |
-| `distributed_tracing.batch_span_processor_options.max_export_batch_size` | `int`     | No (default: `512`)                                                                        | The maximum number of spans to process in a single batch.                                                  |
-| `distributed_tracing.batch_span_processor_options.max_queue_size`        | `int`     | No (default: `2048`)                                                                       | The maximum queue size to buffer spans for delayed processing.                                             |
+| Field                                                                    | Type       | Required                                                                                   | Description                                                                                                |
+| ------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `distributed_tracing.type`                                               | `string`   | No                                                                                         | Setting this to "grpc" enables distributed tracing with an gRPC endpoint; or "http" with an HTTP endpoint. |
+| `distributed_tracing.address`                                            | `string`   | No (default: `localhost:4317` if `type` is `grpc` or `localhost:4318` if `type` is `http`) | Address of the OpenTelemetry Collector gRPC or HTTP endpoint.                                              |
+| `distributed_tracing.service_name`                                       | `string`   | No (default: `opa`)                                                                        | Logical name of the service.                                                                               |
+| `distributed_tracing.sample_percentage`                                  | `float64`  | No (default: `100`)                                                                        | Percentage of traces that are sampled and exported.                                                        |
+| `distributed_tracing.encryption`                                         | `string`   | No (default: `off`)                                                                        | Configures TLS.                                                                                            |
+| `distributed_tracing.allow_insecure_tls`                                 | `bool`     | No (default: `false`)                                                                      | Allow insecure TLS.                                                                                        |
+| `distributed_tracing.tls_ca_cert_file`                                   | `string`   | No                                                                                         | The path to the root CA certificate.                                                                       |
+| `distributed_tracing.tls_cert_file`                                      | `string`   | No (unless `encryption` equals `mtls`)                                                     | The path to the client certificate to authenticate with.                                                   |
+| `distributed_tracing.tls_private_key_file`                               | `string`   | No (unless `tls_cert_file` provided)                                                       | The path to the private key of the client certificate.                                                     |
+| `distributed_tracing.exclude_paths`                                      | `[]string` | No                                                                                         | Glob patterns matching the paths of incoming server requests that should not be traced.                    |
+| `distributed_tracing.resource.service_version`                           | `string`   | No                                                                                         | Service version                                                                                            |
+| `distributed_tracing.resource.service_instance_id`                       | `string`   | No                                                                                         | Service instance id                                                                                        |
+| `distributed_tracing.resource.service_namespace`                         | `string`   | No                                                                                         | Service namespace                                                                                          |
+| `distributed_tracing.resource.deployment_environment`                    | `string`   | No                                                                                         | Deployment environment name                                                                                |
+| `distributed_tracing.batch_span_processor_options.blocking`              | `bool`     | No (default: `false`)                                                                      | Wait for span batch enqueue operations to succeed instead of dropping data when the queue is full.         |
+| `distributed_tracing.batch_span_processor_options.batch_timeout_ms`      | `int`      | No (default: `5000`)                                                                       | The maximum duration for constructing a batch in milliseconds.                                             |
+| `distributed_tracing.batch_span_processor_options.export_timeout_ms`     | `int`      | No (default: `30000`)                                                                      | The maximum duration for exporting spans in milliseconds.                                                  |
+| `distributed_tracing.batch_span_processor_options.max_export_batch_size` | `int`      | No (default: `512`)                                                                        | The maximum number of spans to process in a single batch.                                                  |
+| `distributed_tracing.batch_span_processor_options.max_queue_size`        | `int`      | No (default: `2048`)                                                                       | The maximum queue size to buffer spans for delayed processing.                                             |
 
 The following encryption methods are supported:
 
@@ -962,6 +965,30 @@ The following encryption methods are supported:
 | `off`  | Disable TLS       |
 | `tls`  | Enable TLS        |
 | `mtls` | Enable mutual TLS |
+
+### Excluding endpoints from tracing
+
+Frequently polled endpoints such as the health check can make up the bulk of the
+spans OPA emits without saying much about how policy is being evaluated. List
+them under `exclude_paths` to keep OPA from creating a span for them:
+
+```yaml
+distributed_tracing:
+  type: grpc
+  exclude_paths:
+    - /health**
+    - /metrics
+```
+
+Patterns are [globs](https://github.com/gobwas/glob) matched against the path of
+the incoming request, with `/` as the separator: `*` stays within a single path
+segment, and `**` spans segments. `/health` on its own excludes only the
+`/health` endpoint; `/health**` also covers `/health/live`, `/health/ready`, and
+any other health policy endpoint.
+
+`exclude_paths` applies to OPA's own HTTP server. The requests OPA makes to
+other services — bundle downloads, status and decision log uploads, and
+`http.send` calls during evaluation — are unaffected.
 
 ## Metrics Export
 

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -11,6 +11,10 @@ Each [REST API](./rest-api/) request sent to the server will start a span.
 If processing the request involves policy evaluation, and that in turn uses
 [`http.send`](./policy-reference/builtins/http), those HTTP clients will emit descendant spans.
 
+Endpoints that are polled often enough to drown out the interesting traces, such
+as the health check, can be left out via
+[`distributed_tracing.exclude_paths`](./configuration/#excluding-endpoints-from-tracing).
+
 Furthermore, spans exported for policy evaluation requests will contain an
 attribute `opa.decision_id` of the evaluation's decision ID _if_ the server
 has decision logging enabled.

--- a/internal/distributedtracing/distributedtracing.go
+++ b/internal/distributedtracing/distributedtracing.go
@@ -8,10 +8,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/gobwas/glob"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -25,6 +28,7 @@ import (
 	"github.com/open-policy-agent/opa/internal/tlsutil"
 	"github.com/open-policy-agent/opa/v1/config"
 	"github.com/open-policy-agent/opa/v1/logging"
+	"github.com/open-policy-agent/opa/v1/tracing"
 	"github.com/open-policy-agent/opa/v1/util"
 
 	// The import registers opentelemetry with the top-level `tracing` package,
@@ -91,38 +95,47 @@ type distributedTracingConfig struct {
 	TLSCertFile               string                   `json:"tls_cert_file,omitempty"`
 	TLSCertPrivateKeyFile     string                   `json:"tls_private_key_file,omitempty"`
 	TLSCACertFile             string                   `json:"tls_ca_cert_file,omitempty"`
+	ExcludePaths              []string                 `json:"exclude_paths,omitempty"`
 	Resource                  resourceConfig           `json:"resource"`
 	BatchSpanProcessorOptions batchSpanProcessorConfig `json:"batch_span_processor_options"`
+
+	// compiled form of ExcludePaths, populated by validateAndInjectDefaults
+	excludePaths []*glob.Pattern
 }
 
-func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *trace.TracerProvider, *resource.Resource, error) {
+// Init returns the OpenTelemetry components built from the distributed_tracing
+// section of the given configuration. The returned tracing.Options are only
+// applicable to OPA's HTTP server: they carry request filters that are matched
+// against the path of an *incoming* request, and are meaningless for the
+// outbound requests made by plugins or by http.send during evaluation.
+func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *trace.TracerProvider, *resource.Resource, tracing.Options, error) {
 	parsedConfig, err := config.ParseConfig(raw, id)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	distributedTracingConfig, err := parseDistributedTracingConfig(parsedConfig.DistributedTracing)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	if !strings.EqualFold(distributedTracingConfig.Type, "grpc") && !strings.EqualFold(distributedTracingConfig.Type, "http") {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	certificate, err := tlsutil.LoadCertificate(distributedTracingConfig.TLSCertFile, distributedTracingConfig.TLSCertPrivateKeyFile)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	certPool, err := tlsutil.LoadCertPool(distributedTracingConfig.TLSCACertFile)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	tlsConfig, err := tlsutil.BuildTLSConfig(distributedTracingConfig.EncryptionScheme, *distributedTracingConfig.EncryptionSkipVerify, certificate, certPool)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	var traceExporter *otlptrace.Exporter
@@ -162,7 +175,7 @@ func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *tra
 		resource.WithAttributes(resourceAttributes...),
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	var batchSpanProcessorOptions []trace.BatchSpanProcessorOption
@@ -188,7 +201,25 @@ func Init(ctx context.Context, raw []byte, id string) (*otlptrace.Exporter, *tra
 		trace.WithSpanProcessor(trace.NewBatchSpanProcessor(traceExporter, batchSpanProcessorOptions...)),
 	)
 
-	return traceExporter, traceProvider, res, nil
+	var serverOptions tracing.Options
+	if len(distributedTracingConfig.excludePaths) > 0 {
+		serverOptions = tracing.NewOptions(otelhttp.WithFilter(excludePathsFilter(distributedTracingConfig.excludePaths)))
+	}
+
+	return traceExporter, traceProvider, res, serverOptions, nil
+}
+
+// excludePathsFilter returns a filter reporting whether a request should be
+// traced. Requests whose URL path matches one of the given patterns are not.
+func excludePathsFilter(patterns []*glob.Pattern) otelhttp.Filter {
+	return func(r *http.Request) bool {
+		for _, p := range patterns {
+			if p.Match(r.URL.Path) {
+				return false
+			}
+		}
+		return true
+	}
 }
 
 func SetupLogging(logger logging.Logger) {
@@ -289,6 +320,18 @@ func (c *distributedTracingConfig) validateAndInjectDefaults() error {
 
 	if !isSupportedSampleRatePercentage(*c.SampleRatePercentage) {
 		return fmt.Errorf("unsupported distributed_tracing.sample_percentage '%v'", *c.SampleRatePercentage)
+	}
+
+	// '/' is used as the separator so that a single '*' stays within one path
+	// segment, and '**' is needed to span segments -- e.g. "/health**" excludes
+	// both "/health" and "/health/live".
+	c.excludePaths = make([]*glob.Pattern, 0, len(c.ExcludePaths))
+	for _, p := range c.ExcludePaths {
+		compiled, err := glob.Compile(p, '/')
+		if err != nil {
+			return fmt.Errorf("invalid distributed_tracing.exclude_paths pattern '%s': %w", p, err)
+		}
+		c.excludePaths = append(c.excludePaths, compiled)
 	}
 
 	return nil

--- a/internal/distributedtracing/distributedtracing_test.go
+++ b/internal/distributedtracing/distributedtracing_test.go
@@ -4,15 +4,83 @@
 
 package distributedtracing
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestInitNoTypeReturnsAllNil(t *testing.T) {
 	raw := []byte(`{"distributed_tracing": {}}`)
-	exp, tp, res, err := Init(t.Context(), raw, "test")
+	exp, tp, res, opts, err := Init(t.Context(), raw, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if exp != nil || tp != nil || res != nil {
+	if exp != nil || tp != nil || res != nil || opts != nil {
 		t.Fatal("expected all nil when type is not set")
+	}
+}
+
+func TestInitExcludePathsServerOptions(t *testing.T) {
+	raw := []byte(`{"distributed_tracing": {"type": "grpc", "exclude_paths": ["/health**"]}}`)
+	_, _, _, opts, err := Init(t.Context(), raw, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := len(opts), 1; got != exp {
+		t.Fatalf("got %d server tracing option(s), expected %d", got, exp)
+	}
+
+	raw = []byte(`{"distributed_tracing": {"type": "grpc"}}`)
+	if _, _, _, opts, err = Init(t.Context(), raw, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(opts) != 0 {
+		t.Fatalf("got %d server tracing option(s), expected none", len(opts))
+	}
+}
+
+func TestInitInvalidExcludePath(t *testing.T) {
+	raw := []byte(`{"distributed_tracing": {"type": "grpc", "exclude_paths": ["/health["]}}`)
+	_, _, _, _, err := Init(t.Context(), raw, "test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if exp := "invalid distributed_tracing.exclude_paths pattern '/health['"; !strings.Contains(err.Error(), exp) {
+		t.Fatalf("expected error to contain %q, got %q", exp, err.Error())
+	}
+}
+
+func TestExcludePathsFilter(t *testing.T) {
+	tests := []struct {
+		note     string
+		patterns []string
+		path     string
+		traced   bool
+	}{
+		{note: "no patterns", path: "/health", traced: true},
+		{note: "exact match", patterns: []string{"/health"}, path: "/health", traced: false},
+		{note: "exact match, other path", patterns: []string{"/health"}, path: "/v1/data", traced: true},
+		{note: "single star doesn't cross separators", patterns: []string{"/health*"}, path: "/health/live", traced: true},
+		{note: "double star crosses separators", patterns: []string{"/health**"}, path: "/health/live", traced: false},
+		{note: "double star matches bare prefix", patterns: []string{"/health**"}, path: "/health", traced: false},
+		{note: "prefix isn't matched implicitly", patterns: []string{"/health"}, path: "/health/live", traced: true},
+		{note: "second pattern matches", patterns: []string{"/metrics", "/health"}, path: "/health", traced: false},
+		{note: "query string is not part of the path", patterns: []string{"/health"}, path: "/health?bundles=true", traced: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := distributedTracingConfig{Type: "grpc", ExcludePaths: tc.patterns}
+			if err := c.validateAndInjectDefaults(); err != nil {
+				t.Fatal(err)
+			}
+
+			filter := excludePathsFilter(c.excludePaths)
+			if got := filter(httptest.NewRequest(http.MethodGet, tc.path, nil)); got != tc.traced {
+				t.Errorf("filter(%q) = %v, expected %v", tc.path, got, tc.traced)
+			}
+		})
 	}
 }

--- a/v1/plugins/plugins_test.go
+++ b/v1/plugins/plugins_test.go
@@ -415,7 +415,7 @@ func TestPluginManagerPrometheusRegister(t *testing.T) {
 }
 
 func TestPluginManagerTracerProvider(t *testing.T) {
-	_, tracerProvider, _, err := internal_tracing.Init(t.Context(), []byte(`{ "distributed_tracing": { "type": "grpc" } }`), "test")
+	_, tracerProvider, _, _, err := internal_tracing.Init(t.Context(), []byte(`{ "distributed_tracing": { "type": "grpc" } }`), "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -373,6 +374,11 @@ type Runtime struct {
 	meterProvider     *sdkmetric.MeterProvider
 	loadedPathsResult *initload.LoadPathsResult
 
+	// serverTracingOpts holds the distributed tracing options that only apply to
+	// OPA's own HTTP server, and not to the outbound requests made by plugins or
+	// by http.send during evaluation.
+	serverTracingOpts tracing.Options
+
 	serverStatus  ServerStatus
 	serverInitMtx sync.RWMutex
 	done          chan struct{}
@@ -518,7 +524,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 			inmem.OptReturnASTValuesOnRead(params.ReadAstValuesFromStore))
 	}
 
-	traceExporter, tracerProvider, _, err := internal_tracing.Init(ctx, config, params.ID)
+	traceExporter, tracerProvider, _, serverTracingOpts, err := internal_tracing.Init(ctx, config, params.ID)
 	if err != nil {
 		return nil, fmt.Errorf("config error: %w", err)
 	}
@@ -608,6 +614,7 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		traceExporter:     traceExporter,
 		meterProvider:     meterProvider,
 		loadedPathsResult: loaded,
+		serverTracingOpts: serverTracingOpts,
 	}
 
 	return rt, nil
@@ -723,7 +730,7 @@ func (rt *Runtime) Serve(ctx context.Context) (err error) {
 		WithMetrics(rt.metrics).
 		WithMinTLSVersion(rt.Params.MinTLSVersion).
 		WithCipherSuites(rt.Params.CipherSuites).
-		WithDistributedTracingOpts(rt.Params.DistributedTracingOpts).
+		WithDistributedTracingOpts(slices.Concat(rt.Params.DistributedTracingOpts, rt.serverTracingOpts)).
 		WithHooks(rt.Params.Hooks).
 		WithNDBCacheEnabled(rt.Params.NDBCacheEnabled)
 

--- a/v1/runtime/runtime_test.go
+++ b/v1/runtime/runtime_test.go
@@ -1481,6 +1481,79 @@ func TestGracefulTracerShutdown(t *testing.T) {
 	})
 }
 
+// TestTracingExcludePaths asserts that distributed_tracing.exclude_paths keeps
+// the server from emitting spans for the matching endpoints, so that noisy
+// liveness probes don't drown out the interesting traces.
+func TestTracingExcludePaths(t *testing.T) {
+	ctx := t.Context()
+
+	cfg := filepath.Join(t.TempDir(), "opa.yaml")
+	config := `distributed_tracing:
+  type: grpc
+  exclude_paths:
+    - /health**
+    - /v1/data/secret/**
+`
+	if err := os.WriteFile(cfg, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config %s: %v", cfg, err)
+	}
+
+	params := NewParams()
+	params.Logger = testLog.New()
+	params.Addrs = &[]string{"localhost:0"}
+	params.ConfigFile = cfg
+
+	rt, err := NewRuntime(ctx, params)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	// The config above makes the runtime build a tracer provider that exports to
+	// an (unreachable) OTLP collector. Appending a second provider here redirects
+	// the server's spans into an in-memory exporter instead: otelhttp applies its
+	// options in order, so the last one set wins.
+	spanExporter := tracetest.NewInMemoryExporter()
+	rt.Params.DistributedTracingOpts = append(rt.Params.DistributedTracingOpts,
+		otelhttp.WithTracerProvider(trace.NewTracerProvider(trace.WithSpanProcessor(trace.NewSimpleSpanProcessor(spanExporter)))))
+
+	go rt.StartServer(ctx)
+	if !test.Eventually(t, 5*time.Second, func() bool {
+		return rt.ServerStatus() == ServerInitialized && len(rt.Addrs()) > 0
+	}) {
+		t.Fatal("Timed out waiting for server to start")
+	}
+	base := "http://" + rt.Addrs()[0]
+
+	for _, tc := range []struct {
+		path      string
+		spanNames []string
+	}{
+		{path: "/health", spanNames: nil},
+		{path: "/health/live", spanNames: nil},
+		{path: "/v1/data/secret/key", spanNames: nil},
+		{path: "/v1/data", spanNames: []string{"GET /v1/data"}},
+		{path: "/v1/data/other", spanNames: []string{"GET /v1/data/{path...}"}},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Cleanup(spanExporter.Reset)
+
+			resp, err := http.Get(base + tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			var got []string
+			for _, s := range spanExporter.GetSpans() {
+				got = append(got, s.Name)
+			}
+			if !slices.Equal(got, tc.spanNames) {
+				t.Errorf("got spans %v, expected %v", got, tc.spanNames)
+			}
+		})
+	}
+}
+
 func TestUrlPathToConfigOverride(t *testing.T) {
 	params := NewParams()
 	params.Paths = []string{"https://www.example.com/bundles/bundle.tar.gz"}

--- a/v1/server/server_test.go
+++ b/v1/server/server_test.go
@@ -6306,7 +6306,7 @@ func TestDistributedTracingEnabled(t *testing.T) {
 		}}`)
 
 	ctx := t.Context()
-	_, _, _, err := distributedtracing.Init(ctx, c, "foo")
+	_, _, _, _, err := distributedtracing.Init(ctx, c, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error initializing gRPC trace exporter %v", err)
 	}
@@ -6315,7 +6315,7 @@ func TestDistributedTracingEnabled(t *testing.T) {
 		"type": "http"
 		}}`)
 
-	_, _, _, err = distributedtracing.Init(ctx, c, "foo")
+	_, _, _, _, err = distributedtracing.Init(ctx, c, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error initializing HTTP trace exporter %v", err)
 	}
@@ -6348,7 +6348,7 @@ func TestDistributedTracingResourceAttributes(t *testing.T) {
 		attributes[semconv.DeploymentEnvironmentKey])
 
 	ctx := t.Context()
-	_, traceProvider, resource, err := distributedtracing.Init(ctx, c, "foo")
+	_, traceProvider, resource, _, err := distributedtracing.Init(ctx, c, "foo")
 	if err != nil {
 		t.Fatalf("Unexpected error initializing trace exporter %v", err)
 	}


### PR DESCRIPTION
Health probes polled by an orchestrator can dominate the spans OPA emits, so let operators glob-match the incoming request paths that shouldn't start one. Filters apply to OPA's own server, not to the requests it makes to others.

Fixes: #7494