### PR TITLE
ast: build package exports in a single pass

### DIFF
--- a/build/policy/pr-check/pr_check.rego
+++ b/build/policy/pr-check/pr_check.rego
@@ -77,21 +77,20 @@ changes.proto if {
 
 changes.proto if _workflows_changed
 
-changes.bench contains "./v1/ast" if {
+changes.bench contains "./v1/ast" if _in_go_package("v1/ast/")
+changes.bench contains "./v1/topdown" if _compiler_related
+changes.bench contains "./v1/rego" if _compiler_related
+changes.bench contains "./v1/compile" if _compiler_related
+
+_compiler_related if {
 	some changed_file in input
-	startswith(changed_file.filename, "v1/ast/")
+	strings.any_prefix_match(changed_file.filename, {"v1/topdown/", "v1/rego/", "v1/ast/", "v1/compile/"})
 	endswith(changed_file.filename, ".go")
 }
 
-changes.bench contains "./v1/topdown" if {
+_in_go_package(p) if {
 	some changed_file in input
-	startswith(changed_file.filename, "v1/topdown/")
-	endswith(changed_file.filename, ".go")
-}
-
-changes.bench contains "./v1/rego" if {
-	some changed_file in input
-	startswith(changed_file.filename, "v1/rego/")
+	startswith(changed_file.filename, p)
 	endswith(changed_file.filename, ".go")
 }
 

--- a/build/policy/pr-check/pr_check_test.rego
+++ b/build/policy/pr-check/pr_check_test.rego
@@ -109,16 +109,8 @@ test_run_all_tests_expect if {
 	not pr_check.changes.yaml with input as example_all_checks_root_changelist
 }
 
-test_bench_ast_only if {
-	pr_check.changes.bench == {"./v1/ast"} with input as example_bench_ast_changelist
-}
-
-test_bench_topdown_only if {
-	pr_check.changes.bench == {"./v1/topdown"} with input as example_bench_topdown_changelist
-}
-
-test_bench_rego_only if {
-	pr_check.changes.bench == {"./v1/rego"} with input as example_bench_rego_changelist
+test_bench_compiler_related if {
+	pr_check.changes.bench == {"./v1/topdown", "./v1/compile", "./v1/rego"} with input as example_bench_topdown_changelist
 }
 
 test_bench_no_match if {

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -2119,6 +2119,24 @@ func (c *Compiler) getExport(pkg Ref) []Ref {
 	return refs
 }
 
+// getExports groups every module's exported rule refs by package path in one
+// pass. Use this instead of getExport per package, which is quadratic.
+func (c *Compiler) getExports() *util.HasherMap[Ref, []Ref] {
+	rules := util.NewHasherMap[Ref, []Ref](RefEqual)
+
+	for _, name := range c.sorted {
+		mod := c.Modules[name]
+		refs, _ := rules.Get(mod.Package.Path)
+		refs = slices.Grow(refs, len(mod.Rules))
+		for _, rule := range mod.Rules {
+			refs = append(refs, rule.Head.Ref().GroundPrefix())
+		}
+		rules.Put(mod.Package.Path, refs)
+	}
+
+	return rules
+}
+
 func (c *Compiler) GetAnnotationSet() *AnnotationSet {
 	return c.annotationSet
 }
@@ -2202,9 +2220,11 @@ func (c *Compiler) moduleIsRegoV1Compatible(mod *Module) bool {
 //
 // The reference "c.d.e" would be resolved to "data.a.b.c.d.e".
 func (c *Compiler) resolveAllRefs() {
+	exports := c.getExports()
+
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
-		ruleExports := c.getExport(mod.Package.Path)
+		ruleExports, _ := exports.Get(mod.Package.Path)
 		globals := getGlobals(mod.Package, ruleExports, mod.Imports)
 
 		WalkRules(mod, func(rule *Rule) bool {


### PR DESCRIPTION
resolveAllRefs called getExport per module, and getExport scans every module, making ref resolution O(modules^2).

Group all exports by package path in one pass instead. getExport stays for the query compiler, which only asks for one package.

BenchmarkCompileDynamicPolicy: n=2500 355ms -> 132ms, n=10000 5406ms ->
802ms. Regressed in #9149.

> [!TIP]
> Added `v1/compile` to the post-merge benchlab checks