### PR TITLE
build: pin pigeon in build/tools instead of go run pkg@version

### DIFF
--- a/build/gen-run-go.sh
+++ b/build/gen-run-go.sh
@@ -2,4 +2,22 @@
 
 set -e
 
-GOOS= GOARCH= CC= go run -tags generate $@
+# A generator is either a .go file in this module or a tool pinned in
+# build/tools. Both run in the caller's working directory, so relative paths
+# in //go:generate directives still resolve.
+case $1 in
+*.go)
+	GOOS= GOARCH= CC= go run -tags generate "$@"
+	;;
+*)
+	pkg=$1
+	shift
+
+	root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+	bin=$root/build/tools/bin/$(basename "$pkg")
+
+	GOOS= GOARCH= CC= go -C "$root/build/tools" build -o "$bin" "$pkg"
+
+	exec "$bin" "$@"
+	;;
+esac

--- a/build/tools/go.mod
+++ b/build/tools/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 tool (
 	github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+	github.com/mna/pigeon
 	github.com/rogpeppe/go-internal/cmd/testscript
 	golang.org/x/perf/cmd/benchstat
 	golang.org/x/vuln/cmd/govulncheck
@@ -19,6 +20,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/josephspurrier/goversioninfo v1.7.0 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/mna/pigeon v1.3.0 // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
 	github.com/vbauerster/mpb/v8 v8.12.1 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/build/tools/go.sum
+++ b/build/tools/go.sum
@@ -22,6 +22,8 @@ github.com/josephspurrier/goversioninfo v1.7.0 h1:LQzXOlVm/CtbwJ9/UHl5a2HT0BjcLA
 github.com/josephspurrier/goversioninfo v1.7.0/go.mod h1:z9y0r2G6g5jwSJaFE0cxW9to0aeIibK7UYeLx53aQRU=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mna/pigeon v1.3.0 h1:/3fzVrl1C2RK3x04tyL+ribn+3S3VSEFFbCFLmRPAoc=
+github.com/mna/pigeon v1.3.0/go.mod h1:SKQNHonx2q9U2QSSoPtMigExj+vQ1mOpL7UVFQF/IA0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 }
 
-//go:generate build/gen-run-go.sh github.com/mna/pigeon@v1.3.0 -o v1/topdown/durationparser/duration_parser.go v1/topdown/durationparser/duration.peg
+//go:generate build/gen-run-go.sh github.com/mna/pigeon -o v1/topdown/durationparser/duration_parser.go v1/topdown/durationparser/duration.peg
 //go:generate build/gen-run-go.sh internal/cmd/genopacapabilities/main.go capabilities.json
 //go:generate build/gen-run-go.sh internal/cmd/genbuiltinmetadata/main.go builtin_metadata.json
 //go:generate build/gen-run-go.sh internal/cmd/genversionindex/main.go v1/ast/version_index.json


### PR DESCRIPTION
`go run <pkg>@<version>` resolves outside the main module, so every CI job running `make generate` queries sum.golang.org and intermittently fails there; pinning pigeon puts its checksum in a go.sum like the other tools.