### PR TITLE
Enable more gocritic linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,14 +49,9 @@ linters:
         - stringConcatSimplify
       disabled-checks:
         - appendAssign
-        # NOTE(ae): this one should be enabled, but there were too
-        # many violations to fix in one go... revisit later
-        - singleCaseSwitch
         # Reasonable rule, but not sure what to replace with in
         # many locations, so disabling for now
         - exitAfterDefer
-        # This is disabled from the perfomance tag  enabled further down.
-        - hugeParam
       enabled-tags:
         - performance
       settings:
@@ -65,14 +60,16 @@ linters:
           # lowered to something more reasonable, as the rule
           # is reasonable (replace long if-else chains with
           # switch)... just too many violations right now
-          minThreshold: 10
+          minThreshold: 5
+        hugeParam:
+          sizeThreshold: 400
     govet:
       disable:
-        # enable later and fix
-        - buildtag
-      enable:
-        - deepequalerrors
-        - nilness
+        - fieldalignment
+        - shadow
+        # definitely look into these isses when given time
+        - unusedwrite
+      enable-all: true
     lll:
       line-length: 200
     modernize:
@@ -119,6 +116,10 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - linters:
+          - gocritic
+        text: hugeParam
+        path: v1/test/|cmd/|v1/runtime/runtime.go|_test\.go
       - linters:
           - staticcheck
         text: SA1019 # Using a deprecated function, variable, constant or field

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -281,8 +281,7 @@ func (*goBenchRunner) run(ctx context.Context, ectx *evalContext, params benchma
 				for name, metric := range m.All() {
 					// Note: We only support int64 metrics right now, this should cover pretty
 					// much all the ones we would care about (timers and counters).
-					switch v := metric.(type) {
-					case int64:
+					if v, ok := metric.(int64); ok {
 						hist.Histogram(name).Update(v)
 					}
 				}
@@ -468,8 +467,7 @@ func runE2E(params benchmarkCommandParams, url string, input map[string]any) (te
 			// Add metrics for that evaluation into the top level histogram
 			if params.metrics {
 				for name, metric := range m {
-					switch v := metric.(type) {
-					case json.Number:
+					if v, ok := metric.(json.Number); ok {
 						num, err := v.Int64()
 						if err != nil {
 							benchErr = err

--- a/v1/ast/internal/scanner/scanner.go
+++ b/v1/ast/internal/scanner/scanner.go
@@ -502,12 +502,9 @@ func (s *Scanner) scanRawTemplateString() (string, tokens.Token) {
 			break
 		}
 
-		if ch == '\\' {
-			switch s.curr {
-			case '{':
-				escapes = append(escapes, s.offset-1)
-				s.next()
-			}
+		if ch == '\\' && s.curr == '{' {
+			escapes = append(escapes, s.offset-1)
+			s.next()
 		}
 	}
 

--- a/v1/ast/location/location.go
+++ b/v1/ast/location/location.go
@@ -129,7 +129,7 @@ func EndOf(row, col int, text []byte) (endRow, endCol int) {
 // column of the Location (but not on the text.) Nil locations are greater than
 // non-nil locations.
 func (loc *Location) Compare(other *Location) int {
-	if loc == other {
+	if loc == other { //nolint:gocritic // this is fine as an ifElseChain
 		return 0
 	} else if loc == nil {
 		return 1

--- a/v1/ast/policy.go
+++ b/v1/ast/policy.go
@@ -225,7 +225,6 @@ type (
 	// Rule represents a rule as defined in the language. Rules define the
 	// content of documents that represent policy decisions.
 	Rule struct {
-		Default     bool           `json:"default,omitempty"`
 		Head        *Head          `json:"head"`
 		Body        Body           `json:"body"`
 		Else        *Rule          `json:"else,omitempty"`
@@ -238,6 +237,7 @@ type (
 		// on the rule (e.g., printing, comparison, visiting, etc.)
 		Module *Module `json:"-"`
 
+		Default       bool `json:"default,omitempty"`
 		generatedBody bool
 	}
 

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1197,8 +1197,7 @@ func (ref Ref) Concat(terms []*Term) Ref {
 
 // Dynamic returns the offset of the first non-constant operand of ref.
 func (ref Ref) Dynamic() int {
-	switch ref[0].Value.(type) {
-	case Call:
+	if TermValueIs[Call](ref[0]) {
 		return 0
 	}
 	for i := 1; i < len(ref); i++ {

--- a/v1/ast/unify.go
+++ b/v1/ast/unify.go
@@ -115,8 +115,7 @@ func (u *unifier) unify(a *Term, b *Term) {
 			u.markAllSafe(b)
 		}
 	case *SetComprehension:
-		switch b := b.Value.(type) {
-		case Var:
+		if b, ok := b.Value.(Var); ok {
 			u.markSafe(b)
 		}
 
@@ -166,9 +165,8 @@ func (u *unifier) unify(a *Term, b *Term) {
 		}
 
 	default:
-		switch b := b.Value.(type) {
-		case Var:
-			u.markSafe(b)
+		if v, ok := b.Value.(Var); ok {
+			u.markSafe(v)
 		}
 	}
 }

--- a/v1/bundle/bundle.go
+++ b/v1/bundle/bundle.go
@@ -339,7 +339,7 @@ func (ss stringSet) Equal(other stringSet) bool {
 	return true
 }
 
-func (m *Manifest) validateAndInjectDefaults(b Bundle) error {
+func (m *Manifest) validateAndInjectDefaults(b *Bundle) error {
 	m.Init()
 
 	// Validate roots in bundle.
@@ -680,7 +680,7 @@ func (r *Reader) Read() (Bundle, error) {
 		// Normalize the paths to use `/` separators
 		path := filepath.ToSlash(f.Path())
 
-		if strings.HasSuffix(path, RegoExt) {
+		if strings.HasSuffix(path, RegoExt) { //nolint: gocritic // ifElseChain
 			fullPath := r.fullPath(path)
 			bs := buf.Bytes()
 
@@ -837,7 +837,7 @@ func (r *Reader) Read() (Bundle, error) {
 			"file(s) %v specified in bundle signatures but not found in the target bundle", util.Keys(r.files))
 	}
 
-	if err := bundle.Manifest.validateAndInjectDefaults(*bundle); err != nil {
+	if err := bundle.Manifest.validateAndInjectDefaults(bundle); err != nil {
 		return empty, err
 	}
 
@@ -1556,12 +1556,14 @@ func MergeWithRegoVersion(bundles []*Bundle, regoVersion ast.RegoVersion, usePat
 		return result, nil
 	}
 
-	var roots []string
-	var result Bundle
+	var (
+		roots            []string
+		planFile         string
+		manifestProto    bool
+		manifestProtoSet bool
+	)
 
-	var planFile string
-	var manifestProto bool
-	var manifestProtoSet bool
+	result := &Bundle{}
 
 	for _, b := range bundles {
 		if b.Manifest.Roots == nil {
@@ -1632,7 +1634,7 @@ func MergeWithRegoVersion(bundles []*Bundle, regoVersion ast.RegoVersion, usePat
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 func bundleRegoVersions(bundle *Bundle, regoVersion ast.RegoVersion, usePath bool) (map[string]int, error) {

--- a/v1/bundle/bundle_test.go
+++ b/v1/bundle/bundle_test.go
@@ -2641,7 +2641,7 @@ func TestMerge(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.note, func(t *testing.T) {
 			for i := range tc.bundles {
-				if err := tc.bundles[i].Manifest.validateAndInjectDefaults(*tc.bundles[i]); err != nil {
+				if err := tc.bundles[i].Manifest.validateAndInjectDefaults(tc.bundles[i]); err != nil {
 					panic(err)
 				}
 			}

--- a/v1/dependencies/deps.go
+++ b/v1/dependencies/deps.go
@@ -197,18 +197,11 @@ func (rs *dependencies) visited(rule *ast.Rule) bool {
 }
 
 func (rs *dependencies) toSlice() []ast.Ref {
-	result := make([]ast.Ref, 0, rs.refs.Len())
-	rs.refs.Iter(func(k, _ ast.Ref) bool {
-		result = append(result, k)
-		return false
-	})
-	return result
+	return rs.refs.Keys()
 }
 
 func dedup(refs []ast.Ref) []ast.Ref {
-	slices.SortFunc(refs, ast.RefCompare)
-
-	return slices.CompactFunc(refs, ast.RefEqual)
+	return slices.CompactFunc(util.SortedFunc(refs, ast.RefCompare), ast.RefEqual)
 }
 
 // filter removes all items from the list that cause pred to return true. It is

--- a/v1/plugins/status/plugin_test.go
+++ b/v1/plugins/status/plugin_test.go
@@ -313,8 +313,7 @@ func filterGauges(registerMock *prometheusRegisterMock) []prometheus.Gauge {
 	fltd := make([]prometheus.Gauge, 0)
 
 	for m := range registerMock.Collectors {
-		switch metric := m.(type) {
-		case prometheus.Gauge:
+		if metric, ok := m.(prometheus.Gauge); ok {
 			fltd = append(fltd, metric)
 		}
 	}

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -767,7 +767,7 @@ func RegisterBuiltin1(decl *Function, impl Builtin1) {
 	})
 	topdown.RegisterBuiltinFunc(decl.Name, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return impl(bctx, terms[0]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -781,7 +781,7 @@ func RegisterBuiltin2(decl *Function, impl Builtin2) {
 	})
 	topdown.RegisterBuiltinFunc(decl.Name, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return impl(bctx, terms[0], terms[1]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -795,7 +795,7 @@ func RegisterBuiltin3(decl *Function, impl Builtin3) {
 	})
 	topdown.RegisterBuiltinFunc(decl.Name, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return impl(bctx, terms[0], terms[1], terms[2]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -809,7 +809,7 @@ func RegisterBuiltin4(decl *Function, impl Builtin4) {
 	})
 	topdown.RegisterBuiltinFunc(decl.Name, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return impl(bctx, terms[0], terms[1], terms[2], terms[3]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -823,7 +823,7 @@ func RegisterBuiltinDyn(decl *Function, impl BuiltinDyn) {
 	})
 	topdown.RegisterBuiltinFunc(decl.Name, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return impl(bctx, terms) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -831,7 +831,7 @@ func RegisterBuiltinDyn(decl *Function, impl BuiltinDyn) {
 func Function1(decl *Function, f Builtin1) func(*Rego) {
 	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -839,7 +839,7 @@ func Function1(decl *Function, f Builtin1) func(*Rego) {
 func Function2(decl *Function, f Builtin2) func(*Rego) {
 	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -847,7 +847,7 @@ func Function2(decl *Function, f Builtin2) func(*Rego) {
 func Function3(decl *Function, f Builtin3) func(*Rego) {
 	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1], terms[2]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -855,7 +855,7 @@ func Function3(decl *Function, f Builtin3) func(*Rego) {
 func Function4(decl *Function, f Builtin4) func(*Rego) {
 	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms[0], terms[1], terms[2], terms[3]) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -863,7 +863,7 @@ func Function4(decl *Function, f Builtin4) func(*Rego) {
 func FunctionDyn(decl *Function, f BuiltinDyn) func(*Rego) {
 	return newFunction(decl, func(bctx BuiltinContext, terms []*ast.Term, iter func(*ast.Term) error) error {
 		result, err := memoize(decl, bctx, terms, func() (*ast.Term, error) { return f(bctx, terms) })
-		return finishFunction(decl.Name, bctx, result, err, iter)
+		return finishFunction(decl.Name, bctx.Location, result, err, iter)
 	})
 }
 
@@ -2841,11 +2841,11 @@ func (r *Rego) generateTermVar() *ast.Term {
 	return ast.VarTerm(fmt.Sprintf("%sterm%v", prefix, r.termVarID))
 }
 
-func (r Rego) hasQuery() bool {
+func (r *Rego) hasQuery() bool {
 	return len(r.query) != 0 || len(r.parsedQuery) != 0
 }
 
-func (r Rego) hasWasmModule() bool {
+func (r *Rego) hasWasmModule() bool {
 	for _, b := range r.bundles {
 		if len(b.WasmModules) > 0 {
 			return true
@@ -3020,7 +3020,7 @@ func parseStringsToRefs(s []string) ([]ast.Ref, error) {
 // helper function to finish a built-in function call. If an error occurred,
 // wrap the error and return it. Otherwise, invoke the iterator if the result
 // was defined.
-func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, err error, iter func(*ast.Term) error) error {
+func finishFunction(name string, loc *ast.Location, result *ast.Term, err error, iter func(*ast.Term) error) error {
 	if err != nil {
 		sb := strings.Builder{}
 		if e, ok := errors.AsType[*HaltError](err); ok {
@@ -3031,7 +3031,7 @@ func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, 
 			tdErr := &topdown.Error{
 				Code:     topdown.BuiltinErr,
 				Message:  sb.String(),
-				Location: bctx.Location,
+				Location: loc,
 			}
 			return topdown.Halt{Err: tdErr.Wrap(e)}
 		}
@@ -3042,7 +3042,7 @@ func finishFunction(name string, bctx topdown.BuiltinContext, result *ast.Term, 
 		tdErr := &topdown.Error{
 			Code:     topdown.BuiltinErr,
 			Message:  sb.String(),
-			Location: bctx.Location,
+			Location: loc,
 		}
 		return tdErr.Wrap(err)
 	}
@@ -3068,11 +3068,10 @@ func newFunction(decl *Function, f topdown.BuiltinFunc) func(*Rego) {
 }
 
 func generateJSON(term *ast.Term, ectx *EvalContext) (any, error) {
-	return ast.JSONWithOpt(term.Value,
-		ast.JSONOpt{
-			SortSets: ectx.sortSets,
-			CopyMaps: ectx.copyMaps,
-		})
+	return ast.JSONWithOpt(term.Value, ast.JSONOpt{
+		SortSets: ectx.sortSets,
+		CopyMaps: ectx.copyMaps,
+	})
 }
 
 func (r *Rego) planQuery(queries []ast.Body, evalQueryType queryType) (*ir.Policy, error) {

--- a/v1/server/failtracer/failtracer.go
+++ b/v1/server/failtracer/failtracer.go
@@ -67,8 +67,7 @@ func (b *failTracer) Hints(unknowns []ast.Ref) []Hint {
 
 	for _, expr := range b.exprs {
 		var ref ast.Ref // when this is processed, only one input.X.Y ref is in the expression (SSA)
-		switch {
-		case expr.IsCall():
+		if expr.IsCall() {
 			for _, op := range expr.Operands() {
 				if r, ok := op.Value.(ast.Ref); ok && r.HasPrefix(ast.InputRootRef) {
 					ref = r

--- a/v1/server/server.go
+++ b/v1/server/server.go
@@ -791,8 +791,7 @@ func (s *Server) initHandlerAuthn(handler http.Handler) http.Handler {
 }
 
 func (s *Server) initHandlerAuthz(handler http.Handler) http.Handler {
-	switch s.authorization {
-	case AuthorizationBasic:
+	if s.authorization == AuthorizationBasic {
 		handler = authorizer.NewBasic(
 			handler,
 			s.getCompiler,
@@ -803,8 +802,8 @@ func (s *Server) initHandlerAuthz(handler http.Handler) http.Handler {
 			authorizer.EnablePrintStatements(s.manager.EnablePrintStatements()),
 			authorizer.InterQueryCache(s.interQueryBuiltinCache),
 			authorizer.InterQueryValueCache(s.interQueryBuiltinValueCache),
-			authorizer.URLPathExpectsBodyFunc(s.manager.ExtraAuthorizerRoutes()))
-
+			authorizer.URLPathExpectsBodyFunc(s.manager.ExtraAuthorizerRoutes()),
+		)
 		if s.metrics != nil {
 			handler = s.instrumentHandler(handler.ServeHTTP, PromHandlerAPIAuthz)
 		}
@@ -2699,13 +2698,8 @@ func parseRefQuery(str string) (ast.Body, error) {
 	}
 
 	// assert the single statement is a lone ref
-	expr := query[0]
-	switch t := expr.Terms.(type) {
-	case *ast.Term:
-		switch t.Value.(type) {
-		case ast.Ref:
-			return query, nil
-		}
+	if t, ok := query[0].Terms.(*ast.Term); ok && ast.TermValueIs[ast.Ref](t) {
+		return query, nil
 	}
 
 	return nil, errors.New("complex query")

--- a/v1/tester/runner.go
+++ b/v1/tester/runner.go
@@ -1133,12 +1133,10 @@ func subResults(v any, trace []*topdown.Event) (bool, map[string]*SubResult) {
 	var fail bool
 	result := SubResultMap{}
 
-	switch x := v.(type) {
-	case map[string]any:
+	if x, ok := v.(map[string]any); ok {
 		for k, v := range x {
-			sr := subResult(k, v)
-			result[k] = sr
-			if sr.Fail {
+			result[k] = subResult(k, v)
+			if result[k].Fail {
 				fail = true
 			}
 		}

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -1306,8 +1306,7 @@ func (e *eval) biunifyValues(a, b *ast.Term, b1, b2 *bindings, iter unifyIterato
 	// Sets must not contain unbound variables at this point as we cannot unify
 	// them. So simply plug both sides (to substitute any bound variables with
 	// values) and then check for equality.
-	switch a.Value.(type) {
-	case ast.Set:
+	if _, ok := a.Value.(ast.Set); ok {
 		a = b1.Plug(a)
 		b = b2.Plug(b)
 	}

--- a/v1/util/compare.go
+++ b/v1/util/compare.go
@@ -77,8 +77,7 @@ func Compare(a, b any) int {
 	case nil:
 		return 0
 	case bool:
-		switch b := b.(type) {
-		case bool:
+		if b, ok := b.(bool); ok {
 			if a == b {
 				return 0
 			}
@@ -88,13 +87,11 @@ func Compare(a, b any) int {
 			return 1
 		}
 	case json.Number:
-		switch b := b.(type) {
-		case json.Number:
+		if b, ok := b.(json.Number); ok {
 			return compareJSONNumber(a, b)
 		}
 	case int:
-		switch b := b.(type) {
-		case int:
+		if b, ok := b.(int); ok {
 			if a == b {
 				return 0
 			} else if a < b {
@@ -103,8 +100,7 @@ func Compare(a, b any) int {
 			return 1
 		}
 	case float64:
-		switch b := b.(type) {
-		case float64:
+		if b, ok := b.(float64); ok {
 			if a == b {
 				return 0
 			} else if a < b {
@@ -113,8 +109,7 @@ func Compare(a, b any) int {
 			return 1
 		}
 	case string:
-		switch b := b.(type) {
-		case string:
+		if b, ok := b.(string); ok {
 			if a == b {
 				return 0
 			} else if a < b {
@@ -123,8 +118,7 @@ func Compare(a, b any) int {
 			return 1
 		}
 	case []any:
-		switch b := b.(type) {
-		case []any:
+		if b, ok := b.([]any); ok {
 			bLen := len(b)
 			aLen := len(a)
 			minLen := min(bLen, aLen)
@@ -142,8 +136,7 @@ func Compare(a, b any) int {
 			return 1
 		}
 	case map[string]any:
-		switch b := b.(type) {
-		case map[string]any:
+		if b, ok := b.(map[string]any); ok {
 			aKeys := KeysSorted(a)
 			bKeys := KeysSorted(b)
 			aLen := len(aKeys)


### PR DESCRIPTION
- Enable the `hugeParam` linter and fix some of the worst offenders. Still leave the threshold fairly high as the default will have too much to report. Can definitely be revisited later setting a lower value
- Enable the `singleCaseSwitch` check and fix the locations reported
- Move the `Default` value in the `Rule` struct to avoid some alignment padding and slightly reduce its size