### PR TITLE
Add indexing for prefix match built-in functions

### DIFF
--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -151,6 +151,31 @@ For `glob.match(pattern, delimiter, match)` statements to be indexed the pattern
 | `glob.match("foo:*/bar", [":", "/"], input.x)` | yes     | any delimiter separates    |
 | `glob.match("foo:*:bar", null, input.x)`       | no      | delimiter is `null`        |
 
+#### Prefix statements
+
+For `startswith(search, base)` and `strings.any_prefix_match(search, base)` statements to be indexed the search operand must be a non-nested reference that does not contain any variables, and every base string must be known at compile time — a literal, or a variable previously assigned one. `strings.any_prefix_match` holds if any base string matches, so each of its base strings is indexed as an alternative; a base collection holding anything other than strings is not indexed at all, since indexing only part of it would exclude rules the rest would have matched.
+
+The prefixes recorded for one reference are held in a radix trie, so a lookup walks the input value once no matter how many prefixes are indexed. A rule set with ten prefixes and one with ten thousand cost the same to look up.
+
+Capturing the result (`allowed := startswith(input.path, "/api")`) is not indexed: a rule producing `false` still has to be evaluated.
+
+| Expression                                              | Indexed | Notes                                     |
+| ------------------------------------------------------- | ------- | ----------------------------------------- |
+| `startswith(input.path, "/api")`                        | yes     |                                           |
+| `x := input.path; startswith(x, "/api")`                | yes     | variable resolved to ref via assignment   |
+| `strings.any_prefix_match(input.path, ["/a", "/b"])`    | yes     | each base string is an alternative        |
+| `strings.any_prefix_match(input.path, {"/a", "/b"})`    | yes     | set literals work the same as arrays      |
+| `strings.any_prefix_match(input.path, "/api")`          | yes     | a single base string is like `startswith` |
+| `startswith(input.path, input.prefix)`                  | no      | base is not known until evaluation        |
+| `strings.any_prefix_match(input.path, input.bases)`     | no      | base is not known until evaluation        |
+| `strings.any_prefix_match(input.path, ["/a", input.b])` | no      | base collection is not all literals       |
+| `startswith(input.path[i], "/api")`                     | no      | search contains variable(s)               |
+| `x := startswith(input.path, "/api"); x == true`        | no      | result is captured                        |
+
+:::info
+A prefix statement is indexed the way `glob.match` is, and shares its one rough edge: a rule whose search operand turns out not to be a string is excluded by the index, so the type error the call would have raised is not raised. This only shows with [strict built-in errors](./policy-language#errors) enabled, where the query would otherwise have failed rather than been undefined.
+:::
+
 #### Membership (`in`) statements
 
 For `value in collection` statements to be indexed, the value must be a scalar (or a variable previously assigned a scalar), and the collection must be either a non-nested reference without variables, or a literal set, array, or object.
@@ -193,7 +218,7 @@ Statements joined by the [`and` and `or` keywords](./policy-reference/keywords/l
 
 Building a reference on top of a local variable does not defeat the indexer. When the head of a reference is a variable that was assigned a reference earlier in the rule body, the indexer resolves that head and indexes the statement as if the whole reference had been spelled out: `x := input; x.foo == "a"` is indexed just like `input.foo == "a"`.
 
-The head must resolve to a reference rooted at `input` or `data`, and the resolved reference is then subject to exactly the same conditions as one written out by hand. A head that resolves to a document produced by another rule is not indexed, since the indexer only looks up base documents. `in` and `glob.match` statements benefit from the same resolution: the compiler hoists their reference operand into a local variable of its own, which the indexer then resolves.
+The head must resolve to a reference rooted at `input` or `data`, and the resolved reference is then subject to exactly the same conditions as one written out by hand. A head that resolves to a document produced by another rule is not indexed, since the indexer only looks up base documents. `in`, `glob.match` and the prefix statements benefit from the same resolution: the compiler hoists their reference operand into a local variable of its own, which the indexer then resolves.
 
 The resolution also applies where a local stands in for a whole value rather than the head of a reference, chained assignments included, and inside the operands of an `and` or `or`, where a local assigned in the enclosing rule body still resolves.
 
@@ -205,6 +230,7 @@ The resolution also applies where a local stands in for a whole value rather tha
 | `x := input.role; y := x; y == "a"`           | yes     | indexed as `input.role == "a"`           |
 | `x := input; "a" in x.foo`                    | yes     |                                          |
 | `x := input; glob.match("a/*", ["/"], x.foo)` | yes     |                                          |
+| `x := input; startswith(x.foo, "a/")`         | yes     |                                          |
 | `x := input; x.foo`                           | yes     | bare reference                           |
 | `x := input; x.foo[i] == "a"`                 | yes     | ground prefix `input.foo` is indexed     |
 | `x := input; x.foo[i].bar == "a"`             | no      | variable is not the last element         |

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -170,7 +170,7 @@ func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int,
 		if len(values) == 0 {
 			node = node.Insert(ref, nil, nil)
 		} else if len(values) == 1 {
-			node = node.Insert(ref, values[0].Value, values[0].Mapper)
+			node = values[0].insertInto(node, ref)
 		} else {
 			if slices.ContainsFunc(values, (*refindex).isVar) {
 				child := node.Insert(ref, anyValue, values[0].Mapper)
@@ -186,7 +186,7 @@ func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int,
 				// This creates separate paths for each value so different rules with overlapping
 				// values don't interfere with each other.
 				for _, val := range values {
-					child := node.Insert(ref, val.Value, val.Mapper)
+					child := val.insertInto(node, ref)
 					child.append(prio, rule)
 				}
 				return
@@ -337,6 +337,19 @@ type refindex struct {
 	Ref    Ref
 	Value  Value
 	Mapper *valueMapper
+	// Prefix marks Value as a string the value at Ref has to start with, rather
+	// than one it has to equal -- what startswith and strings.any_prefix_match
+	// contribute. Several of them for one ref are alternatives, as for `in`.
+	Prefix bool
+}
+
+// insertInto adds the level this index constrains to the path being built,
+// returning the node the rest of the path continues from.
+func (i *refindex) insertInto(node *trieNode, ref Ref) *trieNode {
+	if i.Prefix {
+		return node.InsertPrefix(ref, i.Value)
+	}
+	return node.Insert(ref, i.Value, i.Mapper)
 }
 
 // alternatives are sets of indices, any one of which is enough to reach a rule.
@@ -433,6 +446,14 @@ func (i *refindices) Update(rule *Rule, expr *Expr, values map[Var]Value) {
 	case op.Equal(Interned.Refs.Member) && len(expr.Operands()) == 2:
 		// NOTE(sr): Again, 3 operands means captured output (like above).
 		i.updateMember(rule, expr, values)
+
+	case op.Equal(Interned.Refs.StartsWith) && len(expr.Operands()) == 2:
+		// As with equal() above: a third operand captures the result, and a
+		// rule producing `false` still has to be evaluated.
+		i.updateStartsWith(rule, expr, values)
+
+	case op.Equal(Interned.Refs.AnyPrefixMatch) && len(expr.Operands()) == 2:
+		i.updateAnyPrefixMatch(rule, expr, values)
 	}
 }
 
@@ -827,8 +848,12 @@ func (i *refindices) resolvable(rule *Rule) []*refindex {
 // count records that ref took part in indexing a rule, which is what orders the
 // trie levels (see Sorted).
 func (i *refindices) count(ref Ref) {
+	i.countN(ref, 1)
+}
+
+func (i *refindices) countN(ref Ref, n int) {
 	count, _ := i.frequency.Get(ref)
-	i.frequency.Put(ref, count+1)
+	i.frequency.Put(ref, count+n)
 }
 
 func (i *refindices) insert(rule *Rule, index *refindex) {
@@ -838,11 +863,16 @@ func (i *refindices) insert(rule *Rule, index *refindex) {
 
 	for pos, other := range i.rules[rule] {
 		if other.Ref.Equal(index.Ref) {
-			if ValueEqual(other.Value, index.Value) {
+			if other.Prefix == index.Prefix && ValueEqual(other.Value, index.Value) {
 				return
 			}
 			_, otherValueIsVar := other.Value.(Var)
-			if !indexValueIsVar && otherValueIsVar {
+			// A prefix constraint does not take the place of the "ref is
+			// anything" entry the way a concrete value does: that entry is what
+			// lets a later expression resolve the same local back to this ref
+			// (see resolveVarToRef), and insertPath drops it anyway once the
+			// ref has a concrete value on the path.
+			if !indexValueIsVar && !index.Prefix && otherValueIsVar {
 				i.rules[rule][pos] = index
 				return
 			}
@@ -914,6 +944,7 @@ type trieNode struct {
 	any       *trieNode
 	undefined *trieNode
 	scalars   *util.HasherMap[Value, *trieNode]
+	prefixes  *prefixTrie
 	array     *trieNode
 	rules     []*ruleNode
 	value     *Term
@@ -966,6 +997,7 @@ func (node *trieNode) Do(walker trieWalker) {
 		return false
 	})
 
+	node.prefixes.do(next)
 	node.array.Do(next)
 	node.next.Do(next)
 }
@@ -1101,6 +1133,14 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return err
 	}
 
+	// Prefix constraints are tested against the value as it is, never against
+	// what a mapper makes of it: the glob mapper turns a string into the array
+	// of its segments, and matching prefixes against those segments would
+	// answer a question no rule asked.
+	if err = node.traversePrefixes(resolver, tr, v); err != nil {
+		return err
+	}
+
 	for i := range node.mappers {
 		mapped := node.mappers[i].MapValue(v)
 		if !ValueEqual(mapped, v) {
@@ -1196,6 +1236,10 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 	}
 
 	if err := node.array.traverseUnknown(resolver, tr); err != nil {
+		return err
+	}
+
+	if err := node.prefixes.traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -99,6 +99,15 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
+	for _, p := range node.prefixes.walk() {
+		if childID, childExists := nodeIDs[p.node]; childExists {
+			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), childID)
+		} else {
+			p.node.mermaidFormat(sb, counter, nodeIDs, "")
+			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), nodeIDs[p.node])
+		}
+	}
+
 	if node.next != nil {
 		node.next.mermaidFormat(sb, counter, nodeIDs, currentID)
 	}
@@ -218,6 +227,14 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		sb.WriteString(indent)
 		sb.WriteString("  array:\n")
 		node.array.format(sb, depth+2)
+	}
+
+	for _, p := range node.prefixes.walk() {
+		sb.WriteString(indent)
+		sb.WriteString(`  prefix "`)
+		sb.WriteString(p.prefix)
+		sb.WriteString("\":\n")
+		p.node.format(sb, depth+2)
 	}
 
 	if node.next != nil {

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -1,0 +1,383 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"errors"
+	"slices"
+)
+
+// prefixTrie holds the string-prefix constraints recorded for one level of the
+// rule index: what `startswith(input.x, "/api/")` and
+// `strings.any_prefix_match(input.x, [...])` contribute.
+//
+// A scalar constraint is answered with a map lookup, but a prefix constraint
+// has to answer "which of the recorded prefixes does this value start with",
+// and the answer is a set, not a single entry. Testing the value against every
+// recorded prefix in turn costs O(p) string comparisons per lookup for p
+// prefixes -- which is the work strings.any_prefix_match exists to avoid doing
+// in the rule body, so doing it in the index instead would be no bargain.
+//
+// This is a compressed (radix) trie instead: a lookup walks the value once and
+// costs O(len(value)) byte comparisons whatever p is. Compressed rather than
+// one node per byte because the node count is then bounded by 2p-1 rather than
+// by the total length of all prefixes -- 10k prefixes cost thousands of nodes,
+// not hundreds of thousands.
+type prefixTrie struct {
+	// edges are sorted by the first byte of their label, which is unique among
+	// them, so a step down the trie is a binary search.
+	edges []prefixEdge
+	// child is where the rules of the prefixes ending exactly here hang off. It
+	// is an ordinary trieNode, so whatever a rule constrains below a prefix
+	// constraint indexes as usual.
+	child *trieNode
+}
+
+type prefixEdge struct {
+	label string
+	node  *prefixTrie
+}
+
+// edge locates the edge labelled with first byte b, or the position a new one
+// would be inserted at to keep edges sorted.
+func (p *prefixTrie) edge(b byte) (int, bool) {
+	return slices.BinarySearchFunc(p.edges, b, func(e prefixEdge, b byte) int {
+		return int(e.label[0]) - int(b)
+	})
+}
+
+// insert returns the node that the rules constrained by prefix hang off,
+// creating it if this is the first time the prefix is recorded.
+func (p *prefixTrie) insert(prefix string) *trieNode {
+	node := p
+
+	for {
+		if prefix == "" {
+			if node.child == nil {
+				node.child = newTrieNodeImpl()
+			}
+			return node.child
+		}
+
+		pos, found := node.edge(prefix[0])
+		if !found {
+			leaf := &prefixTrie{child: newTrieNodeImpl()}
+			node.edges = slices.Insert(node.edges, pos, prefixEdge{label: prefix, node: leaf})
+			return leaf.child
+		}
+
+		edge := node.edges[pos]
+		common := commonPrefixLen(edge.label, prefix)
+
+		// The two diverge inside this edge -- "/api/v1" meeting "/api/v2" --
+		// so the edge is split where they stop agreeing and what used to hang
+		// off it moves down onto the tail.
+		if common < len(edge.label) {
+			node.edges[pos] = prefixEdge{
+				label: edge.label[:common],
+				node:  &prefixTrie{edges: []prefixEdge{{label: edge.label[common:], node: edge.node}}},
+			}
+		}
+
+		node = node.edges[pos].node
+		prefix = prefix[common:]
+	}
+}
+
+// traverse visits the continuation of every recorded prefix that s starts with.
+// One walk down the trie finds all of them: the prefixes of s that are in the
+// trie are exactly the ends-of-prefix passed on the way down.
+func (p *prefixTrie) traverse(s string, resolver ValueResolver, tr *trieTraversalResult) error {
+	for node := p; node != nil; {
+		if node.child != nil {
+			if err := node.child.Traverse(resolver, tr); err != nil {
+				return err
+			}
+		}
+
+		if s == "" {
+			return nil
+		}
+
+		pos, found := node.edge(s[0])
+		if !found {
+			return nil
+		}
+
+		edge := node.edges[pos]
+		if len(edge.label) > len(s) || s[:len(edge.label)] != edge.label {
+			return nil
+		}
+
+		s = s[len(edge.label):]
+		node = edge.node
+	}
+
+	return nil
+}
+
+func (p *prefixTrie) do(walker trieWalker) {
+	if p == nil {
+		return
+	}
+
+	p.child.Do(walker)
+
+	for _, edge := range p.edges {
+		edge.node.do(walker)
+	}
+}
+
+func (p *prefixTrie) traverseUnknown(resolver ValueResolver, tr *trieTraversalResult) error {
+	if p == nil {
+		return nil
+	}
+
+	if err := p.child.traverseUnknown(resolver, tr); err != nil {
+		return err
+	}
+
+	for _, edge := range p.edges {
+		if err := edge.node.traverseUnknown(resolver, tr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// prefixEntry is a prefix the trie holds, spelled out, with the node its rules
+// hang off.
+type prefixEntry struct {
+	prefix string
+	node   *trieNode
+}
+
+// walk returns the prefixes the trie holds, in lexicographic order. Only the
+// index's debug rendering and its tests have any use for reading back what the
+// compression made of them.
+func (p *prefixTrie) walk() []prefixEntry {
+	if p == nil {
+		return nil
+	}
+
+	var (
+		entries []prefixEntry
+		collect func(node *prefixTrie, prefix string)
+	)
+
+	collect = func(node *prefixTrie, prefix string) {
+		if node.child != nil {
+			entries = append(entries, prefixEntry{prefix: prefix, node: node.child})
+		}
+		for _, edge := range node.edges {
+			collect(edge.node, prefix+edge.label)
+		}
+	}
+
+	collect(p, "")
+
+	return entries
+}
+
+func commonPrefixLen(a, b string) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+// InsertPrefix records that the rules below this node require the value at ref
+// to be a string starting with prefix.
+func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
+	if node.next == nil {
+		node.next = newTrieNodeImpl()
+		node.next.ref = ref
+	}
+
+	s, ok := prefix.(String)
+	if !ok {
+		panic("illegal prefix value")
+	}
+
+	if node.next.prefixes == nil {
+		node.next.prefixes = &prefixTrie{}
+	}
+
+	return node.next.prefixes.insert(string(s))
+}
+
+// traversePrefixes visits the rules whose prefix constraints value satisfies.
+//
+// strings.any_prefix_match takes a collection of search strings as readily as a
+// single one, and holds if any of them starts with any of the base strings, so
+// a collection is tested element by element -- the same way a scalar constraint
+// is matched against the members of a collection (see
+// traverseCollectionMembership).
+func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+	if node.prefixes == nil {
+		return nil
+	}
+
+	if s, ok := value.(String); ok {
+		return node.prefixes.traverse(string(s), resolver, tr)
+	}
+
+	checkMember := func(t *Term) error {
+		if s, ok := t.Value.(String); ok {
+			return node.prefixes.traverse(string(s), resolver, tr)
+		}
+		return nil
+	}
+
+	switch col := value.(type) {
+	case *Array:
+		return col.Iter(checkMember)
+	case Set:
+		return col.Iter(checkMember)
+	case Object:
+		return col.Iter(func(_, v *Term) error {
+			return checkMember(v)
+		})
+	}
+
+	return nil
+}
+
+// updateStartsWith indexes `startswith(x, "base")`: x has to be a string
+// starting with base for the rule to hold.
+func (i *refindices) updateStartsWith(rule *Rule, expr *Expr, constants map[Var]Value) {
+	ref := i.resolveAndValidateRef(rule, rule.Head.Args, expr.Operand(0))
+	if ref == nil {
+		return
+	}
+
+	prefix, ok := constantString(expr.Operand(1), constants)
+	if !ok {
+		return
+	}
+
+	i.insert(rule, &refindex{Ref: ref, Value: prefix, Prefix: true})
+}
+
+// updateAnyPrefixMatch indexes `strings.any_prefix_match(x, base)`, which is
+// a disjunction of startswith calls: each base string is recorded as an
+// alternative prefix for x, the same way each element of `x in [...]` is
+// recorded as an alternative value (see updateMemberRefInValue).
+//
+// The search operand has to be a single ref: a collection of search strings
+// would need every element of one collection tested against the other, which
+// is not a constraint on the value at any one ref.
+func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[Var]Value) {
+	ref := i.resolveAndValidateRef(rule, rule.Head.Args, expr.Operand(0))
+	if ref == nil {
+		return
+	}
+
+	base := expr.Operand(1).Value
+	if v, ok := base.(Var); ok {
+		resolved, ok := constants[v]
+		if !ok {
+			return
+		}
+		base = resolved
+	}
+
+	if s, ok := base.(String); ok {
+		i.insert(rule, &refindex{Ref: ref, Value: s, Prefix: true})
+		return
+	}
+
+	// Every base string has to be recorded, or the index would exclude rules
+	// the dropped ones would have matched -- so a base that isn't a collection
+	// of ground strings throughout leaves the rule unindexed rather than
+	// partly indexed.
+	prefixes, ok := groundStrings(base)
+	if !ok || len(prefixes) == 0 {
+		return
+	}
+
+	i.insertPrefixes(rule, ref, prefixes)
+}
+
+// insertPrefixes records a whole base collection at once. insert() rescans the
+// rule's indices on every call, which is fine for the handful an ordinary rule
+// contributes but quadratic for the thousands strings.any_prefix_match exists
+// to carry, so the scan happens once here instead.
+func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
+	i.countN(ref, len(prefixes))
+
+	seen := make(map[String]struct{}, len(prefixes))
+	for _, other := range i.rules[rule] {
+		if other.Prefix && other.Ref.Equal(ref) {
+			if s, ok := other.Value.(String); ok {
+				seen[s] = struct{}{}
+			}
+		}
+	}
+
+	indices := i.rules[rule]
+	for _, prefix := range prefixes {
+		if _, ok := seen[prefix]; ok {
+			continue
+		}
+		seen[prefix] = struct{}{}
+		indices = append(indices, &refindex{Ref: ref, Value: prefix, Prefix: true})
+	}
+	i.rules[rule] = indices
+}
+
+// constantString resolves term to a string literal, following one level of
+// var binding recorded earlier in the rule body.
+func constantString(term *Term, constants map[Var]Value) (String, bool) {
+	v := term.Value
+	if vr, ok := v.(Var); ok {
+		resolved, ok := constants[vr]
+		if !ok {
+			return "", false
+		}
+		v = resolved
+	}
+
+	s, ok := v.(String)
+	return s, ok
+}
+
+// groundStrings returns the members of an array or set literal, and reports
+// false unless every one of them is a string.
+func groundStrings(v Value) ([]String, bool) {
+	var iter func(func(*Term) error) error
+
+	switch col := v.(type) {
+	case *Array:
+		iter = col.Iter
+	case Set:
+		iter = col.Iter
+	default:
+		return nil, false
+	}
+
+	var out []String
+	err := iter(func(t *Term) error {
+		s, ok := t.Value.(String)
+		if !ok {
+			return errNotAString
+		}
+		out = append(out, s)
+		return nil
+	})
+
+	if err != nil {
+		return nil, false
+	}
+
+	return out, true
+}
+
+// errNotAString stops the iteration in groundStrings; it never reaches a
+// caller.
+var errNotAString = errors.New("not a string")

--- a/v1/ast/index_prefix_bench_test.go
+++ b/v1/ast/index_prefix_bench_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// prefixGrid is the shape of the ruleset the prefix benchmarks build: `rules`
+// rules holding `perRule` prefixes each, so rules*perRule prefixes in total.
+// The two vary independently because the index scales differently in each --
+// see BenchmarkBuildPrefixIndex.
+type prefixGrid struct {
+	rules   int
+	perRule int
+}
+
+func (g prefixGrid) String() string {
+	return fmt.Sprintf("rules=%d/prefixes=%d", g.rules, g.perRule)
+}
+
+func (g prefixGrid) total() int { return g.rules * g.perRule }
+
+var prefixGrids = []prefixGrid{
+	{1, 100}, {1, 1000}, {1, 10000},
+	{10, 100}, {10, 1000}, {10, 10000},
+	{50, 100}, {50, 1000}, {50, 10000},
+	{250, 100}, {250, 1000}, {250, 10000},
+}
+
+// BenchmarkBuildPrefixIndex is the cost of putting rules*perRule prefixes into
+// the index, once as rules matching perRule prefixes each
+// (strings.any_prefix_match) and once as one rule per prefix (startswith).
+// Both are linear in the total number of prefixes and indifferent to how those
+// prefixes are divided into rules -- nothing here is quadratic in either
+// dimension.
+//
+//	                          any_prefix_match              startswith
+//	rules=1/prefixes=10000       2322533 ns    5.5 MB     5731426 ns    6.1 MB
+//	rules=10/prefixes=1000       2205267 ns    5.1 MB     5917098 ns    6.1 MB
+//	rules=250/prefixes=10000   577763666 ns   1387 MB  2344970750 ns   1531 MB
+//
+// The first two rows hold 10000 prefixes each, split two ways, and cost the
+// same; the third holds 250 times as many and costs 250 times as much.
+//
+// any_prefix_match used to be quadratic in perRule -- 302ms and 4.6MB for a
+// single rule of 10000 prefixes -- because refindices.insert rescans the rule's
+// indices on every call. See insertPrefixes.
+//
+// The B/op column is close to what the trie costs to hold, since nothing it
+// allocates is released. At the top of the grid the startswith ruleset is 2.5M
+// rules and takes gigabytes; that ruleset is built once, outside the timer.
+func BenchmarkBuildPrefixIndex(b *testing.B) {
+	for _, tc := range prefixShapes {
+		b.Run(tc.note, func(b *testing.B) {
+			for _, g := range prefixGrids {
+				b.Run(g.String(), func(b *testing.B) {
+					rules := tc.rules(g)
+					b.ReportAllocs()
+					b.ResetTimer()
+
+					for b.Loop() {
+						index := newBaseDocEqIndex(isVirtual)
+						if !index.Build(rules) {
+							b.Fatal("failed to build index")
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkLookupPrefixIndex is the point of the radix trie: a lookup walks the
+// value once, so its cost follows the length of the value and not the number of
+// prefixes indexed -- flat from 100 prefixes to 2.5M, in either dimension.
+//
+//	                          any_prefix_match          startswith
+//	rules=1/prefixes=100         172.0 ns  1 alloc    171.3 ns  1 alloc
+//	rules=250/prefixes=10000     223.5 ns  1 alloc    222.7 ns  1 alloc
+func BenchmarkLookupPrefixIndex(b *testing.B) {
+	for _, tc := range prefixShapes {
+		b.Run(tc.note, func(b *testing.B) {
+			for _, g := range prefixGrids {
+				b.Run(g.String(), func(b *testing.B) {
+					index := newBaseDocEqIndex(isVirtual)
+					if !index.Build(tc.rules(g)) {
+						b.Fatal("failed to build index")
+					}
+
+					// A value under the last prefix, so the walk goes the whole
+					// way down rather than failing at the first byte.
+					input := inputResolver{
+						input: MustParseTerm(fmt.Sprintf(`{"path": %q}`, prefixAt(g.total()-1)+"/and/some/more")).Value,
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+
+					for b.Loop() {
+						res, err := index.Lookup(input)
+						if err != nil {
+							b.Fatal(err)
+						} else if len(res.Rules) != 1 {
+							b.Fatalf("expected 1 rule, got %d", len(res.Rules))
+						}
+						IndexResultPool.Put(res)
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkLookupPrefixIndexMiss is the other half of it: a value sharing no
+// first byte with any prefix costs one binary search, whatever the ruleset is
+// -- 55 ns flat from 100 prefixes to 2.5M.
+func BenchmarkLookupPrefixIndexMiss(b *testing.B) {
+	for _, g := range prefixGrids {
+		b.Run(g.String(), func(b *testing.B) {
+			index := newBaseDocEqIndex(isVirtual)
+			if !index.Build(anyPrefixMatchRules(g)) {
+				b.Fatal("failed to build index")
+			}
+			input := inputResolver{input: MustParseTerm(`{"path": "no/prefix/starts/like/this"}`).Value}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				res, err := index.Lookup(input)
+				if err != nil {
+					b.Fatal(err)
+				} else if len(res.Rules) != 0 {
+					b.Fatalf("expected no rules, got %d", len(res.Rules))
+				}
+				IndexResultPool.Put(res)
+			}
+		})
+	}
+}
+
+// BenchmarkLookupPrefixIndexDepth separates the two things a lookup could scale
+// with. The ruleset is held at 250 rules of 10000 prefixes each while the value
+// grows past the longest prefix. The walk stops where the trie runs out of
+// edges, so the tail of the value costs nothing: 222 ns for a 16-byte tail and
+// 222 ns for a 1024-byte one.
+func BenchmarkLookupPrefixIndexDepth(b *testing.B) {
+	g := prefixGrid{rules: 250, perRule: 10000}
+
+	index := newBaseDocEqIndex(isVirtual)
+	if !index.Build(anyPrefixMatchRules(g)) {
+		b.Fatal("failed to build index")
+	}
+
+	for _, length := range []int{16, 64, 256, 1024} {
+		b.Run(fmt.Sprintf("tail=%d", length), func(b *testing.B) {
+			path := prefixAt(g.total()-1) + strings.Repeat("x", length)
+			input := inputResolver{input: MustParseTerm(fmt.Sprintf(`{"path": %q}`, path)).Value}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				res, err := index.Lookup(input)
+				if err != nil {
+					b.Fatal(err)
+				} else if len(res.Rules) != 1 {
+					b.Fatalf("expected 1 rule, got %d", len(res.Rules))
+				}
+				IndexResultPool.Put(res)
+			}
+		})
+	}
+}
+
+var prefixShapes = []struct {
+	note  string
+	rules func(prefixGrid) []*Rule
+}{
+	{note: "any_prefix_match", rules: anyPrefixMatchRules},
+	{note: "startswith", rules: startsWithRules},
+}
+
+// prefixAt returns the i'th prefix of the benchmark set. They share a long stem
+// so that the trie has edges to split and walk rather than one-byte edges off
+// the root. The counter is zero-padded to a fixed width so that no prefix in
+// the set is a prefix of another, whatever the size of the set.
+func prefixAt(i int) string {
+	return fmt.Sprintf("/service/v1/tenant/%07d", i)
+}
+
+// anyPrefixMatchRules returns g.rules rules matching g.perRule prefixes each.
+func anyPrefixMatchRules(g prefixGrid) []*Rule {
+	var sb strings.Builder
+	sb.WriteString("package p\n\n")
+
+	next := 0
+	for range g.rules {
+		sb.WriteString("allow if strings.any_prefix_match(__local0__, [")
+		for i := range g.perRule {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			fmt.Fprintf(&sb, "%q", prefixAt(next))
+			next++
+		}
+		sb.WriteString("])\n")
+	}
+
+	return prefixRules(sb.String())
+}
+
+// startsWithRules returns the same prefixes as one rule each.
+func startsWithRules(g prefixGrid) []*Rule {
+	var sb strings.Builder
+	sb.WriteString("package p\n\n")
+	for i := range g.total() {
+		fmt.Fprintf(&sb, "allow if startswith(__local0__, %q)\n", prefixAt(i))
+	}
+
+	return prefixRules(sb.String())
+}
+
+// prefixRules parses src and prepends the assignment the compiler would emit
+// for the hoisted call operand, so the indexer sees the shape it sees in
+// practice without paying for a full compile in the benchmark.
+func prefixRules(src string) []*Rule {
+	rules := MustParseModule(src).Rules
+	assign := MustParseExpr("__local0__ = input.path")
+
+	for _, rule := range rules {
+		rule.Body = append(Body{assign}, rule.Body...)
+	}
+
+	return rules
+}

--- a/v1/ast/index_prefix_test.go
+++ b/v1/ast/index_prefix_test.go
@@ -1,0 +1,602 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// selectsWith is selects() with control over the resolver, for the cases where
+// a ref has to be unknown or fail.
+func selectsWith(t *testing.T, index RuleIndex, resolver testResolver) []string {
+	t.Helper()
+
+	res, err := index.Lookup(resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := make([]string, 0, len(res.Rules))
+	for _, rule := range res.Rules {
+		values = append(values, rule.Head.Value.String())
+	}
+	slices.Sort(values)
+	return values
+}
+
+func allRules(t *testing.T, index RuleIndex) []string {
+	t.Helper()
+
+	res, err := index.AllRules(testResolver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := make([]string, 0, len(res.Rules))
+	for _, rule := range res.Rules {
+		values = append(values, rule.Head.Value.String())
+	}
+	slices.Sort(values)
+	return values
+}
+
+func TestIndexStartsWith(t *testing.T) {
+	index := indexFor(t, `package test
+
+p := 1 if startswith(input.path, "/api/")
+
+p := 2 if startswith(input.path, "/api/v2")
+
+p := 3 if startswith(input.path, "/admin")
+
+# Written the way it reads rather than the way the compiler emits it: the
+# operand is hoisted to a local either way, and the index has to resolve it
+# back to input.path.
+p := 4 if {
+	path := input.path
+	startswith(path, "/")
+}
+
+# A prefix of nothing holds for every string.
+p := 5 if startswith(input.path, "")
+
+# A different ref is a different level of the trie.
+p := 6 if startswith(input.method, "P")
+`)
+
+	for _, tc := range []struct {
+		note  string
+		input string
+		exp   []string
+	}{
+		{
+			note:  "one prefix matches, and the ones it extends",
+			input: `{"path": "/api/v1/users"}`,
+			exp:   []string{"1", "4", "5"},
+		},
+		{
+			note:  "the longer of two overlapping prefixes matches too",
+			input: `{"path": "/api/v2/users"}`,
+			exp:   []string{"1", "2", "4", "5"},
+		},
+		{
+			note:  "prefixes that share a first byte but diverge",
+			input: `{"path": "/admin/x"}`,
+			exp:   []string{"3", "4", "5"},
+		},
+		{
+			note:  "the value is exactly a prefix",
+			input: `{"path": "/api/"}`,
+			exp:   []string{"1", "4", "5"},
+		},
+		{
+			note:  "the value stops one byte short of every prefix",
+			input: `{"path": "/"}`,
+			exp:   []string{"4", "5"},
+		},
+		{
+			note:  "the empty string only satisfies the empty prefix",
+			input: `{"path": ""}`,
+			exp:   []string{"5"},
+		},
+		{
+			note:  "no prefix matches",
+			input: `{"path": "/health"}`,
+			exp:   []string{"4", "5"},
+		},
+		{
+			// startswith on a non-string is a type error, which makes the rule
+			// undefined -- the same trade the indexer already makes for
+			// glob.match, whose rules are likewise dropped for a value it
+			// cannot match.
+			note:  "a non-string value satisfies no prefix",
+			input: `{"path": 42}`,
+			exp:   []string{},
+		},
+		{
+			note:  "an absent ref satisfies no prefix",
+			input: `{}`,
+			exp:   []string{},
+		},
+		{
+			note:  "prefixes on a second ref are indexed independently",
+			input: `{"path": "/health", "method": "POST"}`,
+			exp:   []string{"4", "5", "6"},
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			if act := selects(t, index, tc.input); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, act)
+			}
+		})
+	}
+}
+
+func TestIndexAnyPrefixMatch(t *testing.T) {
+	index := indexFor(t, `package test
+
+p := 1 if strings.any_prefix_match(input.path, ["/api/", "/admin/"])
+
+p := 2 if strings.any_prefix_match(input.path, {"/api/v2", "/internal"})
+
+# A single base string is the same as startswith.
+p := 3 if strings.any_prefix_match(input.path, "/api/v2/beta")
+
+# Overlapping with a plain startswith on the same ref.
+p := 4 if startswith(input.path, "/admin/")
+`)
+
+	for _, tc := range []struct {
+		note  string
+		input string
+		exp   []string
+	}{
+		{
+			note:  "one alternative of an array base matches",
+			input: `{"path": "/api/v1"}`,
+			exp:   []string{"1"},
+		},
+		{
+			note:  "the other alternative of an array base matches",
+			input: `{"path": "/admin/users"}`,
+			exp:   []string{"1", "4"},
+		},
+		{
+			note:  "an alternative of a set base matches",
+			input: `{"path": "/internal/metrics"}`,
+			exp:   []string{"2"},
+		},
+		{
+			note:  "alternatives from different rules match the same value",
+			input: `{"path": "/api/v2/beta/x"}`,
+			exp:   []string{"1", "2", "3"},
+		},
+		{
+			note:  "no alternative matches",
+			input: `{"path": "/public"}`,
+			exp:   []string{},
+		},
+		{
+			// strings.any_prefix_match takes a collection of search strings as
+			// well as a single one, and holds if any element matches, so the
+			// index has to look at every element.
+			note:  "a collection of search strings, one of which matches",
+			input: `{"path": ["/nope", "/api/v1"]}`,
+			exp:   []string{"1"},
+		},
+		{
+			note:  "a collection of search strings, none of which matches",
+			input: `{"path": ["/nope", "/nope2"]}`,
+			exp:   []string{},
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			if act := selects(t, index, tc.input); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, act)
+			}
+		})
+	}
+}
+
+// TestIndexPrefixNotIndexable covers the shapes the indexer has to leave alone.
+// Every rule here must come back for every input: a constraint the index cannot
+// represent is one it must not act on.
+func TestIndexPrefixNotIndexable(t *testing.T) {
+	all := []string{"1", "2", "3", "4", "5", "6", "7"}
+
+	index := indexFor(t, `package test
+
+# The result is captured, so a rule the call returns false for still has to run.
+p := 1 if {
+	x := startswith(input.path, "/api")
+	x == true
+}
+
+p := 2 if {
+	x := strings.any_prefix_match(input.path, ["/api"])
+	x == true
+}
+
+# The base is not known until the rule runs.
+p := 3 if startswith(input.path, input.prefix)
+
+p := 4 if strings.any_prefix_match(input.path, input.prefixes)
+
+# A base collection that is not all strings cannot be split into prefixes, and
+# indexing only some of them would exclude rules the rest would have matched.
+p := 5 if strings.any_prefix_match(input.path, ["/api", input.other])
+
+# Negation and with-statements are off limits for the indexer as a whole.
+p := 6 if not startswith(input.path, "/api")
+
+p := 7 if startswith(input.path, "/api") with input.path as "/api"
+`)
+
+	for _, input := range []string{
+		`{"path": "/api/v1", "prefix": "/api", "prefixes": ["/api"], "other": "/x"}`,
+		`{"path": "/nope", "prefix": "/api", "prefixes": ["/api"], "other": "/x"}`,
+		`{"path": 42, "prefix": "/api", "prefixes": ["/api"], "other": "/x"}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			if act := selects(t, index, input); !slices.Equal(act, all) {
+				t.Errorf("expected every rule to be a candidate, got %v", act)
+			}
+		})
+	}
+}
+
+// TestIndexPrefixWithOtherConstraints checks that a prefix constraint composes
+// with the rest of the index rather than displacing it.
+func TestIndexPrefixWithOtherConstraints(t *testing.T) {
+	index := indexFor(t, `package test
+
+p := 1 if {
+	startswith(input.path, "/api/")
+	input.method == "GET"
+}
+
+p := 2 if {
+	startswith(input.path, "/api/")
+	input.method == "POST"
+}
+
+# Two constraints on one ref. They are recorded side by side and the trie
+# reaches the rule through either, so a value satisfying only one of them
+# still selects it -- over-approximating is allowed, dropping the rule is not.
+p := 3 if {
+	path := input.path
+	startswith(path, "/a")
+	path == "/admin"
+}
+
+p := 4 if input.method == "GET"
+`)
+
+	for _, tc := range []struct {
+		note  string
+		input string
+		exp   []string
+	}{
+		{
+			note:  "prefix and scalar both hold",
+			input: `{"path": "/api/x", "method": "GET"}`,
+			exp:   []string{"1", "3", "4"},
+		},
+		{
+			note:  "the prefix holds but the scalar does not",
+			input: `{"path": "/api/x", "method": "DELETE"}`,
+			exp:   []string{"3"},
+		},
+		{
+			note:  "the scalar holds but the prefix does not",
+			input: `{"path": "/health", "method": "GET"}`,
+			exp:   []string{"4"},
+		},
+		{
+			note:  "a rule constrained twice on one ref is selected when both hold",
+			input: `{"path": "/admin"}`,
+			exp:   []string{"3"},
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			if act := selects(t, index, tc.input); !slices.Equal(act, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, act)
+			}
+		})
+	}
+}
+
+// TestIndexPrefixUnknownAndAllRules covers the two traversals that ignore the
+// input: partial evaluation, where the ref is unknown, and AllRules.
+func TestIndexPrefixUnknownAndAllRules(t *testing.T) {
+	index := indexFor(t, `package test
+
+p := 1 if startswith(input.path, "/api/")
+
+p := 2 if strings.any_prefix_match(input.path, ["/admin", "/internal"])
+
+p := 3 if input.path == "/health"
+`)
+
+	all := []string{"1", "2", "3"}
+
+	t.Run("unknown ref", func(t *testing.T) {
+		resolver := testResolver{
+			input:       MustParseTerm(`{}`),
+			unknownRefs: NewSet(MustParseTerm("input.path")),
+		}
+		if act := selectsWith(t, index, resolver); !slices.Equal(act, all) {
+			t.Errorf("expected every rule to be a candidate, got %v", act)
+		}
+	})
+
+	t.Run("all rules", func(t *testing.T) {
+		if act := allRules(t, index); !slices.Equal(act, all) {
+			t.Errorf("expected every rule, got %v", act)
+		}
+	})
+}
+
+// TestIndexPrefixDocumentedShapes mirrors the table in
+// docs/docs/policy-performance.md, so the documented answer to "is this
+// indexed" stays the one the indexer gives.
+func TestIndexPrefixDocumentedShapes(t *testing.T) {
+	for _, tc := range []struct {
+		body    string
+		indexed bool
+	}{
+		{body: `startswith(input.path, "/api")`, indexed: true},
+		{body: `x := input.path; startswith(x, "/api")`, indexed: true},
+		{body: `strings.any_prefix_match(input.path, ["/a", "/b"])`, indexed: true},
+		{body: `strings.any_prefix_match(input.path, {"/a", "/b"})`, indexed: true},
+		{body: `strings.any_prefix_match(input.path, "/api")`, indexed: true},
+		{body: `x := input; startswith(x.foo, "a/")`, indexed: true},
+		{body: `startswith(input.path, input.prefix)`, indexed: false},
+		{body: `strings.any_prefix_match(input.path, input.bases)`, indexed: false},
+		{body: `strings.any_prefix_match(input.path, ["/a", input.b])`, indexed: false},
+		{body: `some i; startswith(input.path[i], "/api")`, indexed: false},
+		{body: `x := startswith(input.path, "/api"); x == true`, indexed: false},
+	} {
+		t.Run(tc.body, func(t *testing.T) {
+			index := indexFor(t, fmt.Sprintf("package test\n\np := 1 if { %s }\n", tc.body))
+
+			// The input defines every ref the rule reads, so nothing but a
+			// prefix constraint can exclude the rule -- and no value here
+			// starts with any of the prefixes.
+			selected := selects(t, index, `{"path": "/zzz", "prefix": "/api", "bases": ["/a"], "foo": "zzz", "b": "/q"}`)
+
+			if indexed := len(selected) == 0; indexed != tc.indexed {
+				t.Errorf("expected indexed=%v, got %v (selected %v)", tc.indexed, indexed, selected)
+			}
+		})
+	}
+}
+
+// TestIndexPrefixTrieStaysCompressed is the reason for a radix trie rather than
+// a node per byte: the node count follows the number of prefixes, not their
+// total length.
+func TestIndexPrefixTrieStaysCompressed(t *testing.T) {
+	const n = 500
+
+	var src strings.Builder
+	src.WriteString("package test\n\np := 1 if strings.any_prefix_match(input.path, [")
+	for i := range n {
+		if i > 0 {
+			src.WriteString(", ")
+		}
+		// Long, mostly-shared prefixes: a byte-per-node trie would need one
+		// node per byte of the shared stem plus one per distinguishing suffix.
+		fmt.Fprintf(&src, `"/some/quite/long/shared/stem/%06d"`, i)
+	}
+	src.WriteString("])\n")
+
+	index := indexFor(t, src.String())
+
+	root, ok := index.(*baseDocEqIndex)
+	if !ok {
+		t.Fatalf("expected a baseDocEqIndex, got %T", index)
+	}
+
+	prefixes := root.root.next.prefixes
+	if prefixes == nil {
+		t.Fatal("expected the prefixes to be indexed")
+	}
+
+	if got := len(prefixes.walk()); got != n {
+		t.Errorf("expected %d prefixes in the trie, got %d", n, got)
+	}
+
+	// A compressed trie holds at most 2p-1 nodes; a byte-per-node one would
+	// hold ~30 per prefix here.
+	if nodes, max := countPrefixNodes(prefixes), 2*n; nodes > max {
+		t.Errorf("expected at most %d prefix trie nodes, got %d", max, nodes)
+	}
+}
+
+func countPrefixNodes(p *prefixTrie) int {
+	if p == nil {
+		return 0
+	}
+	n := 1
+	for _, edge := range p.edges {
+		n += countPrefixNodes(edge.node)
+	}
+	return n
+}
+
+// TestPrefixTrieInsertAndTraverse exercises the trie directly, including the
+// edge splits that only happen for particular insertion orders.
+func TestPrefixTrieInsertAndTraverse(t *testing.T) {
+	for _, tc := range []struct {
+		note     string
+		prefixes []string
+	}{
+		{note: "disjoint", prefixes: []string{"a", "b", "c"}},
+		{note: "nested, shortest first", prefixes: []string{"a", "ab", "abc"}},
+		{note: "nested, longest first", prefixes: []string{"abc", "ab", "a"}},
+		{note: "split an edge in the middle", prefixes: []string{"abcdef", "abcxyz"}},
+		{note: "split an edge twice", prefixes: []string{"abcdef", "abcxyz", "abq"}},
+		{note: "split at the very first byte", prefixes: []string{"abc", "xbc"}},
+		{note: "empty prefix among others", prefixes: []string{"", "a", "ab"}},
+		{note: "duplicate insertions", prefixes: []string{"ab", "ab", "ab"}},
+		{note: "shared stem", prefixes: []string{"/api/v1", "/api/v2", "/api", "/admin", "/a"}},
+		{note: "high bytes", prefixes: []string{"\xff\x00", "\xff\x01", "\x00"}},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			trie := &prefixTrie{}
+			nodes := map[string]*trieNode{}
+			for _, p := range tc.prefixes {
+				node := trie.insert(p)
+				if node == nil {
+					t.Fatalf("insert(%q) returned nil", p)
+				}
+				if prev, ok := nodes[p]; ok && prev != node {
+					t.Errorf("insert(%q) returned a second node for the same prefix", p)
+				}
+				nodes[p] = node
+			}
+
+			// walk() has to report exactly the distinct prefixes inserted.
+			want := slices.Compact(slices.Sorted(slices.Values(tc.prefixes)))
+			var got []string
+			for _, entry := range trie.walk() {
+				got = append(got, entry.prefix)
+				if nodes[entry.prefix] != entry.node {
+					t.Errorf("walk() reported a different node for %q", entry.prefix)
+				}
+			}
+			slices.Sort(got)
+			if !slices.Equal(got, want) {
+				t.Errorf("expected prefixes %q, got %q", want, got)
+			}
+
+			// A lookup has to find every inserted prefix that the value starts
+			// with, and nothing else. Checked against the naive answer.
+			for _, s := range prefixTrieProbes(tc.prefixes) {
+				var exp []string
+				for _, p := range want {
+					if strings.HasPrefix(s, p) {
+						exp = append(exp, p)
+					}
+				}
+				slices.Sort(exp)
+
+				act := prefixTrieMatches(t, trie, nodes, s)
+				if !slices.Equal(act, exp) {
+					t.Errorf("traverse(%q): expected %q, got %q", s, exp, act)
+				}
+			}
+		})
+	}
+}
+
+// prefixTrieProbes returns strings worth looking up for a set of prefixes: each
+// prefix itself, one byte short of it, one byte past it, and a few misses.
+func prefixTrieProbes(prefixes []string) []string {
+	probes := []string{"", "z", "zzzzzz"}
+	for _, p := range prefixes {
+		probes = append(probes, p, p+"x", p+"xyz")
+		if len(p) > 0 {
+			probes = append(probes, p[:len(p)-1])
+		}
+	}
+	return probes
+}
+
+// prefixTrieMatches reports which prefixes a traversal of s reaches, by way of
+// the rule each prefix's node was given.
+func prefixTrieMatches(t *testing.T, trie *prefixTrie, nodes map[string]*trieNode, s string) []string {
+	t.Helper()
+
+	// Give each prefix node a rule of its own, so the traversal result names
+	// the prefixes it reached.
+	byRule := map[*Rule]string{}
+	for prefix, node := range nodes {
+		node.rules = node.rules[:0]
+		rule := &Rule{Head: NewHead(Var("p"), nil, InternedTerm(len(byRule)))}
+		byRule[rule] = prefix
+		node.append([2]int{len(byRule), 0}, rule)
+	}
+
+	tr := newTrieTraversalResult()
+	if err := trie.traverse(s, testResolver{input: MustParseTerm(`{}`)}, tr); err != nil {
+		t.Fatal(err)
+	}
+
+	var matched []string
+	for _, pos := range tr.ordering {
+		for _, node := range tr.unordered[pos] {
+			matched = append(matched, byRule[node.rule])
+		}
+	}
+	slices.Sort(matched)
+
+	return matched
+}
+
+// TestIndexPrefixSelectsSameRulesAsEvaluation is the property that matters: the
+// index may return rules that turn out not to hold, but never omit one that
+// does. Checked against the answer computed by running the prefix checks
+// directly.
+func TestIndexPrefixSelectsSameRulesAsEvaluation(t *testing.T) {
+	prefixes := [][]string{
+		{"/api"},
+		{"/api/v1"},
+		{"/api/v1/users"},
+		{"/api/v2"},
+		{"/admin", "/api/v1/u"},
+		{"/a"},
+		{""},
+		{"/health", "/metrics"},
+		{"/apis"},
+		{"/api/v1/users/1"},
+	}
+
+	var src strings.Builder
+	src.WriteString("package test\n\n")
+	for i, ps := range prefixes {
+		if len(ps) == 1 {
+			fmt.Fprintf(&src, "p := %d if startswith(input.path, %q)\n\n", i, ps[0])
+			continue
+		}
+		fmt.Fprintf(&src, "p := %d if strings.any_prefix_match(input.path, [", i)
+		for j, p := range ps {
+			if j > 0 {
+				src.WriteString(", ")
+			}
+			fmt.Fprintf(&src, "%q", p)
+		}
+		src.WriteString("])\n\n")
+	}
+
+	index := indexFor(t, src.String())
+
+	for _, path := range []string{
+		"", "/", "/a", "/ap", "/api", "/apis", "/api/", "/api/v1", "/api/v1/users",
+		"/api/v1/users/1", "/api/v1/users/2", "/api/v2/x", "/admin", "/health",
+		"/metrics/x", "/nope",
+	} {
+		t.Run(path, func(t *testing.T) {
+			var exp []string
+			for i, ps := range prefixes {
+				if slices.ContainsFunc(ps, func(p string) bool { return strings.HasPrefix(path, p) }) {
+					exp = append(exp, strconv.Itoa(i))
+				}
+			}
+			slices.Sort(exp)
+
+			act := selects(t, index, fmt.Sprintf(`{"path": %q}`, path))
+			for _, want := range exp {
+				if !slices.Contains(act, want) {
+					t.Errorf("rule %s holds for %q but the index did not select it (got %v)", want, path, act)
+				}
+			}
+		})
+	}
+}

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -18,6 +18,7 @@ type interned struct {
 }
 
 type internedRefs struct {
+	AnyPrefixMatch    Ref
 	Equal             Ref
 	Equality          Ref
 	GlobMatch         Ref
@@ -29,6 +30,7 @@ type internedRefs struct {
 	Print             Ref
 	RegoMetadataChain Ref
 	RegoMetadataRule  Ref
+	StartsWith        Ref
 }
 
 // NOTE! Great care must be taken **not** to modify the terms returned
@@ -39,6 +41,7 @@ type internedRefs struct {
 var (
 	Interned = &interned{
 		Refs: &internedRefs{
+			AnyPrefixMatch:    AnyPrefixMatch.Ref(),
 			Equal:             Equal.Ref(),
 			Equality:          Equality.Ref(),
 			GlobMatch:         GlobMatch.Ref(),
@@ -50,6 +53,7 @@ var (
 			Print:             Print.Ref(),
 			RegoMetadataChain: RegoMetadataChain.Ref(),
 			RegoMetadataRule:  RegoMetadataRule.Ref(),
+			StartsWith:        StartsWith.Ref(),
 		},
 	}
 

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1556,9 +1556,11 @@ func (arr *Array) Sorted() *Array {
 
 	slices.SortFunc(cpy, TermValueCompare)
 
-	a := NewArray(cpy...)
-	a.hashs = arr.hashs
-	return a
+	// NewArray has already hashed cpy in its own order. Taking arr.hashs over
+	// that would leave hashs[i] holding the hash of some other element, which
+	// Array.set relies on, and would share the slice with arr so that setting
+	// an element here corrupted arr.
+	return NewArray(cpy...)
 }
 
 // Hash returns the hash code for the Value.
@@ -1603,8 +1605,14 @@ func (arr *Array) rehash() {
 func (arr *Array) set(i int, v *Term) {
 	arr.ground = arr.ground && v.IsGround()
 	arr.elems[i] = v
-	arr.hashs[i] = v.Value.Hash()
-	arr.rehash()
+
+	// arr.hash is the sum of arr.hashs, so swapping one element's hash in is
+	// enough -- rehashing the whole array here makes building an array of n
+	// elements O(n^2), which is felt on the large arrays that appear in
+	// generated policies.
+	h := v.Value.Hash()
+	arr.hash += h - arr.hashs[i]
+	arr.hashs[i] = h
 }
 
 // Slice returns a slice of arr starting from i index to j. -1

--- a/v1/ast/term_bench_test.go
+++ b/v1/ast/term_bench_test.go
@@ -536,6 +536,73 @@ func BenchmarkArrayCopy(b *testing.B) {
 	}
 }
 
+// BenchmarkArraySet is one Array.Set on an array of n elements. Set keeps the
+// cached hash up to date, and it does so by swapping the one element's hash
+// into the sum rather than resumming arr.hashs, so the cost does not follow n:
+//
+//	        resumming    swapping in
+//	   5       6.9 ns         5.3 ns
+//	  50      26.9 ns         5.3 ns
+//	 500     493.4 ns         5.3 ns
+//	5000      5179 ns         5.4 ns
+func BenchmarkArraySet(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000}
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			elems := make([]*Term, n)
+			for i := range elems {
+				elems[i] = IntNumberTerm(i)
+			}
+			arr := NewArray(elems...)
+			v := IntNumberTerm(-1)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				arr.Set(n/2, v)
+			}
+		})
+	}
+}
+
+// BenchmarkArrayFill is what that costs in aggregate: setting every element of
+// an array of n elements once. Linear in n, where resumming on each Set made
+// it quadratic -- 1000x at n=5000.
+//
+//	        resumming    swapping in
+//	   5      34.7 ns        27.8 ns
+//	  50     930.6 ns       274.0 ns
+//	 500    244842 ns        2598 ns
+//	5000  26854962 ns       26813 ns
+//
+// This is the shape a large array literal in a policy takes on its way through
+// the compiler, where each Transform pass rebuilds the array element by
+// element: compiling a rule holding a 16000 element array spent 95% of its
+// time in rehash.
+func BenchmarkArrayFill(b *testing.B) {
+	sizes := []int{5, 50, 500, 5000}
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			elems := make([]*Term, n)
+			for i := range elems {
+				elems[i] = IntNumberTerm(i)
+			}
+			arr := NewArray(elems...)
+			v := IntNumberTerm(-1)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				for i := range n {
+					arr.Set(i, v)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkRefCopy(b *testing.B) {
 	sizes := []int{5, 10, 20}
 	for _, n := range sizes {

--- a/v1/rego/index_prefix_test.go
+++ b/v1/rego/index_prefix_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// TestPrefixIndexMatchesUnindexedEval is the property the prefix index owes its
+// callers: the index is an optimisation, so a query has to give the same answer
+// with it as without it. The rule index in v1/ast is tested on the rules it
+// selects; this one runs the policies and compares.
+//
+// The policies are generated rather than written out because the shapes that
+// break a prefix index are combinations -- one prefix extending another, a
+// prefix alongside an equality on the same reference, a value that isn't a
+// string at all -- and a fixed table only reaches the combinations someone
+// thought of. The alphabet is deliberately tiny so that prefixes collide,
+// nest, and split trie edges constantly.
+func TestPrefixIndexMatchesUnindexedEval(t *testing.T) {
+	ctx := t.Context()
+
+	for seed := range 4 {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			rnd := rand.New(rand.NewSource(int64(seed)))
+
+			for range 100 {
+				policy := randomPrefixPolicy(rnd)
+
+				pq, err := New(Query("data.test.p"), Module("test.rego", policy)).PrepareForEval(ctx)
+				if err != nil {
+					t.Fatalf("%v\npolicy:\n%s", err, policy)
+				}
+
+				for range 10 {
+					input := randomPrefixInput(rnd)
+
+					var results [2]string
+					for i, indexing := range []bool{true, false} {
+						rs, err := pq.Eval(ctx, EvalInput(input), EvalRuleIndexing(indexing))
+						if err != nil {
+							t.Fatalf("%v\npolicy:\n%s", err, policy)
+						}
+						results[i] = fmt.Sprint(rs)
+					}
+
+					if results[0] != results[1] {
+						t.Fatalf("indexed %v != unindexed %v for input %v\npolicy:\n%s",
+							results[0], results[1], input, policy)
+					}
+				}
+			}
+		})
+	}
+}
+
+// prefixAlphabet is small enough that randomly generated prefixes overlap,
+// nest, and diverge mid-edge all the time.
+const prefixAlphabet = "ab/"
+
+func randomPrefixString(rnd *rand.Rand, maxLen int) string {
+	var sb strings.Builder
+	for range rnd.Intn(maxLen + 1) {
+		sb.WriteByte(prefixAlphabet[rnd.Intn(len(prefixAlphabet))])
+	}
+	return sb.String()
+}
+
+func randomPrefixPolicy(rnd *rand.Rand) string {
+	var sb strings.Builder
+	sb.WriteString("package test\n\nimport rego.v1\n\n")
+
+	writeList := func(opening, closing string, n int) {
+		sb.WriteString(opening)
+		for j := range n {
+			if j > 0 {
+				sb.WriteString(", ")
+			}
+			fmt.Fprintf(&sb, "%q", randomPrefixString(rnd, 4))
+		}
+		sb.WriteString(closing)
+	}
+
+	for i := range 1 + rnd.Intn(8) {
+		switch rnd.Intn(7) {
+		case 0:
+			fmt.Fprintf(&sb, "p contains %d if startswith(input.path, %q)\n\n", i, randomPrefixString(rnd, 4))
+		case 1:
+			fmt.Fprintf(&sb, "p contains %d if strings.any_prefix_match(input.path, ", i)
+			writeList("[", "]", 1+rnd.Intn(4))
+			sb.WriteString(")\n\n")
+		case 2:
+			fmt.Fprintf(&sb, "p contains %d if strings.any_prefix_match(input.path, ", i)
+			writeList("{", "}", 1+rnd.Intn(3))
+			sb.WriteString(")\n\n")
+		case 3:
+			// A prefix and an inequality on the same reference.
+			fmt.Fprintf(&sb, "p contains %d if {\n\tx := input.path\n\tstartswith(x, %q)\n\tx != %q\n}\n\n",
+				i, randomPrefixString(rnd, 3), randomPrefixString(rnd, 4))
+		case 4:
+			// A prefix and an equality on the same reference, which the index
+			// records side by side and reaches the rule through either.
+			fmt.Fprintf(&sb, "p contains %d if {\n\tx := input.path\n\tstartswith(x, %q)\n\tx == %q\n}\n\n",
+				i, randomPrefixString(rnd, 2), randomPrefixString(rnd, 3))
+		case 5:
+			// A prefix on one reference and an equality on another.
+			fmt.Fprintf(&sb, "p contains %d if {\n\tstartswith(input.path, %q)\n\tinput.other == %q\n}\n\n",
+				i, randomPrefixString(rnd, 3), randomPrefixString(rnd, 2))
+		case 6:
+			// Two rules producing the same value by different means.
+			fmt.Fprintf(&sb, "p contains %d if startswith(input.path, %q)\n\n", i, randomPrefixString(rnd, 3))
+			fmt.Fprintf(&sb, "p contains %d if strings.any_prefix_match(input.path, ", i)
+			writeList("[", "]", 2)
+			sb.WriteString(")\n\n")
+		}
+	}
+
+	return sb.String()
+}
+
+func randomPrefixInput(rnd *rand.Rand) map[string]any {
+	input := map[string]any{
+		"path":  randomPrefixString(rnd, 6),
+		"other": randomPrefixString(rnd, 2),
+	}
+
+	switch rnd.Intn(6) {
+	case 0:
+		// strings.any_prefix_match takes a collection of search strings too.
+		input["path"] = []any{randomPrefixString(rnd, 4), randomPrefixString(rnd, 4)}
+	case 1:
+		// Not a string at all: the calls error and the rules are undefined.
+		input["path"] = 42
+	case 2:
+		delete(input, "path")
+	}
+
+	return input
+}

--- a/v1/topdown/index_prefix_bench_test.go
+++ b/v1/topdown/index_prefix_bench_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+)
+
+// prefixMatchShape is a way of writing "the path starts with one of these".
+type prefixMatchShape struct {
+	note string
+	// rule renders one rule matching the given prefixes.
+	rule func(sb *strings.Builder, prefixes []string)
+}
+
+var prefixMatchShapes = []prefixMatchShape{
+	{
+		// Indexable: the base strings are known at compile time, so they go
+		// into the rule index and the rule is only evaluated for a path that
+		// starts with one of them.
+		note: "any_prefix_match",
+		rule: func(sb *strings.Builder, prefixes []string) {
+			sb.WriteString("allow if strings.any_prefix_match(input.path, [")
+			writePrefixList(sb, prefixes)
+			sb.WriteString("])\n\n")
+		},
+	},
+	{
+		// The same thing spelled out as iteration, which is what
+		// strings.any_prefix_match replaces. The base is a variable, so there
+		// is nothing for the index to record and every rule runs its whole
+		// loop on every query.
+		note: "iteration",
+		rule: func(sb *strings.Builder, prefixes []string) {
+			sb.WriteString("allow if {\n\tsome prefix in [")
+			writePrefixList(sb, prefixes)
+			sb.WriteString("]\n\tstartswith(input.path, prefix)\n}\n\n")
+		},
+	},
+	{
+		// One rule per prefix. Indexable like any_prefix_match, but it costs a
+		// rule -- and a trie leaf -- per prefix rather than per rule, which is
+		// what makes it worth comparing the two.
+		note: "startswith",
+		rule: func(sb *strings.Builder, prefixes []string) {
+			for _, prefix := range prefixes {
+				fmt.Fprintf(sb, "allow if startswith(input.path, %q)\n\n", prefix)
+			}
+		},
+	},
+}
+
+// BenchmarkRuleIndexPrefixMatch measures what the rule index does for policies
+// that admit a request by the prefix of its path -- the shape of a routing or
+// authorization policy with a list of allowed path prefixes per rule.
+//
+// The input path matches nothing, which is the case the index is for: without
+// it every rule has to be evaluated to find that out, and with it the trie
+// walks the path once and returns nothing. Rules and prefixes-per-rule vary
+// independently, up to 250 rules of 10000 prefixes each -- 2.5M prefixes.
+//
+// At the top of that grid:
+//
+//	                      indexing=true                indexing=false
+//	any_prefix_match        597 ns      1096 B/op     63295856 ns   41216594 B/op
+//	startswith              613 ns      1096 B/op   1592790750 ns 1558489144 B/op
+//	iteration         850229396 ns 504413952 B/op    846111188 ns  504412388 B/op
+//
+// The indexed rows are flat across both dimensions: the whole ruleset costs one
+// walk of the path. 597 ns at 2.5M prefixes is the same 600-700 ns the index
+// costs at 100. `iteration` is the same policy written as a loop over the
+// prefixes, which is what strings.any_prefix_match exists to replace -- there is
+// nothing there for the index to record, so it stays at the cost of evaluating
+// every rule.
+//
+// The top of the grid is a large policy to build: 2.5M prefixes is 74MB of
+// source for any_prefix_match and iteration, and 156MB and ~8GB of heap for
+// startswith, which spends a rule on each prefix. That is setup rather than
+// measured time, and the two indexing settings of a grid point share one
+// compile (see compilePrefixPolicy).
+func BenchmarkRuleIndexPrefixMatch(b *testing.B) {
+	for _, shape := range prefixMatchShapes {
+		b.Run(shape.note, func(b *testing.B) {
+			for _, rules := range []int{1, 10, 50, 250} {
+				for _, perRule := range []int{100, 1000, 10000} {
+					b.Run(fmt.Sprintf("rules=%d/prefixes=%d", rules, perRule), func(b *testing.B) {
+						for _, indexing := range []bool{true, false} {
+							b.Run(fmt.Sprintf("indexing=%v", indexing), func(b *testing.B) {
+								benchmarkPrefixMatch(b, shape, rules, perRule, indexing, "/no/such/path/at/all", false)
+							})
+						}
+					})
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRuleIndexPrefixMatchHit is the same policy queried with a path that
+// one rule admits. Complete-rule evaluation stops at the first rule that holds,
+// so the matching prefix is put in the last rule to keep the two shapes
+// comparable.
+//
+// At 250 rules of 10000 prefixes each -- 2.5M prefixes:
+//
+//	                      indexing=true                indexing=false
+//	any_prefix_match     159350 ns    167258 B/op     80579479 ns   41301049 B/op
+//	startswith             1956 ns      2672 B/op   1563445458 ns 1558490072 B/op
+//	iteration         811024271 ns 504414304 B/op    806562979 ns  504413028 B/op
+//
+// This is where the two indexable shapes come apart, and it is the reason to
+// vary prefixes per rule rather than in total. The index narrows 250 rules to
+// the one that can hold either way, but that rule still has to be evaluated:
+// for startswith it is a single comparison, while for any_prefix_match the
+// builtin scans the rule's own 10000-element array. So any_prefix_match pays
+// per prefix in the rule it selects, not per prefix in the policy -- 159 us
+// here against 597 ns for the miss, which returns no rule to evaluate. Both
+// still beat the unindexed policy by two to five orders of magnitude.
+func BenchmarkRuleIndexPrefixMatchHit(b *testing.B) {
+	const (
+		rules   = 250
+		perRule = 10000
+	)
+
+	for _, shape := range prefixMatchShapes {
+		b.Run(shape.note, func(b *testing.B) {
+			for _, indexing := range []bool{true, false} {
+				b.Run(fmt.Sprintf("indexing=%v", indexing), func(b *testing.B) {
+					benchmarkPrefixMatch(b, shape, rules, perRule, indexing,
+						benchPrefix(rules*perRule-1)+"/some/request", true)
+				})
+			}
+		})
+	}
+}
+
+func benchmarkPrefixMatch(b *testing.B, shape prefixMatchShape, rules, perRule int, indexing bool, path string, defined bool) {
+	b.Helper()
+
+	ctx := b.Context()
+
+	compiler := compilePrefixPolicy(b, shape, rules, perRule)
+
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store)
+	input := ast.NewTerm(ast.MustInterfaceToValue(map[string]any{"path": path}))
+
+	query := NewQuery(ast.MustParseBody("data.bench.allow = x")).
+		WithCompiler(compiler).
+		WithStore(store).
+		WithTransaction(txn).
+		WithInput(input).
+		WithIndexing(indexing)
+
+	// Whether the query is defined is a property of the policy and the path,
+	// not of indexing, so check it once up front rather than in the loop.
+	rs, err := query.Run(ctx)
+	if err != nil {
+		b.Fatalf("unexpected topdown query error: %v", err)
+	}
+	if (len(rs) == 1) != defined {
+		b.Fatalf("expected defined=%v for %q, got %v", defined, path, rs)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := query.Run(ctx); err != nil {
+			b.Fatalf("unexpected topdown query error: %v", err)
+		}
+	}
+}
+
+// prefixPolicyCache holds the most recently compiled policy, so that the
+// indexing=true and indexing=false runs of one grid point do not each pay for
+// it. Only one is kept: at the top of the grid a compiled policy is gigabytes,
+// and the previous one has to be released before the next is built.
+var prefixPolicyCache struct {
+	key      string
+	compiler *ast.Compiler
+}
+
+func compilePrefixPolicy(b *testing.B, shape prefixMatchShape, rules, perRule int) *ast.Compiler {
+	b.Helper()
+
+	key := fmt.Sprintf("%s/%d/%d", shape.note, rules, perRule)
+	if prefixPolicyCache.key == key {
+		return prefixPolicyCache.compiler
+	}
+	prefixPolicyCache.key, prefixPolicyCache.compiler = "", nil
+
+	compiler := ast.NewCompiler()
+	mods := map[string]*ast.Module{"policy": ast.MustParseModule(prefixMatchPolicy(shape, rules, perRule))}
+	if compiler.Compile(mods); compiler.Failed() {
+		b.Fatalf("unexpected compiler error: %v", compiler.Errors)
+	}
+
+	prefixPolicyCache.key, prefixPolicyCache.compiler = key, compiler
+
+	return compiler
+}
+
+// prefixMatchPolicy renders a policy of the given shape holding `rules` rules
+// of `perRule` prefixes each, so rules*perRule prefixes in total. The prefixes
+// are distinct across the whole policy.
+func prefixMatchPolicy(shape prefixMatchShape, rules, perRule int) string {
+	var sb strings.Builder
+	sb.WriteString("package bench\n\nimport rego.v1\n\n")
+
+	batch := make([]string, perRule)
+	next := 0
+
+	for range rules {
+		for i := range batch {
+			batch[i] = benchPrefix(next)
+			next++
+		}
+
+		shape.rule(&sb, batch)
+	}
+
+	return sb.String()
+}
+
+func writePrefixList(sb *strings.Builder, prefixes []string) {
+	for i, prefix := range prefixes {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(sb, "%q", prefix)
+	}
+}
+
+// benchPrefix returns the i'th path prefix. They share a stem, the way the
+// paths of one service do, so the index cannot tell them apart on the first
+// byte and has to walk. The counter is zero-padded to a fixed width so that no
+// prefix in the set is a prefix of another, whatever the size of the set.
+func benchPrefix(i int) string {
+	return fmt.Sprintf("/service/v1/tenant/%07d", i)
+}


### PR DESCRIPTION
The title is pretty self-explanatory. For policies that contain a large number of prefix matches, the lack of rule indexing becomes a major bottleneck. We can extend the rule indexer to support prefix matching and speed up evaluation significantly. In the process this identified O(n) runtime in `Array.set` so I have pushed a fix for that as well.