### PR TITLE
format: allow early exit on the fail condition

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -158,15 +159,21 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 		return newError("failed to open file: %v", err)
 	}
 
+	failOnChange := params.fail && !params.list && !params.diff
+
 	opts := format.Opts{
 		RegoVersion:   params.regoVersion(),
 		DropV0Imports: params.dropV0Imports,
 		Capabilities:  params.capabilities(),
 		ParserOptions: params.parserOptions(),
+		FailFast:      failOnChange,
 	}
 
 	formatted, err := format.SourceWithOpts(filename, contents, opts)
 	if err != nil {
+		if _, ok := errors.AsType[format.UnformattedError](err); ok {
+			return newError("unexpected diff")
+		}
 		return newError("failed to format Rego source file: %v", err)
 	}
 
@@ -183,7 +190,7 @@ func formatFile(params *fmtCommandParams, out io.Writer, filename string, info o
 
 	changed := !bytes.Equal(contents, formatted)
 
-	if params.fail && !params.list && !params.diff {
+	if failOnChange {
 		if changed {
 			return newError("unexpected diff")
 		}

--- a/format/format.go
+++ b/format/format.go
@@ -14,6 +14,10 @@ import (
 // Opts lets you control the code formatting via `AstWithOpts()`.
 type Opts = v1.Opts
 
+// UnformattedError is returned by the Source* functions when [Opts.FailFast] is set and the formatted output
+// differs from the source. Loc is the element being written when the difference was noticed.
+type UnformattedError = v1.UnformattedError
+
 // Source formats a Rego source file. The bytes provided must describe a complete
 // Rego module. If they don't, Source will return an error resulting from the attempt
 // to parse the bytes.

--- a/format/format.go
+++ b/format/format.go
@@ -14,10 +14,6 @@ import (
 // Opts lets you control the code formatting via `AstWithOpts()`.
 type Opts = v1.Opts
 
-// UnformattedError is returned by the Source* functions when [Opts.FailFast] is set and the formatted output
-// differs from the source. Loc is the element being written when the difference was noticed.
-type UnformattedError = v1.UnformattedError
-
 // Source formats a Rego source file. The bytes provided must describe a complete
 // Rego module. If they don't, Source will return an error resulting from the attempt
 // to parse the bytes.

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -53,7 +53,27 @@ type Opts struct {
 	// as some formatting operations may otherwise mutate the AST.
 	SkipDefensiveCopying bool
 
+	// FailFast instructs the formatter to stop at the first element whose formatted form differs from the
+	// source text, and return an [UnformattedError] instead of laying out the rest of the module.
+	// Only the Source* functions honour this option, as they alone have source text to compare against.
+	// Not returning an [UnformattedError] doesn't promise that the output matches the source: FailFast never
+	// reports a formatted module as unformatted, but it doesn't catch every difference either.
+	FailFast bool
+
 	Capabilities *ast.Capabilities
+}
+
+// UnformattedError is returned by the Source* functions when [Opts.FailFast] is set and the formatted output
+// differs from the source. Loc is the element being written when the difference was noticed.
+type UnformattedError struct {
+	Loc *ast.Location
+}
+
+func (e UnformattedError) Error() string {
+	if e.Loc == nil {
+		return "source is not formatted"
+	}
+	return fmt.Sprintf("%s:%d: source is not formatted", e.Loc.File, e.Loc.Row)
 }
 
 func (o Opts) effectiveRegoVersion() ast.RegoVersion {
@@ -106,8 +126,11 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 		}
 	}
 
-	formatted, err := AstWithOpts(module, opts)
+	formatted, err := astWithOpts(module, opts, src)
 	if err != nil {
+		if unformatted, ok := errors.AsType[UnformattedError](err); ok {
+			return nil, unformatted
+		}
 		return nil, fmt.Errorf("%s: %v", filename, err)
 	}
 
@@ -176,6 +199,13 @@ func (o fmtOpts) keywords() []string {
 }
 
 func AstWithOpts(x any, opts Opts) ([]byte, error) {
+	// No source text to compare against, so [Opts.FailFast] can't be honoured here.
+	return astWithOpts(x, opts, nil)
+}
+
+// astWithOpts formats x. src, when non-nil, is the source text x was parsed from,
+// and is only used to serve [Opts.FailFast].
+func astWithOpts(x any, opts Opts, src []byte) ([]byte, error) {
 	// The node has to be deep copied because it may be mutated below. Alternatively,
 	// we could avoid the copy by checking if mutation will occur first. For now,
 	// since format is not latency sensitive, just deep copy in all cases.
@@ -279,6 +309,10 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 		fmtOpts: o,
 	}
 
+	if opts.FailFast && src != nil {
+		w.check = &srcChecker{src: src}
+	}
+
 	switch x := x.(type) {
 	case *ast.Module:
 		if regoVersion == ast.RegoV1 && opts.DropV0Imports {
@@ -311,6 +345,9 @@ func AstWithOpts(x any, opts Opts) ([]byte, error) {
 
 		err := w.writeModule(x)
 		if err != nil {
+			if unformatted, ok := errors.AsType[UnformattedError](err); ok {
+				return nil, unformatted
+			}
 			w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
 		}
 	case *ast.Package:
@@ -428,6 +465,10 @@ type writer struct {
 
 	buf bytes.Buffer
 
+	// check compares the output against the source as it's written, so that formatting can stop at the
+	// first element that differs. Nil unless [Opts.FailFast] was set.
+	check *srcChecker
+
 	indent                  string
 	level                   int
 	inline                  bool
@@ -436,6 +477,56 @@ type writer struct {
 	errs                    ast.Errors
 	fmtOpts                 fmtOpts
 	writeCommentOnFinalLine bool
+}
+
+// srcChecker compares the formatter's output against the source the module was parsed from, so that a caller
+// asking only "is this formatted?" doesn't pay to lay out a module whose first rule already answers it.
+type srcChecker struct {
+	src []byte
+
+	// matched is the number of leading bytes of src the output is known to reproduce, so that each check
+	// only compares what has been written since the last one.
+	matched int
+}
+
+// check reports an [UnformattedError] if out can't be a prefix of the source: the final output can only equal
+// the source if every prefix of it does. Trailing newlines are excluded, as elements are separated by blank
+// lines that are squashed at the end, so the newlines following the last element written aren't decided yet.
+func (c *srcChecker) check(out []byte, loc *ast.Location) error {
+	out = bytes.TrimRight(out, "\n")
+
+	if len(out) > len(c.src) {
+		return UnformattedError{Loc: loc}
+	}
+	if len(out) <= c.matched {
+		return nil
+	}
+	if !bytes.Equal(out[c.matched:], c.src[c.matched:len(out)]) {
+		return UnformattedError{Loc: loc}
+	}
+
+	c.matched = len(out)
+
+	return nil
+}
+
+// checkFormatted stops formatting if the output already differs from the source. A no-op unless
+// [Opts.FailFast] was set, and only safe to call between elements: writeTerm rewinds the buffer to re-write a
+// term as unformatted source when it meets an unexpected comment, so bytes written within an element may yet
+// be replaced, and a comment registered for the end of a line is written when the line ends, which can be
+// after the element that registered it.
+func (w *writer) checkFormatted(loc *ast.Location) error {
+	if w.check == nil || w.beforeEnd != nil {
+		return nil
+	}
+
+	// Elements the formatter added itself, such as a missing future keyword import, carry a synthetic location
+	// that points nowhere in the source.
+	if loc != nil && loc.File == defaultLocationFile {
+		loc = nil
+	}
+
+	return w.check.check(w.buf.Bytes(), loc)
 }
 
 func (w *writer) writeModule(module *ast.Module) error {
@@ -494,6 +585,9 @@ func (w *writer) writeModule(module *ast.Module) error {
 	var err error
 	comments, err = w.writePackage(pkg, comments)
 	if err != nil {
+		return err
+	}
+	if err := w.checkFormatted(pkg.Loc()); err != nil {
 		return err
 	}
 	comments, err = w.writeImports(added, comments)
@@ -606,6 +700,10 @@ func (w *writer) writeRules(rules []*ast.Rule, comments []*ast.Comment) ([]*ast.
 			if _, ok := errors.AsType[unexpectedCommentError](err); !ok {
 				w.errs = append(w.errs, ast.NewError(ast.FormatErr, &ast.Location{}, "%s", err.Error()))
 			}
+		}
+
+		if err := w.checkFormatted(rule.Loc()); err != nil {
+			return comments, err
 		}
 
 		if i < len(rules)-1 && w.groupableOneLiner(rule) {
@@ -2250,6 +2348,10 @@ func (w *writer) writeImports(imports []*ast.Import, comments []*ast.Comment) ([
 				w.write(" " + c.String())
 			}
 			w.endLine()
+
+			if err := w.checkFormatted(i.Loc()); err != nil {
+				return nil, err
+			}
 		}
 		w.blankLine()
 	}

--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -61,6 +61,11 @@ type Opts struct {
 	FailFast bool
 
 	Capabilities *ast.Capabilities
+
+	// srcCheck carries the source text that FailFast compares against. It stays unexported so
+	// that only SourceWithOpts can set it, since the comparison is only sound when the bytes
+	// are the ones x was parsed from.
+	srcCheck *srcChecker
 }
 
 // UnformattedError is returned by the Source* functions when [Opts.FailFast] is set and the formatted output
@@ -126,7 +131,11 @@ func SourceWithOpts(filename string, src []byte, opts Opts) ([]byte, error) {
 		}
 	}
 
-	formatted, err := astWithOpts(module, opts, src)
+	if opts.FailFast {
+		opts.srcCheck = &srcChecker{src: src}
+	}
+
+	formatted, err := AstWithOpts(module, opts)
 	if err != nil {
 		if unformatted, ok := errors.AsType[UnformattedError](err); ok {
 			return nil, unformatted
@@ -199,13 +208,6 @@ func (o fmtOpts) keywords() []string {
 }
 
 func AstWithOpts(x any, opts Opts) ([]byte, error) {
-	// No source text to compare against, so [Opts.FailFast] can't be honoured here.
-	return astWithOpts(x, opts, nil)
-}
-
-// astWithOpts formats x. src, when non-nil, is the source text x was parsed from,
-// and is only used to serve [Opts.FailFast].
-func astWithOpts(x any, opts Opts, src []byte) ([]byte, error) {
 	// The node has to be deep copied because it may be mutated below. Alternatively,
 	// we could avoid the copy by checking if mutation will occur first. For now,
 	// since format is not latency sensitive, just deep copy in all cases.
@@ -309,9 +311,7 @@ func astWithOpts(x any, opts Opts, src []byte) ([]byte, error) {
 		fmtOpts: o,
 	}
 
-	if opts.FailFast && src != nil {
-		w.check = &srcChecker{src: src}
-	}
+	w.check = opts.srcCheck
 
 	switch x := x.(type) {
 	case *ast.Module:

--- a/v1/format/format_test.go
+++ b/v1/format/format_test.go
@@ -6,6 +6,7 @@ package format
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1462,6 +1463,158 @@ x3 := {"foo": {
 	}
 }
 
+func TestFormatFailFastFormattedSource(t *testing.T) {
+	cases := []struct {
+		dir  string
+		opts Opts
+	}{
+		{
+			dir: "testfiles/v0",
+			opts: Opts{
+				RegoVersion:   ast.RegoV0,
+				ParserOptions: &ast.ParserOptions{RegoVersion: ast.RegoV0},
+				FailFast:      true,
+			},
+		},
+		{
+			dir: "testfiles/v1",
+			opts: Opts{
+				RegoVersion:   ast.RegoV1,
+				ParserOptions: &ast.ParserOptions{RegoVersion: ast.RegoV1},
+				FailFast:      true,
+			},
+		},
+		{
+			dir: "testfiles/v0_to_v1",
+			opts: Opts{
+				RegoVersion: ast.RegoV0CompatV1,
+				FailFast:    true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		regoFiles, err := filepath.Glob(tc.dir + "/*.rego.formatted")
+		if err != nil {
+			panic(err)
+		}
+
+		if len(regoFiles) == 0 {
+			t.Fatalf("Found no formatted files in %s", tc.dir)
+		}
+
+		for _, rego := range regoFiles {
+			t.Run(rego, func(t *testing.T) {
+				contents, err := os.ReadFile(rego)
+				if err != nil {
+					t.Fatalf("Failed to read rego source: %v", err)
+				}
+
+				formatted, err := SourceWithOpts(rego, contents, tc.opts)
+				if err != nil {
+					t.Fatalf("Expected formatted source to format without error, got: %v", err)
+				}
+
+				if ln, at := differsAt(formatted, contents); ln != 0 {
+					t.Fatalf("Expected formatted bytes to equal source bytes but differed near line %d / byte %d:\n%s", ln, at, prefixWithLineNumbers(formatted))
+				}
+			})
+		}
+	}
+}
+
+func TestFormatFailFastLocation(t *testing.T) {
+	cases := []struct {
+		note   string
+		module string
+		expRow int
+	}{
+		{
+			note: "formatted",
+			module: `package p
+
+import data.foo
+
+allow if input.x
+
+deny if input.y
+`,
+		},
+		{
+			note: "unformatted package",
+			module: `package  p
+
+allow if input.x
+`,
+			expRow: 1,
+		},
+		{
+			note: "unformatted import",
+			module: `package p
+
+import  data.foo
+
+allow if input.x
+`,
+			expRow: 3,
+		},
+		{
+			note: "unformatted first rule",
+			module: `package p
+
+allow if  input.x
+
+deny if  input.y
+`,
+			expRow: 3,
+		},
+		{
+			note: "unformatted second rule",
+			module: `package p
+
+allow if input.x
+
+deny if  input.y
+`,
+			expRow: 5,
+		},
+	}
+
+	opts := Opts{
+		RegoVersion:   ast.RegoV1,
+		ParserOptions: &ast.ParserOptions{RegoVersion: ast.RegoV1},
+		FailFast:      true,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			formatted, err := SourceWithOpts("test.rego", []byte(tc.module), opts)
+
+			if tc.expRow == 0 {
+				if err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if string(formatted) != tc.module {
+					t.Fatalf("Expected:\n%s\n\nGot:\n%s", tc.module, formatted)
+				}
+
+				return
+			}
+
+			unformatted, ok := errors.AsType[UnformattedError](err)
+			if !ok {
+				t.Fatalf("Expected UnformattedError, got: %v", err)
+			}
+			if unformatted.Loc.Row != tc.expRow {
+				t.Fatalf("Expected difference reported at row %d, got %d", tc.expRow, unformatted.Loc.Row)
+			}
+			if formatted != nil {
+				t.Fatalf("Expected no formatted bytes, got:\n%s", formatted)
+			}
+		})
+	}
+}
+
 // 3064960 ns/op	 4573131 B/op	   26266 allocs/op // no optimizations
 // 1737719 ns/op	 1972193 B/op	   14160 allocs/op // pre-allocate partitionComments
 // 1674343 ns/op	 1916700 B/op	   11556 allocs/op // static memberRef & memberWithKeyRef
@@ -1483,6 +1636,47 @@ func BenchmarkFormatLargePolicy(b *testing.B) {
 	for b.Loop() {
 		if _, err := AstWithOpts(module, opts); err != nil {
 			b.Fatal(err)
+		}
+	}
+}
+
+// formatted/fail_fast=false  	3156799 ns/op	 2038109 B/op	   33208 allocs/op
+// formatted/fail_fast=true   	3183775 ns/op	 2038132 B/op	   33209 allocs/op // no overhead beyond noise
+// unformatted/fail_fast=false	3163590 ns/op	 2038238 B/op	   33209 allocs/op
+// unformatted/fail_fast=true 	2546876 ns/op	 1795916 B/op	   30340 allocs/op // stops at the package
+func BenchmarkFormatLargePolicySource(b *testing.B) {
+	contents, err := os.ReadFile("testdata/bench.rego")
+	if err != nil {
+		b.Fatalf("Failed to read rego source: %v", err)
+	}
+
+	cases := []struct {
+		note string
+		src  []byte
+	}{
+		{
+			note: "formatted",
+			src:  contents,
+		},
+		{
+			note: "unformatted",
+			src:  bytes.Replace(contents, []byte("package regal.ast"), []byte("package  regal.ast"), 1),
+		},
+	}
+
+	for _, tc := range cases {
+		for _, failFast := range []bool{false, true} {
+			opts := Opts{RegoVersion: ast.RegoV1, SkipDefensiveCopying: true, FailFast: failFast}
+
+			b.Run(fmt.Sprintf("%s/fail_fast=%v", tc.note, failFast), func(b *testing.B) {
+				for b.Loop() {
+					if _, err := SourceWithOpts("bench.rego", tc.src, opts); err != nil {
+						if _, ok := errors.AsType[UnformattedError](err); !ok {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
 		}
 	}
 }

--- a/v1/format/format_test.go
+++ b/v1/format/format_test.go
@@ -1640,10 +1640,14 @@ func BenchmarkFormatLargePolicy(b *testing.B) {
 	}
 }
 
+// Parsing always runs in full, before any layout, and it is the bulk of the cost below: roughly 30k
+// of these allocs. BenchmarkFormatLargePolicy lays out the same module pre-parsed for 3188 allocs,
+// so the layout is all FailFast can skip, and the savings on the last row are the layout it skipped.
+//
 // formatted/fail_fast=false  	3156799 ns/op	 2038109 B/op	   33208 allocs/op
 // formatted/fail_fast=true   	3183775 ns/op	 2038132 B/op	   33209 allocs/op // no overhead beyond noise
 // unformatted/fail_fast=false	3163590 ns/op	 2038238 B/op	   33209 allocs/op
-// unformatted/fail_fast=true 	2546876 ns/op	 1795916 B/op	   30340 allocs/op // stops at the package
+// unformatted/fail_fast=true 	2546876 ns/op	 1795916 B/op	   30340 allocs/op // layout stops at the package
 func BenchmarkFormatLargePolicySource(b *testing.B) {
 	contents, err := os.ReadFile("testdata/bench.rego")
 	if err != nil {


### PR DESCRIPTION
### Why the changes in this PR are needed?

`opa fmt --fail` only needs to know whether a policy is formatted, and the same goes for API consumers like Regal. Getting that answer currently means laying out the whole module and then throwing the result away. See #8841.

### What are the changes in this PR?

- A new `format.Opts.FailFast`. With it set, the formatter stops at the first element whose formatted form differs from the source and returns an `UnformattedError` pointing at that element, instead of laying out the rest. Only the `Source*` functions can honour it, since they're the ones with source text to compare against.
- `cmd/fmt.go` sets it for plain `--fail`, without `-l` or `-d`. That's the only case where nothing reads the formatted text afterwards, so not producing it costs nothing.
- The source text reaches the writer through an unexported `Opts.srcCheck`, set only by `SourceWithOpts`. Unexported because the comparison is only sound when the bytes are the ones the module was parsed from, and a pointer so `Opts` stays comparable.
- `FailFast` only ever errs one way. It won't tell you a formatted module is unformatted, but it won't catch every difference either, so if you need a definitive answer you still have to compare bytes. `cmd/fmt.go` keeps its `bytes.Equal` check and its exit codes don't change. That's also why it only compares at element boundaries, since bytes written inside an element aren't settled yet.
- Tests cover the 125 already-formatted files under `v1/format/testfiles/` still coming out byte-identical with `FailFast` on, plus the reported location when the difference is in the package, an import, or either of the first two rules.
- Numbers are in the comment block above `BenchmarkFormatLargePolicySource`: roughly 20% off an unformatted module, nothing measurable on a formatted one. The ceiling is low, though. Parsing `bench.rego` costs ~2.23ms against ~0.87ms to lay it out, so layout is only about 27% of `SourceWithOpts`, and that 20% is most of it already.

One thing I'd like your call on. `--check-result` defaults to `true` and re-parses the output to catch the formatter emitting invalid Rego. With `FailFast` an unformatted file returns early with nothing to re-parse, so in `--fail` mode that check stops covering unformatted files, though formatted ones are still covered. Gating on `!params.checkResult` would keep it, but with `--check-result` on by default that leaves the optimization off for almost everyone. I went with the narrower check and will switch it if you'd rather keep the assertion.

