### PR TITLE
topdown: record evaluated rules during partial evaluation

### DIFF
--- a/v1/rego/evaluated_test.go
+++ b/v1/rego/evaluated_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package rego
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/topdown"
+)
+
+func partialWithTracker(t *testing.T, src string, unknowns []string, input map[string]any) *topdown.EvaluatedRuleTracker {
+	t.Helper()
+
+	tracker := &topdown.EvaluatedRuleTracker{}
+	pq, err := New(
+		Query("data.test.allow"),
+		ParsedModule(ast.MustParseModuleWithOpts(src, ast.ParserOptions{ProcessAnnotation: true})),
+		Unknowns(unknowns),
+		EvaluatedRuleTracker(tracker),
+	).PrepareForPartial(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pq.Partial(t.Context(), EvalInput(input)); err != nil {
+		t.Fatal(err)
+	}
+	return tracker
+}
+
+// topdown.Query.PartialRun resolves an annotation set for the tracker, but the
+// rego layer used to build its partial query without passing one, so the
+// EvaluatedRuleTracker options were silently ignored. Rules resolved during
+// partial evaluation are now recorded, as they are during evaluation.
+func TestEvaluatedRuleTrackerPartial(t *testing.T) {
+	const module = `package test
+
+# METADATA
+# labels:
+#   id: allow-admin
+allow if input.role == "admin"
+`
+
+	tracker := partialWithTracker(t, module, []string{"input.resource"}, map[string]any{"role": "admin"})
+
+	exp := []map[string]any{{"id": "allow-admin"}}
+	if diff := cmp.Diff(exp, tracker.Labels, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected labels (-want, +got):\n%s", diff)
+	}
+}
+
+// The per-evaluation tracker takes precedence over the one set on the Rego
+// object, matching how the eval path resolves the two.
+func TestEvaluatedRuleTrackerPartialEvalOptionWins(t *testing.T) {
+	module := ast.MustParseModuleWithOpts(`package test
+
+# METADATA
+# labels:
+#   id: allow-admin
+allow if input.role == "admin"
+`, ast.ParserOptions{ProcessAnnotation: true})
+
+	onRego := &topdown.EvaluatedRuleTracker{}
+	onEval := &topdown.EvaluatedRuleTracker{}
+
+	pq, err := New(
+		Query("data.test.allow"),
+		ParsedModule(module),
+		Unknowns([]string{"input.resource"}),
+		EvaluatedRuleTracker(onRego),
+	).PrepareForPartial(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pq.Partial(t.Context(),
+		EvalInput(map[string]any{"role": "admin"}),
+		EvalEvaluatedRuleTracker(onEval)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(onEval.Labels) != 1 {
+		t.Fatalf("eval-scoped tracker: got %v, want one label set", onEval.Labels)
+	}
+	if len(onRego.Labels) != 0 {
+		t.Fatalf("rego-scoped tracker should be unused: got %v", onRego.Labels)
+	}
+}
+
+// Rules left as residuals are recorded too: the label identifies a rule that
+// contributed to the result, and under partial evaluation a residual disjunct
+// is a contribution. Rules that cannot match are still left out.
+func TestEvaluatedRuleTrackerPartialResidual(t *testing.T) {
+	const module = `package test
+
+# METADATA
+# labels:
+#   id: allow-x
+allow if input.resource == "x"
+
+# METADATA
+# labels:
+#   id: allow-y
+allow if input.resource == "y"
+
+# METADATA
+# labels:
+#   id: allow-nobody
+allow if input.role == "nobody"
+`
+
+	got := partialWithTracker(t, module, []string{"input.resource"}, map[string]any{"role": "admin"}).Labels
+
+	exp := []map[string]any{{"id": "allow-x"}, {"id": "allow-y"}}
+	less := func(a, b map[string]any) bool { return a["id"].(string) < b["id"].(string) }
+	if diff := cmp.Diff(exp, got, cmpopts.SortSlices(less), cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected labels (-want, +got):\n%s", diff)
+	}
+}
+
+// A default rule sends partial evaluation down the support-module path; the
+// rules folded into that support module are recorded as well.
+func TestEvaluatedRuleTrackerPartialSupport(t *testing.T) {
+	const module = `package test
+
+default allow := false
+
+# METADATA
+# labels:
+#   id: allow-x
+allow if input.resource == "x"
+`
+
+	got := partialWithTracker(t, module, []string{"input.resource"}, map[string]any{}).Labels
+
+	exp := []map[string]any{{"id": "allow-x"}}
+	if diff := cmp.Diff(exp, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("unexpected labels (-want, +got):\n%s", diff)
+	}
+}

--- a/v1/rego/rego.go
+++ b/v1/rego/rego.go
@@ -7,6 +7,7 @@ package rego
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -2343,13 +2344,8 @@ func (r *Rego) eval(ctx context.Context, ectx *EvalContext) (ResultSet, error) {
 		WithVirtualCache(ectx.virtualCache).
 		WithBaseCache(ectx.baseCache).
 		WithRequestMetadata(ectx.requestMetadata).
-		WithResponseMetadata(ectx.responseMetadata)
-
-	if ectx.evaluated != nil {
-		q = q.WithEvaluatedRuleTracker(ectx.evaluated)
-	} else {
-		q = q.WithEvaluatedRuleTracker(r.evaluated)
-	}
+		WithResponseMetadata(ectx.responseMetadata).
+		WithEvaluatedRuleTracker(cmp.Or(ectx.evaluated, r.evaluated))
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)
@@ -2650,7 +2646,8 @@ func (r *Rego) partial(ctx context.Context, ectx *EvalContext) (*PartialQueries,
 		WithSeed(ectx.seed).
 		WithPrintHook(ectx.printHook).
 		WithRequestMetadata(ectx.requestMetadata).
-		WithResponseMetadata(ectx.responseMetadata)
+		WithResponseMetadata(ectx.responseMetadata).
+		WithEvaluatedRuleTracker(cmp.Or(ectx.evaluated, r.evaluated))
 
 	if !ectx.time.IsZero() {
 		q = q.WithTime(ectx.time)

--- a/v1/topdown/eval.go
+++ b/v1/topdown/eval.go
@@ -2491,6 +2491,7 @@ func (e *evalFunc) partialEvalSupportRule(rule *ast.Rule, path ast.Ref) error {
 		// Skip this rule body if it fails to type-check.
 		// Type-checking failure means the rule body will never succeed.
 		if e.e.compiler.PassesTypeCheck(plugged) {
+			e.e.evaluated.Record(rule)
 			head := &ast.Head{
 				Name:      rule.Head.Name,
 				Reference: rule.Head.Reference,
@@ -3386,6 +3387,7 @@ func (e evalVirtualPartial) partialEvalSupportRule(rule *ast.Rule, _ ast.Ref) (b
 		// Skip this rule body if it fails to type-check.
 		// Type-checking failure means the rule body will never succeed.
 		if e.e.compiler.PassesTypeCheck(plugged) {
+			e.e.evaluated.Record(rule)
 			var value *ast.Term
 
 			if rule.Head.Value != nil {
@@ -3918,6 +3920,7 @@ func (e evalVirtualComplete) partialEval(iter unifyIterator) error {
 
 		err := child.eval(func(child *eval) error {
 			child.traceExit(rule)
+			e.e.evaluated.Record(rule)
 			term, termbindings := child.bindings.apply(rule.Head.Value)
 
 			if err := e.evalTerm(iter, term, termbindings); err != nil {
@@ -4003,6 +4006,7 @@ func (e evalVirtualComplete) partialEvalSupportRule(rule *ast.Rule, packagePath 
 		// Skip this rule body if it fails to type-check.
 		// Type-checking failure means the rule body will never succeed.
 		if e.e.compiler.PassesTypeCheck(plugged) {
+			e.e.evaluated.Record(rule)
 			head := ast.RefHead(ruleRef, child.bindings.PlugNamespaced(rule.Head.Value, e.e.caller.bindings))
 
 			if !e.e.inliningControl.shallow {


### PR DESCRIPTION
EvaluatedRuleTracker only saw rules exited by ordinary evaluation. Two gaps: rego.partial() built its query without passing a tracker, so both tracker options were silently ignored; and Record was only called from the three sites that exit a rule during ordinary evaluation.

Partial evaluation exits rules too, where a residual disjunct or support rule is produced. A rule that contributes a residual has been evaluated and has contributed, so record at those four sites as well. The support-rule sites record after the type check that can discard a body, so a rule that never contributes is not attributed.
