### PR TITLE
index: also index suffix matching (endswith, strings.any_suffix_match) + some tweaks

### DIFF
--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -155,7 +155,7 @@ For `glob.match(pattern, delimiter, match)` statements to be indexed the pattern
 
 For `startswith(search, base)` and `strings.any_prefix_match(search, base)` statements to be indexed the search operand must be a non-nested reference that does not contain any variables, and every base string must be known at compile time — a literal, or a variable previously assigned one. `strings.any_prefix_match` holds if any base string matches, so each of its base strings is indexed as an alternative; a base collection holding anything other than strings is not indexed at all, since indexing only part of it would exclude rules the rest would have matched.
 
-The prefixes recorded for one reference are held in a radix trie, so a lookup walks the input value once no matter how many prefixes are indexed. A rule set with ten prefixes and one with ten thousand cost the same to look up.
+The prefixes recorded for one reference are held in a radix trie, so a lookup walks the input value once no matter how many prefixes are indexed. A rule set with ten prefixes and one with ten thousand cost the same to look up. Several base strings do make the search operand a reference the rule reaches by more than one value, which affects what else the rule is indexed on — see [Several values for one reference](#several-values-for-one-reference).
 
 Capturing the result (`allowed := startswith(input.path, "/api")`) is not indexed: a rule producing `false` still has to be evaluated.
 
@@ -213,6 +213,18 @@ Statements joined by the [`and` and `or` keywords](./policy-reference/keywords/l
 | `input.x == 1 or input.y == 2`         | yes     | both operands are indexed             |
 | `input.x == 1 or count(input.y) == 3`  | no      | `count(...)` is not indexable         |
 | `not (input.x == 1 and input.y == 2)`  | no      | negated expressions are never indexed |
+
+#### Several values for one reference
+
+Some statements leave a rule with more than one value for a single reference: `strings.any_prefix_match` with several base strings, or `in` over a literal collection. The rule is indexed under each of those values, and that reference is the last level of the index the rule appears on — whatever it constrains below is left to evaluation.
+
+The indexer orders such references after every other one, so a rule's single-valued constraints are indexed first and only the reference carrying the alternatives ends its path. A rule that has alternatives for one reference is therefore still indexed on everything else it constrains; a rule that has them for two is indexed on only one of the two.
+
+| Rule body                                                                   | Indexed on      |
+| --------------------------------------------------------------------------- | --------------- |
+| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.method == "GET"` | both references |
+| `input.x in {1, 2}; input.y == 3`                                           | both references |
+| `input.x in {1, 2}; input.y in {3, 4}`                                      | one of the two  |
 
 #### References rooted at a local variable
 

--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -220,19 +220,23 @@ Statements joined by the [`and` and `or` keywords](./policy-reference/keywords/l
 
 Some statements leave a rule with more than one value for a single reference: `strings.any_prefix_match` with several base strings, or `in` over a collection. The rule is indexed under each of those values.
 
-Where the rule is indexed below that reference depends on the statement. The values of an `in` collection converge on one continuation, so the rule goes on being indexed on everything else it constrains, however many such references it has. The base strings of a `strings.any_prefix_match` or `strings.any_suffix_match` are leaves of the radix trie described above, which cannot converge, so that reference is the last level of the index the rule appears on — whatever it constrains below is left to evaluation.
+Where the rule is indexed below that reference depends on the statement. The values of an `in` collection converge on one continuation, so the rule goes on being indexed on everything else it constrains, however many such references it has — as long as they are scalars. A collection holding arrays, objects or sets cannot converge, so that reference ends the rule's path the way base strings do. The base strings of a `strings.any_prefix_match` or `strings.any_suffix_match` are leaves of the radix trie described above, which cannot converge, so that reference is the last level of the index the rule appears on — whatever it constrains below is left to evaluation.
 
 The indexer orders references carrying alternatives after every other one, so a rule's single-valued constraints are indexed first either way.
 
-| Rule body                                                                                              | Indexed on      |
-| ------------------------------------------------------------------------------------------------------ | --------------- |
-| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.method == "GET"`                            | both references |
-| `input.x in {1, 2}; input.y == 3`                                                                      | both references |
-| `input.x in {1, 2}; input.y in {3, 4}`                                                                 | both references |
-| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.x in {1, 2}`                                | both references |
-| `strings.any_prefix_match(input.p, ["/a", "/b"]); strings.any_suffix_match(input.n, [".go", ".rego"])` | one of the two  |
+| Rule body                                                                                              | Indexed on           |
+| ------------------------------------------------------------------------------------------------------ | -------------------- |
+| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.method == "GET"`                            | both references      |
+| `input.x in {1, 2}; input.y == 3`                                                                      | both references      |
+| `input.x in {1, 2}; input.y in {3, 4}`                                                                 | both references      |
+| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.x in {1, 2}`                                | both references      |
+| `input.x in [[1], [2]]; input.y == 3`                                                                  | one reference        |
+| `strings.any_prefix_match(input.p, ["/a", "/b"]); strings.any_suffix_match(input.n, [".go", ".rego"])` | one of the two       |
+| `strings.any_prefix_match(input.p, ["/a", "/b"]); strings.any_suffix_match(input.p, [".go", ".rego"])` | one end of `input.p` |
 
 A reference reached by base strings is ordered after one reached by an `in` collection, so only a rule that reaches _two_ references by base strings loses one of them — and which of the two the author wrote first does not decide which is lost.
+
+Requiring base strings at both ends of the _same_ reference runs into the same limit from the other direction. The two sets are leaves of two tries, and a leaf cannot be made to depend on the other trie's answer, so the index tests one end and leaves the other to evaluation. Indexing both would admit a value matching either one, where the rule requires both, so it would hand more rules to evaluation than testing one end does. The end kept is the one whose shortest base string is longest: a set admits a value matching any one of its bases, so its shortest base is what decides how much it admits — `["/"]` admits every absolute path however many longer prefixes sit beside it.
 
 #### References rooted at a local variable
 

--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -218,15 +218,21 @@ Statements joined by the [`and` and `or` keywords](./policy-reference/keywords/l
 
 #### Several values for one reference
 
-Some statements leave a rule with more than one value for a single reference: `strings.any_prefix_match` with several base strings, or `in` over a literal collection. The rule is indexed under each of those values, and that reference is the last level of the index the rule appears on — whatever it constrains below is left to evaluation.
+Some statements leave a rule with more than one value for a single reference: `strings.any_prefix_match` with several base strings, or `in` over a collection. The rule is indexed under each of those values.
 
-The indexer orders such references after every other one, so a rule's single-valued constraints are indexed first and only the reference carrying the alternatives ends its path. A rule that has alternatives for one reference is therefore still indexed on everything else it constrains; a rule that has them for two is indexed on only one of the two.
+Where the rule is indexed below that reference depends on the statement. The values of an `in` collection converge on one continuation, so the rule goes on being indexed on everything else it constrains, however many such references it has. The base strings of a `strings.any_prefix_match` or `strings.any_suffix_match` are leaves of the radix trie described above, which cannot converge, so that reference is the last level of the index the rule appears on — whatever it constrains below is left to evaluation.
 
-| Rule body                                                                   | Indexed on      |
-| --------------------------------------------------------------------------- | --------------- |
-| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.method == "GET"` | both references |
-| `input.x in {1, 2}; input.y == 3`                                           | both references |
-| `input.x in {1, 2}; input.y in {3, 4}`                                      | one of the two  |
+The indexer orders references carrying alternatives after every other one, so a rule's single-valued constraints are indexed first either way.
+
+| Rule body                                                                                              | Indexed on      |
+| ------------------------------------------------------------------------------------------------------ | --------------- |
+| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.method == "GET"`                            | both references |
+| `input.x in {1, 2}; input.y == 3`                                                                      | both references |
+| `input.x in {1, 2}; input.y in {3, 4}`                                                                 | both references |
+| `strings.any_prefix_match(input.path, ["/a", "/b"]); input.x in {1, 2}`                                | both references |
+| `strings.any_prefix_match(input.p, ["/a", "/b"]); strings.any_suffix_match(input.n, [".go", ".rego"])` | one of the two  |
+
+A reference reached by base strings is ordered after one reached by an `in` collection, so only a rule that reaches _two_ references by base strings loses one of them — and which of the two the author wrote first does not decide which is lost.
 
 #### References rooted at a local variable
 

--- a/docs/docs/policy-performance.md
+++ b/docs/docs/policy-performance.md
@@ -151,29 +151,31 @@ For `glob.match(pattern, delimiter, match)` statements to be indexed the pattern
 | `glob.match("foo:*/bar", [":", "/"], input.x)` | yes     | any delimiter separates    |
 | `glob.match("foo:*:bar", null, input.x)`       | no      | delimiter is `null`        |
 
-#### Prefix statements
+#### Prefix and suffix statements
 
-For `startswith(search, base)` and `strings.any_prefix_match(search, base)` statements to be indexed the search operand must be a non-nested reference that does not contain any variables, and every base string must be known at compile time — a literal, or a variable previously assigned one. `strings.any_prefix_match` holds if any base string matches, so each of its base strings is indexed as an alternative; a base collection holding anything other than strings is not indexed at all, since indexing only part of it would exclude rules the rest would have matched.
+For `startswith(search, base)` and `strings.any_prefix_match(search, base)` statements to be indexed the search operand must be a non-nested reference that does not contain any variables, and every base string must be known at compile time — a literal, or a variable previously assigned one. `strings.any_prefix_match` holds if any base string matches, so each of its base strings is indexed as an alternative; a base collection holding anything other than strings is not indexed at all, since indexing only part of it would exclude rules the rest would have matched. `endswith` and `strings.any_suffix_match` are indexed under the same conditions.
 
 The prefixes recorded for one reference are held in a radix trie, so a lookup walks the input value once no matter how many prefixes are indexed. A rule set with ten prefixes and one with ten thousand cost the same to look up. Several base strings do make the search operand a reference the rule reaches by more than one value, which affects what else the rule is indexed on — see [Several values for one reference](#several-values-for-one-reference).
 
 Capturing the result (`allowed := startswith(input.path, "/api")`) is not indexed: a rule producing `false` still has to be evaluated.
 
-| Expression                                              | Indexed | Notes                                     |
-| ------------------------------------------------------- | ------- | ----------------------------------------- |
-| `startswith(input.path, "/api")`                        | yes     |                                           |
-| `x := input.path; startswith(x, "/api")`                | yes     | variable resolved to ref via assignment   |
-| `strings.any_prefix_match(input.path, ["/a", "/b"])`    | yes     | each base string is an alternative        |
-| `strings.any_prefix_match(input.path, {"/a", "/b"})`    | yes     | set literals work the same as arrays      |
-| `strings.any_prefix_match(input.path, "/api")`          | yes     | a single base string is like `startswith` |
-| `startswith(input.path, input.prefix)`                  | no      | base is not known until evaluation        |
-| `strings.any_prefix_match(input.path, input.bases)`     | no      | base is not known until evaluation        |
-| `strings.any_prefix_match(input.path, ["/a", input.b])` | no      | base collection is not all literals       |
-| `startswith(input.path[i], "/api")`                     | no      | search contains variable(s)               |
-| `x := startswith(input.path, "/api"); x == true`        | no      | result is captured                        |
+| Expression                                               | Indexed | Notes                                     |
+| -------------------------------------------------------- | ------- | ----------------------------------------- |
+| `startswith(input.path, "/api")`                         | yes     |                                           |
+| `x := input.path; startswith(x, "/api")`                 | yes     | variable resolved to ref via assignment   |
+| `strings.any_prefix_match(input.path, ["/a", "/b"])`     | yes     | each base string is an alternative        |
+| `strings.any_prefix_match(input.path, {"/a", "/b"})`     | yes     | set literals work the same as arrays      |
+| `strings.any_prefix_match(input.path, "/api")`           | yes     | a single base string is like `startswith` |
+| `endswith(input.path, ".gz")`                            | yes     | anchored to the end instead               |
+| `strings.any_suffix_match(input.path, [".go", ".rego"])` | yes     | each base string is an alternative        |
+| `startswith(input.path, input.prefix)`                   | no      | base is not known until evaluation        |
+| `strings.any_prefix_match(input.path, input.bases)`      | no      | base is not known until evaluation        |
+| `strings.any_prefix_match(input.path, ["/a", input.b])`  | no      | base collection is not all literals       |
+| `startswith(input.path[i], "/api")`                      | no      | search contains variable(s)               |
+| `x := startswith(input.path, "/api"); x == true`         | no      | result is captured                        |
 
 :::info
-A prefix statement is indexed the way `glob.match` is, and shares its one rough edge: a rule whose search operand turns out not to be a string is excluded by the index, so the type error the call would have raised is not raised. This only shows with [strict built-in errors](./policy-language#errors) enabled, where the query would otherwise have failed rather than been undefined.
+A prefix or suffix statement is indexed the way `glob.match` is, and shares its one rough edge: a rule whose search operand turns out not to be a string is excluded by the index, so the type error the call would have raised is not raised. This only shows with [strict built-in errors](./policy-language#errors) enabled, where the query would otherwise have failed rather than been undefined.
 :::
 
 #### Membership (`in`) statements
@@ -230,7 +232,7 @@ The indexer orders such references after every other one, so a rule's single-val
 
 Building a reference on top of a local variable does not defeat the indexer. When the head of a reference is a variable that was assigned a reference earlier in the rule body, the indexer resolves that head and indexes the statement as if the whole reference had been spelled out: `x := input; x.foo == "a"` is indexed just like `input.foo == "a"`.
 
-The head must resolve to a reference rooted at `input` or `data`, and the resolved reference is then subject to exactly the same conditions as one written out by hand. A head that resolves to a document produced by another rule is not indexed, since the indexer only looks up base documents. `in`, `glob.match` and the prefix statements benefit from the same resolution: the compiler hoists their reference operand into a local variable of its own, which the indexer then resolves.
+The head must resolve to a reference rooted at `input` or `data`, and the resolved reference is then subject to exactly the same conditions as one written out by hand. A head that resolves to a document produced by another rule is not indexed, since the indexer only looks up base documents. `in`, `glob.match` and the prefix and suffix statements benefit from the same resolution: the compiler hoists their reference operand into a local variable of its own, which the indexer then resolves.
 
 The resolution also applies where a local stands in for a whole value rather than the head of a reference, chained assignments included, and inside the operands of an `and` or `or`, where a local assigned in the enclosing rule body still resolves.
 
@@ -243,6 +245,7 @@ The resolution also applies where a local stands in for a whole value rather tha
 | `x := input; "a" in x.foo`                    | yes     |                                          |
 | `x := input; glob.match("a/*", ["/"], x.foo)` | yes     |                                          |
 | `x := input; startswith(x.foo, "a/")`         | yes     |                                          |
+| `x := input; endswith(x.foo, ".gz")`          | yes     |                                          |
 | `x := input; x.foo`                           | yes     | bare reference                           |
 | `x := input; x.foo[i] == "a"`                 | yes     | ground prefix `input.foo` is indexed     |
 | `x := input; x.foo[i].bar == "a"`             | no      | variable is not the last element         |

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -1245,7 +1245,8 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 
 	var iterErr error
 	node.scalars.Iter(func(_ Value, child *trieNode) bool {
-		return child.traverseUnknown(resolver, tr) != nil
+		iterErr = child.traverseUnknown(resolver, tr)
+		return iterErr != nil
 	})
 
 	return iterErr

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -1113,9 +1113,8 @@ func (tr *trieTraversalResult) Add(t *trieNode) {
 }
 
 type trieNode struct {
-	// detail is what only a level node has; see levelDetail.
-	detail   *levelDetail
-	next     *trieNode
+	// next is the level below this node, nil where the paths under it end.
+	next     *levelDetail
 	rules    []*ruleNode
 	value    *Term
 	multiple bool
@@ -1170,7 +1169,7 @@ type levelDetail struct {
 	ref          Ref
 	any          *trieNode
 	undefined    *trieNode
-	array        *trieNode
+	array        *arrayTrie
 	scalars      *util.HasherMap[Value, *trieNode]
 	mappers      []*valueMapper
 	prefixes     *prefixTrie
@@ -1202,85 +1201,24 @@ func newTrieNodeImpl() *trieNode {
 	return &trieNode{}
 }
 
-func (node *trieNode) ref() Ref {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.ref
+// level returns the level below node, creating it if this is the first rule to
+// be discriminated there.
+func (node *trieNode) level() *levelDetail {
+	node.next = util.Or(node.next, newLevelDetail)
+	return node.next
 }
 
-func (node *trieNode) any() *trieNode {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.any
-}
-
-func (node *trieNode) undefined() *trieNode {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.undefined
-}
-
-func (node *trieNode) array() *trieNode {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.array
-}
-
-func (node *trieNode) scalars() *util.HasherMap[Value, *trieNode] {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.scalars
-}
-
-func (node *trieNode) prefixes() *prefixTrie {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.prefixes
-}
-
-func (node *trieNode) suffixes() *prefixTrie {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.suffixes
-}
-
-func (node *trieNode) alternatives() *alternativeChildren {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.alternatives
-}
-
-func (node *trieNode) converged() []*trieNode {
-	if alt := node.alternatives(); alt != nil {
-		return alt.converged
+func (d *levelDetail) converged() []*trieNode {
+	if d != nil && d.alternatives != nil {
+		return d.alternatives.converged
 	}
 	return nil
 }
 
-func (node *trieNode) mappers() []*valueMapper {
-	if node.detail == nil {
-		return nil
-	}
-	return node.detail.mappers
-}
-
-func (node *trieNode) levelDetail() *levelDetail {
-	node.detail = util.Or(node.detail, newLevelDetail)
-	return node.detail
-}
-
 // affixTrie returns the trie for one end of the value, creating it and the
 // detail that holds it on first use.
-func (node *trieNode) affixTrie(a affix) *prefixTrie {
-	detail := node.levelDetail()
+func (d *levelDetail) affixTrie(a affix) *prefixTrie {
+	detail := d
 
 	switch a {
 	case affixSuffix:
@@ -1313,22 +1251,29 @@ func (node *trieNode) Do(walker trieWalker) {
 		return
 	}
 
-	node.any().Do(next)
-	node.undefined().Do(next)
+	node.next.do(next)
+}
 
-	node.scalars().Iter(func(_ Value, child *trieNode) bool {
-		child.Do(next)
+func (d *levelDetail) do(walker trieWalker) {
+	if d == nil {
+		return
+	}
+
+	d.any.Do(walker)
+	d.undefined.Do(walker)
+
+	d.scalars.Iter(func(_ Value, child *trieNode) bool {
+		child.Do(walker)
 		return false
 	})
 
-	for _, child := range node.converged() {
-		child.Do(next)
+	for _, child := range d.converged() {
+		child.Do(walker)
 	}
 
-	node.prefixes().do(next)
-	node.suffixes().do(next)
-	node.array().Do(next)
-	node.next.Do(next)
+	d.prefixes.do(walker)
+	d.suffixes.do(walker)
+	d.array.do(walker)
 }
 
 // compact walks the trie once the index is built and releases what its slices
@@ -1338,25 +1283,32 @@ func (node *trieNode) compact() {
 		return
 	}
 
-	node.prefixes().compact()
-	node.suffixes().compact()
-
-	node.any().compact()
-	node.undefined().compact()
-	node.array().compact()
 	node.next.compact()
+}
 
-	for _, child := range node.converged() {
+func (d *levelDetail) compact() {
+	if d == nil {
+		return
+	}
+
+	d.prefixes.compact()
+	d.suffixes.compact()
+
+	d.any.compact()
+	d.undefined.compact()
+	d.array.compact()
+
+	for _, child := range d.converged() {
 		child.compact()
 	}
 
-	node.scalars().Iter(func(_ Value, child *trieNode) bool {
+	d.scalars.Iter(func(_ Value, child *trieNode) bool {
 		child.compact()
 		return false
 	})
 
-	if alt := node.alternatives(); alt != nil {
-		alt.converged = slices.Clip(alt.converged)
+	if d.alternatives != nil {
+		d.alternatives.converged = slices.Clip(d.alternatives.converged)
 	}
 }
 
@@ -1365,12 +1317,8 @@ func (node *trieNode) compact() {
 // keys to that node, so what the rule constrains below is built once instead of
 // repeated under each alternative.
 func (node *trieNode) insertAlternatives(ref Ref, values []*refindex) *trieNode {
-	if node.next == nil {
-		node.next = newTrieNodeImpl()
-		node.next.levelDetail().ref = ref
-	}
-
-	level := node.next.levelDetail()
+	level := node.level()
+	level.ref = ref
 	level.alternatives = util.Or(level.alternatives, newAlternativeChildren)
 	alt := level.alternatives
 
@@ -1379,7 +1327,7 @@ func (node *trieNode) insertAlternatives(ref Ref, values []*refindex) *trieNode 
 
 	for _, val := range values {
 		if val.Mapper != nil {
-			node.next.addMapper(val.Mapper)
+			level.addMapper(val.Mapper)
 		}
 		nodes, _ := alt.members.Get(val.Value)
 		alt.members.Put(val.Value, append(nodes, converge))
@@ -1395,16 +1343,14 @@ func newAlternativeChildren() *alternativeChildren {
 }
 
 func (node *trieNode) Insert(ref Ref, value Value, mapper *valueMapper) *trieNode {
-	if node.next == nil {
-		node.next = newTrieNodeImpl()
-		node.next.levelDetail().ref = ref
-	}
+	level := node.level()
+	level.ref = ref
 
 	if mapper != nil {
-		node.next.addMapper(mapper)
+		level.addMapper(mapper)
 	}
 
-	return node.next.insertValue(value)
+	return level.insertValue(value)
 }
 
 func (node *trieNode) Traverse(resolver ValueResolver, tr *trieTraversalResult) error {
@@ -1417,8 +1363,8 @@ func (node *trieNode) Traverse(resolver ValueResolver, tr *trieTraversalResult) 
 	return node.next.traverse(resolver, tr)
 }
 
-func (node *trieNode) addMapper(mapper *valueMapper) {
-	detail := node.levelDetail()
+func (d *levelDetail) addMapper(mapper *valueMapper) {
+	detail := d
 	for i := range detail.mappers {
 		if detail.mappers[i].Key == mapper.Key {
 			return
@@ -1427,8 +1373,8 @@ func (node *trieNode) addMapper(mapper *valueMapper) {
 	detail.mappers = append(detail.mappers, mapper)
 }
 
-func (node *trieNode) insertValue(value Value) *trieNode {
-	detail := node.levelDetail()
+func (d *levelDetail) insertValue(value Value) *trieNode {
+	detail := d
 
 	switch value := value.(type) {
 	case nil:
@@ -1446,8 +1392,8 @@ func (node *trieNode) insertValue(value Value) *trieNode {
 		}
 		return child
 	case *Array:
-		detail.array = util.Or(detail.array, newTrieNodeImpl)
-		return detail.array.insertArray(value)
+		detail.array = util.Or(detail.array, newArrayTrie)
+		return detail.array.insert(value)
 
 	// `x in <collection>` (see updateMemberRefInValue) inserts each element of
 	// the literal collection as-is, without restricting it to scalars/arrays
@@ -1465,52 +1411,136 @@ func (node *trieNode) insertValue(value Value) *trieNode {
 	panic("illegal value")
 }
 
-func (node *trieNode) insertArray(arr *Array) *trieNode {
+// arrayTrie dispatches on the elements of an array, one node per position. A
+// position dispatches the element after it and ends a rule's array, which a
+// trieNode cannot hold at once.
+type arrayTrie struct {
+	any     *arrayTrie
+	scalars *util.HasherMap[Value, *arrayTrie]
+	// end is where a rule whose array ends at this position continues.
+	end *trieNode
+}
+
+func newArrayTrie() *arrayTrie {
+	return &arrayTrie{}
+}
+
+func newArrayChildren() *util.HasherMap[Value, *arrayTrie] {
+	return util.NewHasherMap[Value, *arrayTrie](ValueEqual)
+}
+
+// insert returns the node the rule's path continues from once arr is consumed.
+func (a *arrayTrie) insert(arr *Array) *trieNode {
 	if arr.Len() == 0 {
-		return node
+		a.end = util.Or(a.end, newTrieNodeImpl)
+		return a.end
 	}
 
-	detail := node.levelDetail()
-
 	switch head := arr.Elem(0).Value.(type) {
-	case Var:
-		detail.any = util.Or(detail.any, newTrieNodeImpl)
-		return detail.any.insertArray(arr.Slice(1, -1))
 	case Null, Boolean, Number, String:
-		child, ok := detail.scalars.Get(head)
+		child, ok := a.scalars.Get(head)
 		if !ok {
-			child = newTrieNodeImpl()
-			detail.scalars = util.Or(detail.scalars, newScalarChildren)
-			detail.scalars.Put(head, child)
+			child = newArrayTrie()
+			a.scalars = util.Or(a.scalars, newArrayChildren)
+			a.scalars.Put(head, child)
 		}
-		return child.insertArray(arr.Slice(1, -1))
+		return child.insert(arr.Slice(1, -1))
 
-	// Same reasoning as in insertValue above: an array element can itself be
-	// a nested array, object, or set, none of which can be indexed precisely
-	// at this position, so fall back to "any" and keep indexing the
-	// remaining elements.
-	case *Array, Object, Set:
-		detail.any = util.Or(detail.any, newTrieNodeImpl)
-		return detail.any.insertArray(arr.Slice(1, -1))
+	// An element that is itself an array, object or set cannot be indexed
+	// precisely at this position, so -- as for a var -- it falls back to any,
+	// and the elements after it go on being indexed.
+	case Var, *Array, Object, Set:
+		a.any = util.Or(a.any, newArrayTrie)
+		return a.any.insert(arr.Slice(1, -1))
 	}
 
 	panic("illegal value")
 }
 
-func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) error {
-	if node == nil {
+func (a *arrayTrie) traverse(resolver ValueResolver, tr *trieTraversalResult, arr *Array) error {
+	if a == nil {
 		return nil
 	}
 
-	v, err := resolver.Resolve(node.ref())
+	if arr.Len() == 0 {
+		return a.end.Traverse(resolver, tr)
+	}
+
+	if err := a.any.traverse(resolver, tr, arr.Slice(1, -1)); err != nil {
+		return err
+	}
+
+	switch head := arr.Elem(0).Value.(type) {
+	case Null, Boolean, Number, String:
+		child, _ := a.scalars.Get(head)
+		return child.traverse(resolver, tr, arr.Slice(1, -1))
+	}
+
+	return nil
+}
+
+func (a *arrayTrie) traverseUnknown(resolver ValueResolver, tr *trieTraversalResult) error {
+	if a == nil {
+		return nil
+	}
+
+	if err := a.end.Traverse(resolver, tr); err != nil {
+		return err
+	}
+
+	if err := a.any.traverseUnknown(resolver, tr); err != nil {
+		return err
+	}
+
+	var iterErr error
+	a.scalars.Iter(func(_ Value, child *arrayTrie) bool {
+		iterErr = child.traverseUnknown(resolver, tr)
+		return iterErr != nil
+	})
+
+	return iterErr
+}
+
+func (a *arrayTrie) do(walker trieWalker) {
+	if a == nil {
+		return
+	}
+
+	a.end.Do(walker)
+	a.any.do(walker)
+	a.scalars.Iter(func(_ Value, child *arrayTrie) bool {
+		child.do(walker)
+		return false
+	})
+}
+
+func (a *arrayTrie) compact() {
+	if a == nil {
+		return
+	}
+
+	a.end.compact()
+	a.any.compact()
+	a.scalars.Iter(func(_ Value, child *arrayTrie) bool {
+		child.compact()
+		return false
+	})
+}
+
+func (d *levelDetail) traverse(resolver ValueResolver, tr *trieTraversalResult) error {
+	if d == nil {
+		return nil
+	}
+
+	v, err := resolver.Resolve(d.ref)
 	if err != nil {
 		if IsUnknownValueErr(err) {
-			return node.traverseUnknown(resolver, tr)
+			return d.traverseUnknown(resolver, tr)
 		}
 		return err
 	}
 
-	if err = node.undefined().Traverse(resolver, tr); err != nil {
+	if err = d.undefined.Traverse(resolver, tr); err != nil {
 		return err
 	}
 
@@ -1518,11 +1548,11 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return nil
 	}
 
-	if err = node.any().Traverse(resolver, tr); err != nil {
+	if err = d.any.Traverse(resolver, tr); err != nil {
 		return err
 	}
 
-	if err = node.traverseValue(resolver, tr, v); err != nil {
+	if err = d.traverseValue(resolver, tr, v); err != nil {
 		return err
 	}
 
@@ -1530,19 +1560,18 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 	// what a mapper makes of it: the glob mapper turns a string into the array
 	// of its segments, and matching prefixes against those segments would
 	// answer a question no rule asked.
-	if err = node.traversePrefixes(resolver, tr, v); err != nil {
+	if err = d.traversePrefixes(resolver, tr, v); err != nil {
 		return err
 	}
 
-	if err = node.traverseSuffixes(resolver, tr, v); err != nil {
+	if err = d.traverseSuffixes(resolver, tr, v); err != nil {
 		return err
 	}
 
-	mappers := node.mappers()
-	for i := range mappers {
-		mapped := mappers[i].MapValue(v)
+	for i := range d.mappers {
+		mapped := d.mappers[i].MapValue(v)
 		if !ValueEqual(mapped, v) {
-			if err := node.traverseValue(resolver, tr, mapped); err != nil {
+			if err := d.traverseValue(resolver, tr, mapped); err != nil {
 				return err
 			}
 		}
@@ -1551,33 +1580,29 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 	return nil
 }
 
-func (node *trieNode) traverseValue(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+func (d *levelDetail) traverseValue(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
 	switch value := value.(type) {
 	case *Array, Set, Object:
-		if node.array() != nil {
+		if d.array != nil {
 			if arr, ok := value.(*Array); ok {
-				if err := node.array().traverseArray(resolver, tr, arr); err != nil {
+				if err := d.array.traverse(resolver, tr, arr); err != nil {
 					return err
 				}
 			}
 		}
-		if node.scalars().Len() > 0 {
-			return node.traverseCollectionMembership(resolver, tr, value)
+		if d.scalars.Len() > 0 {
+			return d.traverseCollectionMembership(resolver, tr, value)
 		}
 	case Null, Boolean, Number, String:
-		// One load of detail for both, so that a level with no alternatives --
-		// almost all of them -- pays a branch and nothing more.
-		detail := node.detail
-		if detail == nil {
-			return nil
-		}
-		if child, ok := detail.scalars.Get(value); ok {
+		if child, ok := d.scalars.Get(value); ok {
 			if err := child.Traverse(resolver, tr); err != nil {
 				return err
 			}
 		}
-		if detail.alternatives != nil {
-			return detail.alternatives.traverse(resolver, tr, value)
+		// A level with no alternatives -- almost all of them -- pays a branch
+		// and nothing more.
+		if d.alternatives != nil {
+			return d.alternatives.traverse(resolver, tr, value)
 		}
 	}
 
@@ -1601,11 +1626,11 @@ func (alt *alternativeChildren) traverse(resolver ValueResolver, tr *trieTravers
 	return nil
 }
 
-func (node *trieNode) traverseCollectionMembership(resolver ValueResolver, tr *trieTraversalResult, collection Value) error {
-	alt := node.alternatives()
+func (d *levelDetail) traverseCollectionMembership(resolver ValueResolver, tr *trieTraversalResult, collection Value) error {
+	alt := d.alternatives
 	checkMember := func(t *Term) error {
 		if IsScalar(t.Value) {
-			child, _ := node.scalars().Get(t.Value)
+			child, _ := d.scalars.Get(t.Value)
 			if err := child.Traverse(resolver, tr); err != nil {
 				return err
 			}
@@ -1630,64 +1655,43 @@ func (node *trieNode) traverseCollectionMembership(resolver ValueResolver, tr *t
 	return nil
 }
 
-func (node *trieNode) traverseArray(resolver ValueResolver, tr *trieTraversalResult, arr *Array) (err error) {
-	if node == nil {
+// traverseUnknown visits every child of a level whose reference the resolver
+// cannot answer for. What each child constrains below resolves as usual: an
+// unknown at one level says nothing about the levels under it.
+func (d *levelDetail) traverseUnknown(resolver ValueResolver, tr *trieTraversalResult) error {
+	if d == nil {
 		return nil
 	}
 
-	if arr.Len() == 0 {
-		return node.Traverse(resolver, tr)
-	}
-
-	if err = node.any().traverseArray(resolver, tr, arr.Slice(1, -1)); err == nil {
-		switch head := arr.Elem(0).Value.(type) {
-		case Null, Boolean, Number, String:
-			child, _ := node.scalars().Get(head)
-			return child.traverseArray(resolver, tr, arr.Slice(1, -1))
-		}
-	}
-
-	return err
-}
-
-func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalResult) error {
-	if node == nil {
-		return nil
-	}
-
-	if err := node.Traverse(resolver, tr); err != nil {
+	if err := d.undefined.Traverse(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.undefined().traverseUnknown(resolver, tr); err != nil {
+	if err := d.any.Traverse(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.any().traverseUnknown(resolver, tr); err != nil {
+	if err := d.array.traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.array().traverseUnknown(resolver, tr); err != nil {
+	if err := d.prefixes.traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.prefixes().traverseUnknown(resolver, tr); err != nil {
+	if err := d.suffixes.traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.suffixes().traverseUnknown(resolver, tr); err != nil {
-		return err
-	}
-
-	for _, child := range node.converged() {
-		if err := child.traverseUnknown(resolver, tr); err != nil {
+	for _, child := range d.converged() {
+		if err := child.Traverse(resolver, tr); err != nil {
 			return err
 		}
 	}
 
 	var iterErr error
-	node.scalars().Iter(func(_ Value, child *trieNode) bool {
-		iterErr = child.traverseUnknown(resolver, tr)
+	d.scalars.Iter(func(_ Value, child *trieNode) bool {
+		iterErr = child.Traverse(resolver, tr)
 		return iterErr != nil
 	})
 

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -401,9 +401,13 @@ func newrefindices(isVirtual func(Ref) bool) *refindices {
 	}
 }
 
+func valueIsVar(v Value) bool {
+	_, ok := v.(Var)
+	return ok
+}
+
 func (i *refindex) isVar() bool {
-	_, isVar := i.Value.(Var)
-	return isVar
+	return valueIsVar(i.Value)
 }
 
 // Update attempts to update the refindices for the given expression in the
@@ -804,13 +808,9 @@ func (i *refindices) updateMemberRefInValue(rule *Rule, ref Ref, rhs *Term, cons
 	i.insertMembers(rule, ref, members)
 }
 
-// insertMembers records the members of the literal collection of an `in`
-// statement, each of which is a value the rule may reach ref by. It is
-// insertPrefixes again -- see there for why the scan is hoisted out of insert
-// -- and stays a copy of it because the two cannot share a dedup set: a base
-// string is always a String, so insertPrefixes gets a plain map, while an `in`
-// collection holds arbitrary values and needs a HasherMap. Sharing the code
-// meant sharing the HasherMap, which cost the prefix path 27% of its build.
+// insertMembers records the members of an `in` collection, each a value the
+// rule may reach ref by, hoisting insert's scan out of the loop. insertAffixes
+// is the same for base strings; the two dedup on different key types.
 func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
 	if len(members) < 2 {
 		for _, member := range members {
@@ -824,7 +824,21 @@ func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
 	// the rule's list is short at that point, so the scan it costs is cheap.
 	i.insert(rule, &refindex{Ref: ref, Value: members[0]})
 
-	concrete, counted := 0, 0
+	// insert is the only one that may put a value somewhere other than the end
+	// of the list, which is what a var needs, so those go in through it and are
+	// left out of the block below. A collection holding one is rare, and paying
+	// a copy for it keeps the common case a single pass.
+	rest := members[1:]
+	if slices.ContainsFunc(rest, valueIsVar) {
+		for _, member := range rest {
+			if valueIsVar(member) {
+				i.insert(rule, &refindex{Ref: ref, Value: member})
+			}
+		}
+		rest = slices.DeleteFunc(slices.Clone(rest), valueIsVar)
+	}
+
+	concrete := 0
 	seen := util.NewHasherMap[Value, struct{}](ValueEqual)
 
 	for _, other := range i.rules[rule] {
@@ -839,26 +853,25 @@ func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
 		}
 	}
 
-	for _, member := range members[1:] {
-		if _, isVar := member.(Var); isVar {
-			// A var is the one value insert may have to put somewhere other
-			// than the end. It counts itself.
-			i.insert(rule, &refindex{Ref: ref, Value: member})
-			continue
-		}
+	// One refindex per member, laid down in a single block rather than
+	// allocated one at a time, as in insertAffixes. Duplicates leave slack at
+	// the end of the block, which the reslice drops.
+	pos := len(i.rules[rule])
+	indices := util.GrowPtrSlice(i.rules[rule], len(rest))
 
-		counted++
-
+	for _, member := range rest {
 		if _, ok := seen.Get(member); ok {
 			continue
 		}
 		seen.Put(member, struct{}{})
 		concrete++
 
-		i.rules[rule] = append(i.rules[rule], &refindex{Ref: ref, Value: member})
+		*indices[pos] = refindex{Ref: ref, Value: member}
+		pos++
 	}
+	i.rules[rule] = indices[:pos]
 
-	i.countN(ref, counted)
+	i.countN(ref, len(rest))
 
 	if concrete > 1 {
 		i.alternate(ref)

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -757,20 +757,91 @@ func (i *refindices) updateMemberRefInValue(rule *Rule, ref Ref, rhs *Term, cons
 		}
 	}
 
-	addRef := func(t *Term) error {
-		i.insert(rule, &refindex{Ref: ref, Value: t.Value})
-		return nil
-	}
+	var (
+		forEach func(func(*Term))
+		n       int
+	)
 
 	switch rcol := rval.(type) {
 	case *Array:
-		_ = rcol.Iter(addRef)
+		forEach, n = rcol.Foreach, rcol.Len()
 	case Set:
-		_ = rcol.Iter(addRef)
+		forEach, n = rcol.Foreach, rcol.Len()
 	case Object:
-		_ = rcol.Iter(func(_, v *Term) error {
-			return addRef(v)
-		})
+		n = rcol.Len()
+		forEach = func(f func(*Term)) {
+			rcol.Foreach(func(_, v *Term) { f(v) })
+		}
+	default:
+		return
+	}
+
+	members := make([]Value, 0, n)
+	forEach(func(t *Term) {
+		members = append(members, t.Value)
+	})
+
+	i.insertMembers(rule, ref, members)
+}
+
+// insertMembers records the members of the literal collection of an `in`
+// statement, each of which is a value the rule may reach ref by. It is
+// insertPrefixes again -- see there for why the scan is hoisted out of insert
+// -- and stays a copy of it because the two cannot share a dedup set: a base
+// string is always a String, so insertPrefixes gets a plain map, while an `in`
+// collection holds arbitrary values and needs a HasherMap. Sharing the code
+// meant sharing the HasherMap, which cost the prefix path 27% of its build.
+func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
+	if len(members) < 2 {
+		for _, member := range members {
+			i.insert(rule, &refindex{Ref: ref, Value: member})
+		}
+		return
+	}
+
+	// Unlike a prefix, a concrete member takes the place of a "reference is
+	// anything" entry (see insert), so the first one goes the ordinary way --
+	// the rule's list is short at that point, so the scan it costs is cheap.
+	i.insert(rule, &refindex{Ref: ref, Value: members[0]})
+
+	concrete, counted := 0, 0
+	seen := util.NewHasherMap[Value, struct{}](ValueEqual)
+
+	for _, other := range i.rules[rule] {
+		if !other.Ref.Equal(ref) {
+			continue
+		}
+		if !other.isVar() {
+			concrete++
+		}
+		if !other.Prefix {
+			seen.Put(other.Value, struct{}{})
+		}
+	}
+
+	for _, member := range members[1:] {
+		if _, isVar := member.(Var); isVar {
+			// A var is the one value insert may have to put somewhere other
+			// than the end. It counts itself.
+			i.insert(rule, &refindex{Ref: ref, Value: member})
+			continue
+		}
+
+		counted++
+
+		if _, ok := seen.Get(member); ok {
+			continue
+		}
+		seen.Put(member, struct{}{})
+		concrete++
+
+		i.rules[rule] = append(i.rules[rule], &refindex{Ref: ref, Value: member})
+	}
+
+	i.countN(ref, counted)
+
+	if concrete > 1 {
+		i.alternate(ref)
 	}
 }
 

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -337,17 +337,31 @@ type refindex struct {
 	Ref    Ref
 	Value  Value
 	Mapper *valueMapper
-	// Prefix marks Value as a string the value at Ref has to start with, rather
-	// than one it has to equal -- what startswith and strings.any_prefix_match
-	// contribute. Several of them for one ref are alternatives, as for `in`.
-	Prefix bool
+	// Affix says whether Value is a string the value at Ref has to start or end
+	// with, rather than one it has to equal -- what startswith, endswith and
+	// their strings.any_*_match forms contribute. Several of them for one ref
+	// are alternatives, as for `in`.
+	Affix affix
 }
+
+// affix is which end of the value at a reference a refindex constrains, if it
+// constrains an end rather than the whole of it.
+type affix uint8
+
+const (
+	affixNone affix = iota
+	affixPrefix
+	affixSuffix
+)
 
 // insertInto adds the level this index constrains to the path being built,
 // returning the node the rest of the path continues from.
 func (i *refindex) insertInto(node *trieNode, ref Ref) *trieNode {
-	if i.Prefix {
+	switch i.Affix {
+	case affixPrefix:
 		return node.InsertPrefix(ref, i.Value)
+	case affixSuffix:
+		return node.InsertSuffix(ref, i.Value)
 	}
 	return node.Insert(ref, i.Value, i.Mapper)
 }
@@ -456,10 +470,16 @@ func (i *refindices) Update(rule *Rule, expr *Expr, values map[Var]Value) {
 	case op.Equal(Interned.Refs.StartsWith) && len(expr.Operands()) == 2:
 		// As with equal() above: a third operand captures the result, and a
 		// rule producing `false` still has to be evaluated.
-		i.updateStartsWith(rule, expr, values)
+		i.updateAffix(rule, expr, values, affixPrefix)
 
 	case op.Equal(Interned.Refs.AnyPrefixMatch) && len(expr.Operands()) == 2:
-		i.updateAnyPrefixMatch(rule, expr, values)
+		i.updateAnyAffixMatch(rule, expr, values, affixPrefix)
+
+	case op.Equal(Interned.Refs.EndsWith) && len(expr.Operands()) == 2:
+		i.updateAffix(rule, expr, values, affixSuffix)
+
+	case op.Equal(Interned.Refs.AnySuffixMatch) && len(expr.Operands()) == 2:
+		i.updateAnyAffixMatch(rule, expr, values, affixSuffix)
 	}
 }
 
@@ -814,7 +834,7 @@ func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
 		if !other.isVar() {
 			concrete++
 		}
-		if !other.Prefix {
+		if other.Affix == affixNone {
 			seen.Put(other.Value, struct{}{})
 		}
 	}
@@ -959,16 +979,16 @@ func (i *refindices) insert(rule *Rule, index *refindex) {
 
 	for pos, other := range i.rules[rule] {
 		if other.Ref.Equal(index.Ref) {
-			if other.Prefix == index.Prefix && ValueEqual(other.Value, index.Value) {
+			if other.Affix == index.Affix && ValueEqual(other.Value, index.Value) {
 				return
 			}
 			otherValueIsVar := other.isVar()
-			// A prefix constraint does not take the place of the "ref is
+			// An affix constraint does not take the place of the "ref is
 			// anything" entry the way a concrete value does: that entry is what
 			// lets a later expression resolve the same local back to this ref
 			// (see resolveVarToRef), and insertPath drops it anyway once the
 			// ref has a concrete value on the path.
-			if !indexValueIsVar && !index.Prefix && otherValueIsVar {
+			if !indexValueIsVar && index.Affix == affixNone && otherValueIsVar {
 				i.rules[rule][pos] = index
 				return
 			}
@@ -1044,10 +1064,14 @@ type trieNode struct {
 	undefined *trieNode
 	scalars   *util.HasherMap[Value, *trieNode]
 	prefixes  *prefixTrie
-	array     *trieNode
-	rules     []*ruleNode
-	value     *Term
-	multiple  bool
+	// suffixes holds the base strings reversed, so that requiring one at the
+	// end of a value is requiring it at the start of the value reversed and the
+	// same trie answers both (see traverseSuffix).
+	suffixes *prefixTrie
+	array    *trieNode
+	rules    []*ruleNode
+	value    *Term
+	multiple bool
 }
 
 func (node *trieNode) append(prio [2]int, rule *Rule) {
@@ -1097,6 +1121,7 @@ func (node *trieNode) Do(walker trieWalker) {
 	})
 
 	node.prefixes.do(next)
+	node.suffixes.do(next)
 	node.array.Do(next)
 	node.next.Do(next)
 }
@@ -1240,6 +1265,10 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return err
 	}
 
+	if err = node.traverseSuffixes(resolver, tr, v); err != nil {
+		return err
+	}
+
 	for i := range node.mappers {
 		mapped := node.mappers[i].MapValue(v)
 		if !ValueEqual(mapped, v) {
@@ -1339,6 +1368,10 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 	}
 
 	if err := node.prefixes.traverseUnknown(resolver, tr); err != nil {
+		return err
+	}
+
+	if err := node.suffixes.traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -1071,16 +1071,13 @@ func (tr *trieTraversalResult) Add(t *trieNode) {
 
 type trieNode struct {
 	ref       Ref
-	mappers   []*valueMapper
 	next      *trieNode
 	any       *trieNode
 	undefined *trieNode
 	scalars   *util.HasherMap[Value, *trieNode]
-	prefixes  *prefixTrie
-	// suffixes holds the base strings reversed, so that requiring one at the
-	// end of a value is requiring it at the start of the value reversed and the
-	// same trie answers both (see traverseSuffix).
-	suffixes *prefixTrie
+	// detail is what only a level with an unusual constraint records; see
+	// levelDetail.
+	detail   *levelDetail
 	array    *trieNode
 	rules    []*ruleNode
 	value    *Term
@@ -1112,8 +1109,74 @@ func (a *ruleNode) prioEqual(b *ruleNode) bool {
 	return a.prio == b.prio
 }
 
+// levelDetail is what a level records beyond the exact values in its scalars
+// map: the mappers a glob attaches, and the tries for values constrained at one
+// end. The suffix trie holds its base strings reversed, so that requiring one at
+// the end of a value is requiring it at the start of the value reversed and the
+// same trie answers both (see traverseSuffix).
+//
+// It is held behind one pointer because a trieNode is allocated per indexed
+// value and almost none of them are levels -- half a million prefixes make one
+// level and half a million leaves. Inline, these three fields put trieNode in
+// Go's 144-byte size class; out of line it is 112, so every node in the index is
+// 32 bytes smaller.
+type levelDetail struct {
+	mappers  []*valueMapper
+	prefixes *prefixTrie
+	suffixes *prefixTrie
+}
+
 func newTrieNodeImpl() *trieNode {
 	return &trieNode{}
+}
+
+func (node *trieNode) prefixes() *prefixTrie {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.prefixes
+}
+
+func (node *trieNode) suffixes() *prefixTrie {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.suffixes
+}
+
+func (node *trieNode) mappers() []*valueMapper {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.mappers
+}
+
+func (node *trieNode) levelDetail() *levelDetail {
+	node.detail = util.Or(node.detail, newLevelDetail)
+	return node.detail
+}
+
+// affixTrie returns the trie for one end of the value, creating it and the
+// detail that holds it on first use.
+func (node *trieNode) affixTrie(a affix) *prefixTrie {
+	detail := node.levelDetail()
+
+	switch a {
+	case affixSuffix:
+		detail.suffixes = util.Or(detail.suffixes, newPrefixTrie)
+		return detail.suffixes
+	default:
+		detail.prefixes = util.Or(detail.prefixes, newPrefixTrie)
+		return detail.prefixes
+	}
+}
+
+func newLevelDetail() *levelDetail {
+	return &levelDetail{}
+}
+
+func newPrefixTrie() *prefixTrie {
+	return &prefixTrie{}
 }
 
 func (node *trieNode) Do(walker trieWalker) {
@@ -1133,8 +1196,8 @@ func (node *trieNode) Do(walker trieWalker) {
 		return false
 	})
 
-	node.prefixes.do(next)
-	node.suffixes.do(next)
+	node.prefixes().do(next)
+	node.suffixes().do(next)
 	node.array.Do(next)
 	node.next.Do(next)
 }
@@ -1163,12 +1226,13 @@ func (node *trieNode) Traverse(resolver ValueResolver, tr *trieTraversalResult) 
 }
 
 func (node *trieNode) addMapper(mapper *valueMapper) {
-	for i := range node.mappers {
-		if node.mappers[i].Key == mapper.Key {
+	detail := node.levelDetail()
+	for i := range detail.mappers {
+		if detail.mappers[i].Key == mapper.Key {
 			return
 		}
 	}
-	node.mappers = append(node.mappers, mapper)
+	detail.mappers = append(detail.mappers, mapper)
 }
 
 func (node *trieNode) insertValue(value Value) *trieNode {
@@ -1282,8 +1346,9 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return err
 	}
 
-	for i := range node.mappers {
-		mapped := node.mappers[i].MapValue(v)
+	mappers := node.mappers()
+	for i := range mappers {
+		mapped := mappers[i].MapValue(v)
 		if !ValueEqual(mapped, v) {
 			if err := node.traverseValue(resolver, tr, mapped); err != nil {
 				return err
@@ -1380,11 +1445,11 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 		return err
 	}
 
-	if err := node.prefixes.traverseUnknown(resolver, tr); err != nil {
+	if err := node.prefixes().traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.suffixes.traverseUnknown(resolver, tr); err != nil {
+	if err := node.suffixes().traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -183,11 +183,16 @@ func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int,
 					}
 				}
 				node = child
-			} else if remaining == 0 || slices.ContainsFunc(values, (*refindex).isAffix) {
+			} else if remaining == 0 || slices.ContainsFunc(values, (*refindex).isAffix) ||
+				slices.ContainsFunc(values, (*refindex).isComposite) {
 				// Nothing below to continue a path with, so the rule hangs off
 				// every alternative -- which rules reaching the same values
-				// share. Affixes always take this route; see alternation.
-				for _, val := range values {
+				// share. Affixes always take this route; see alternation, and
+				// so does anything a converging level could not be keyed on:
+				// insertValue sends an object or a set to the "anything" node
+				// and an array into the array trie, which is where a lookup
+				// goes looking for them.
+				for _, val := range oneAffixEnd(values) {
 					child := val.insertInto(node, ref)
 					child.append(prio, rule)
 				}
@@ -372,6 +377,60 @@ func (i *refindex) insertInto(node *trieNode, ref Ref) *trieNode {
 	return node.Insert(ref, i.Value, i.Mapper)
 }
 
+// oneAffixEnd keeps the affixes of one end of the value where values constrain
+// both, and everything that is not an affix.
+//
+// A rule hung off the leaves of both the prefix and the suffix trie is admitted
+// by either, which is the disjunction of what it wrote where it wrote a
+// conjunction:
+//
+//	p if {
+//		strings.any_prefix_match(input.path, ["/a", "/b"])
+//		strings.any_suffix_match(input.path, [".go", ".rego"])
+//	}
+//
+// admits "/c/x.go" on the suffix alone. Testing one end and leaving the other to
+// evaluation admits a subset of that -- what one end admits, both admit -- so
+// one end is kept. A level cannot test both: the tries hold leaves, and a leaf
+// cannot be made to depend on another trie's answer.
+//
+// Which end is kept is decided by the shortest base string of each, since a set
+// admits a value that matches any one of its bases and the shortest of them
+// admits the most. Counting them instead would keep ["/"] over [".go",
+// ".rego"], and every absolute path matches "/".
+func oneAffixEnd(values []*refindex) []*refindex {
+	prefix, suffix := -1, -1
+	for _, val := range values {
+		s, ok := val.Value.(String)
+		if !ok {
+			continue
+		}
+		switch val.Affix {
+		case affixPrefix:
+			if prefix < 0 || len(s) < prefix {
+				prefix = len(s)
+			}
+		case affixSuffix:
+			if suffix < 0 || len(s) < suffix {
+				suffix = len(s)
+			}
+		}
+	}
+
+	if prefix < 0 || suffix < 0 {
+		return values
+	}
+
+	drop := affixSuffix
+	if suffix > prefix {
+		drop = affixPrefix
+	}
+
+	return slices.DeleteFunc(slices.Clone(values), func(val *refindex) bool {
+		return val.Affix == drop
+	})
+}
+
 // alternatives are sets of indices, any one of which is enough to reach a rule.
 type alternatives = [][]*refindex
 
@@ -419,6 +478,14 @@ func (i *refindex) isVar() bool {
 
 func (i *refindex) isAffix() bool {
 	return i.Affix != affixNone
+}
+
+// isComposite reports whether a lookup could not find this value among a
+// level's alternatives, which are keyed on the value as it stands. insertValue
+// sends an object or a set to the "anything" node and an array into the array
+// trie, which is where a lookup goes looking for them instead.
+func (i *refindex) isComposite() bool {
+	return !IsScalar(i.Value)
 }
 
 // Update attempts to update the refindices for the given expression in the
@@ -1590,7 +1657,11 @@ func (d *levelDetail) traverseValue(resolver ValueResolver, tr *trieTraversalRes
 				}
 			}
 		}
-		if d.scalars.Len() > 0 {
+		// Alternatives as well as scalars: a level every rule reaches by
+		// several values has its children under alternatives and none under
+		// scalars, and a collection at the reference still has to be tested
+		// against them.
+		if d.scalars.Len() > 0 || d.alternatives != nil {
 			return d.traverseCollectionMembership(resolver, tr, value)
 		}
 	case Null, Boolean, Number, String:

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -1073,15 +1073,9 @@ func (tr *trieTraversalResult) Add(t *trieNode) {
 }
 
 type trieNode struct {
-	ref       Ref
-	next      *trieNode
-	any       *trieNode
-	undefined *trieNode
-	scalars   *util.HasherMap[Value, *trieNode]
-	// detail is what only a level with an unusual constraint records; see
-	// levelDetail.
+	// detail is what only a level node has; see levelDetail.
 	detail   *levelDetail
-	array    *trieNode
+	next     *trieNode
 	rules    []*ruleNode
 	value    *Term
 	multiple bool
@@ -1112,25 +1106,70 @@ func (a *ruleNode) prioEqual(b *ruleNode) bool {
 	return a.prio == b.prio
 }
 
-// levelDetail is what a level records beyond the exact values in its scalars
-// map: the mappers a glob attaches, and the tries for values constrained at one
-// end. The suffix trie holds its base strings reversed, so that requiring one at
-// the end of a value is requiring it at the start of the value reversed and the
-// same trie answers both (see traverseSuffix).
+// levelDetail is everything a trieNode has by virtue of being a *level* -- the
+// reference it resolves, the children it dispatches the resolved value to, and
+// the constraints that are not exact values. The suffix trie holds its base
+// strings reversed, so that requiring one at the end of a value is requiring it
+// at the start of the value reversed and the same trie answers both (see
+// traverseSuffix).
 //
 // It is held behind one pointer because a trieNode is allocated per indexed
-// value and almost none of them are levels -- half a million prefixes make one
-// level and half a million leaves. Inline, these three fields put trieNode in
-// Go's 144-byte size class; out of line it is 112, so every node in the index is
-// 32 bytes smaller.
+// value and almost none of them are levels: half a million prefixes make one
+// level and half a million nodes that only carry rules. Measured over such an
+// index, every field here is set on 0 or 1 of the 500002 nodes.
+//
+// Where the boundaries fall decides how much that is worth. Inline, these
+// fields put trieNode in Go's 144-byte size class; out of line it is 56 bytes,
+// which rounds to 64. Moving them out a few at a time buys nothing -- 136 and
+// 112 bytes both round up to a class the struct already occupied.
 type levelDetail struct {
-	mappers  []*valueMapper
-	prefixes *prefixTrie
-	suffixes *prefixTrie
+	ref       Ref
+	any       *trieNode
+	undefined *trieNode
+	array     *trieNode
+	scalars   *util.HasherMap[Value, *trieNode]
+	mappers   []*valueMapper
+	prefixes  *prefixTrie
+	suffixes  *prefixTrie
 }
 
 func newTrieNodeImpl() *trieNode {
 	return &trieNode{}
+}
+
+func (node *trieNode) ref() Ref {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.ref
+}
+
+func (node *trieNode) any() *trieNode {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.any
+}
+
+func (node *trieNode) undefined() *trieNode {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.undefined
+}
+
+func (node *trieNode) array() *trieNode {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.array
+}
+
+func (node *trieNode) scalars() *util.HasherMap[Value, *trieNode] {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.scalars
 }
 
 func (node *trieNode) prefixes() *prefixTrie {
@@ -1178,6 +1217,10 @@ func newLevelDetail() *levelDetail {
 	return &levelDetail{}
 }
 
+func newScalarChildren() *util.HasherMap[Value, *trieNode] {
+	return util.NewHasherMap[Value, *trieNode](ValueEqual)
+}
+
 func newPrefixTrie() *prefixTrie {
 	return &prefixTrie{}
 }
@@ -1191,17 +1234,17 @@ func (node *trieNode) Do(walker trieWalker) {
 		return
 	}
 
-	node.any.Do(next)
-	node.undefined.Do(next)
+	node.any().Do(next)
+	node.undefined().Do(next)
 
-	node.scalars.Iter(func(_ Value, child *trieNode) bool {
+	node.scalars().Iter(func(_ Value, child *trieNode) bool {
 		child.Do(next)
 		return false
 	})
 
 	node.prefixes().do(next)
 	node.suffixes().do(next)
-	node.array.Do(next)
+	node.array().Do(next)
 	node.next.Do(next)
 }
 
@@ -1215,12 +1258,12 @@ func (node *trieNode) compact() {
 	node.prefixes().compact()
 	node.suffixes().compact()
 
-	node.any.compact()
-	node.undefined.compact()
-	node.array.compact()
+	node.any().compact()
+	node.undefined().compact()
+	node.array().compact()
 	node.next.compact()
 
-	node.scalars.Iter(func(_ Value, child *trieNode) bool {
+	node.scalars().Iter(func(_ Value, child *trieNode) bool {
 		child.compact()
 		return false
 	})
@@ -1229,7 +1272,7 @@ func (node *trieNode) compact() {
 func (node *trieNode) Insert(ref Ref, value Value, mapper *valueMapper) *trieNode {
 	if node.next == nil {
 		node.next = newTrieNodeImpl()
-		node.next.ref = ref
+		node.next.levelDetail().ref = ref
 	}
 
 	if mapper != nil {
@@ -1260,26 +1303,26 @@ func (node *trieNode) addMapper(mapper *valueMapper) {
 }
 
 func (node *trieNode) insertValue(value Value) *trieNode {
+	detail := node.levelDetail()
+
 	switch value := value.(type) {
 	case nil:
-		node.undefined = util.Or(node.undefined, newTrieNodeImpl)
-		return node.undefined
+		detail.undefined = util.Or(detail.undefined, newTrieNodeImpl)
+		return detail.undefined
 	case Var:
-		node.any = util.Or(node.any, newTrieNodeImpl)
-		return node.any
+		detail.any = util.Or(detail.any, newTrieNodeImpl)
+		return detail.any
 	case Null, Boolean, Number, String:
-		child, ok := node.scalars.Get(value)
+		child, ok := detail.scalars.Get(value)
 		if !ok {
 			child = newTrieNodeImpl()
-			if node.scalars == nil {
-				node.scalars = util.NewHasherMap[Value, *trieNode](ValueEqual)
-			}
-			node.scalars.Put(value, child)
+			detail.scalars = util.Or(detail.scalars, newScalarChildren)
+			detail.scalars.Put(value, child)
 		}
 		return child
 	case *Array:
-		node.array = util.Or(node.array, newTrieNodeImpl)
-		return node.array.insertArray(value)
+		detail.array = util.Or(detail.array, newTrieNodeImpl)
+		return detail.array.insertArray(value)
 
 	// `x in <collection>` (see updateMemberRefInValue) inserts each element of
 	// the literal collection as-is, without restricting it to scalars/arrays
@@ -1290,8 +1333,8 @@ func (node *trieNode) insertValue(value Value) *trieNode {
 	// Call - can't actually reach here: the compiler rewrites them into
 	// separate statements, bound to a Var, before the index is built.)
 	case Object, Set:
-		node.any = util.Or(node.any, newTrieNodeImpl)
-		return node.any
+		detail.any = util.Or(detail.any, newTrieNodeImpl)
+		return detail.any
 	}
 
 	panic("illegal value")
@@ -1302,18 +1345,18 @@ func (node *trieNode) insertArray(arr *Array) *trieNode {
 		return node
 	}
 
+	detail := node.levelDetail()
+
 	switch head := arr.Elem(0).Value.(type) {
 	case Var:
-		node.any = util.Or(node.any, newTrieNodeImpl)
-		return node.any.insertArray(arr.Slice(1, -1))
+		detail.any = util.Or(detail.any, newTrieNodeImpl)
+		return detail.any.insertArray(arr.Slice(1, -1))
 	case Null, Boolean, Number, String:
-		child, ok := node.scalars.Get(head)
+		child, ok := detail.scalars.Get(head)
 		if !ok {
 			child = newTrieNodeImpl()
-			if node.scalars == nil {
-				node.scalars = util.NewHasherMap[Value, *trieNode](ValueEqual)
-			}
-			node.scalars.Put(head, child)
+			detail.scalars = util.Or(detail.scalars, newScalarChildren)
+			detail.scalars.Put(head, child)
 		}
 		return child.insertArray(arr.Slice(1, -1))
 
@@ -1322,8 +1365,8 @@ func (node *trieNode) insertArray(arr *Array) *trieNode {
 	// at this position, so fall back to "any" and keep indexing the
 	// remaining elements.
 	case *Array, Object, Set:
-		node.any = util.Or(node.any, newTrieNodeImpl)
-		return node.any.insertArray(arr.Slice(1, -1))
+		detail.any = util.Or(detail.any, newTrieNodeImpl)
+		return detail.any.insertArray(arr.Slice(1, -1))
 	}
 
 	panic("illegal value")
@@ -1334,7 +1377,7 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return nil
 	}
 
-	v, err := resolver.Resolve(node.ref)
+	v, err := resolver.Resolve(node.ref())
 	if err != nil {
 		if IsUnknownValueErr(err) {
 			return node.traverseUnknown(resolver, tr)
@@ -1342,7 +1385,7 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return err
 	}
 
-	if err = node.undefined.Traverse(resolver, tr); err != nil {
+	if err = node.undefined().Traverse(resolver, tr); err != nil {
 		return err
 	}
 
@@ -1350,7 +1393,7 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 		return nil
 	}
 
-	if err = node.any.Traverse(resolver, tr); err != nil {
+	if err = node.any().Traverse(resolver, tr); err != nil {
 		return err
 	}
 
@@ -1386,18 +1429,18 @@ func (node *trieNode) traverse(resolver ValueResolver, tr *trieTraversalResult) 
 func (node *trieNode) traverseValue(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
 	switch value := value.(type) {
 	case *Array, Set, Object:
-		if node.array != nil {
+		if node.array() != nil {
 			if arr, ok := value.(*Array); ok {
-				if err := node.array.traverseArray(resolver, tr, arr); err != nil {
+				if err := node.array().traverseArray(resolver, tr, arr); err != nil {
 					return err
 				}
 			}
 		}
-		if node.scalars.Len() > 0 {
+		if node.scalars().Len() > 0 {
 			return node.traverseCollectionMembership(resolver, tr, value)
 		}
 	case Null, Boolean, Number, String:
-		if child, ok := node.scalars.Get(value); ok {
+		if child, ok := node.scalars().Get(value); ok {
 			return child.Traverse(resolver, tr)
 		}
 	}
@@ -1408,7 +1451,7 @@ func (node *trieNode) traverseValue(resolver ValueResolver, tr *trieTraversalRes
 func (node *trieNode) traverseCollectionMembership(resolver ValueResolver, tr *trieTraversalResult, collection Value) error {
 	checkMember := func(t *Term) error {
 		if IsScalar(t.Value) {
-			child, _ := node.scalars.Get(t.Value)
+			child, _ := node.scalars().Get(t.Value)
 			return child.Traverse(resolver, tr)
 		}
 		return nil
@@ -1437,10 +1480,10 @@ func (node *trieNode) traverseArray(resolver ValueResolver, tr *trieTraversalRes
 		return node.Traverse(resolver, tr)
 	}
 
-	if err = node.any.traverseArray(resolver, tr, arr.Slice(1, -1)); err == nil {
+	if err = node.any().traverseArray(resolver, tr, arr.Slice(1, -1)); err == nil {
 		switch head := arr.Elem(0).Value.(type) {
 		case Null, Boolean, Number, String:
-			child, _ := node.scalars.Get(head)
+			child, _ := node.scalars().Get(head)
 			return child.traverseArray(resolver, tr, arr.Slice(1, -1))
 		}
 	}
@@ -1457,15 +1500,15 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 		return err
 	}
 
-	if err := node.undefined.traverseUnknown(resolver, tr); err != nil {
+	if err := node.undefined().traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.any.traverseUnknown(resolver, tr); err != nil {
+	if err := node.any().traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
-	if err := node.array.traverseUnknown(resolver, tr); err != nil {
+	if err := node.array().traverseUnknown(resolver, tr); err != nil {
 		return err
 	}
 
@@ -1478,7 +1521,7 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 	}
 
 	var iterErr error
-	node.scalars.Iter(func(_ Value, child *trieNode) bool {
+	node.scalars().Iter(func(_ Value, child *trieNode) bool {
 		iterErr = child.traverseUnknown(resolver, tr)
 		return iterErr != nil
 	})

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -127,6 +127,9 @@ func (i *baseDocEqIndex) Build(rules []*Rule) bool {
 			return false
 		})
 	}
+
+	i.root.compact()
+
 	return true
 }
 
@@ -1200,6 +1203,27 @@ func (node *trieNode) Do(walker trieWalker) {
 	node.suffixes().do(next)
 	node.array.Do(next)
 	node.next.Do(next)
+}
+
+// compact walks the trie once the index is built and releases what its slices
+// grew but do not use.
+func (node *trieNode) compact() {
+	if node == nil {
+		return
+	}
+
+	node.prefixes().compact()
+	node.suffixes().compact()
+
+	node.any.compact()
+	node.undefined.compact()
+	node.array.compact()
+	node.next.compact()
+
+	node.scalars.Iter(func(_ Value, child *trieNode) bool {
+		child.compact()
+		return false
+	})
 }
 
 func (node *trieNode) Insert(ref Ref, value Value, mapper *valueMapper) *trieNode {

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -183,16 +183,19 @@ func (i *baseDocEqIndex) insertPath(sorted []Ref, path []*refindex, prio [2]int,
 					}
 				}
 				node = child
-			} else {
-				// When a rule has multiple scalar values (e.g., internal.member_2 with a set),
-				// each value should have its own child node, and the rule is appended to each.
-				// This creates separate paths for each value so different rules with overlapping
-				// values don't interfere with each other.
+			} else if remaining == 0 || slices.ContainsFunc(values, (*refindex).isAffix) {
+				// Nothing below to continue a path with, so the rule hangs off
+				// every alternative -- which rules reaching the same values
+				// share. Affixes always take this route; see alternation.
 				for _, val := range values {
 					child := val.insertInto(node, ref)
 					child.append(prio, rule)
 				}
 				return
+			} else {
+				// The alternatives meet again on one node, and the rest of the
+				// path is built from there rather than under each of them.
+				node = node.insertAlternatives(ref, values)
 			}
 		}
 	}
@@ -382,11 +385,12 @@ type refindices struct {
 	// operand body: resolvable from inside, but not the operand's own.
 	outer     []*refindex
 	frequency *util.HasherMap[Ref, int]
-	// alternated holds the refs some rule reaches by more than one value, which
-	// insertPath ends that rule's path on. Sorted ranks them last. An `or` is
-	// not recorded: its alternatives are separate paths, and only meet a second
-	// value for one ref once paths() combines them, after Sorted has run.
-	alternated *util.HasherMap[Ref, struct{}]
+	// alternated holds the refs some rule reaches by more than one value, and
+	// what that costs insertPath. Sorted ranks them last, terminal after
+	// converging. An `or` is not recorded: its alternatives are separate paths,
+	// and only meet a second value for one ref once paths() combines them,
+	// after Sorted has run.
+	alternated *util.HasherMap[Ref, alternation]
 	sorted     []Ref
 }
 
@@ -400,7 +404,7 @@ func newrefindices(isVirtual func(Ref) bool) *refindices {
 		isVirtual:  isVirtual,
 		rules:      map[*Rule][]*refindex{},
 		frequency:  util.NewHasherMap[Ref, int](RefEqual),
-		alternated: util.NewHasherMap[Ref, struct{}](RefEqual),
+		alternated: util.NewHasherMap[Ref, alternation](RefEqual),
 	}
 }
 
@@ -411,6 +415,10 @@ func valueIsVar(v Value) bool {
 
 func (i *refindex) isVar() bool {
 	return valueIsVar(i.Value)
+}
+
+func (i *refindex) isAffix() bool {
+	return i.Affix != affixNone
 }
 
 // Update attempts to update the refindices for the given expression in the
@@ -628,10 +636,11 @@ func (i *refindices) isValidIndexRef(ref Ref) bool {
 func (i *refindices) Sorted() []Ref {
 	if i.sorted == nil {
 		i.sorted = util.SortedFunc(i.frequency.Keys(), func(a, b Ref) int {
-			// A ref that ends some rule's path is worth less as an early level,
-			// however often it was recorded, so it outranks frequency.
-			if altA, altB := i.isAlternated(a), i.isAlternated(b); altA != altB {
-				if altA {
+			// A ref reached by several values is worth less as an early level,
+			// and one that ends the rule's path less again, however often
+			// either was recorded -- so both outrank frequency.
+			if altA, altB := i.alternationOf(a), i.alternationOf(b); altA != altB {
+				if altA > altB {
 					return 1
 				}
 				return -1
@@ -877,7 +886,7 @@ func (i *refindices) insertMembers(rule *Rule, ref Ref, members []Value) {
 	i.countN(ref, len(rest))
 
 	if concrete > 1 {
-		i.alternate(ref)
+		i.alternate(ref, alternationConverging)
 	}
 }
 
@@ -977,15 +986,40 @@ func (i *refindices) countN(ref Ref, n int) {
 	i.frequency.Put(ref, count+n)
 }
 
-// alternate records that a rule reaches ref by more than one value. Only the
-// values surviving insertPath's var-stripping count.
-func (i *refindices) alternate(ref Ref) {
-	i.alternated.Put(ref, struct{}{})
+// alternation is what a ref reached by several values costs the rest of the
+// rule's path, and what Sorted ranks such refs by.
+type alternation uint8
+
+const (
+	// alternationNone: no rule reaches the ref by more than one value.
+	alternationNone alternation = iota
+
+	// alternationConverging: the alternatives meet again on one node, so the
+	// path continues from there. Still ranked after the plain refs, since the
+	// rule gets a node of its own and stops sharing what is below.
+	alternationConverging
+
+	// alternationTerminal: the alternatives cannot meet again, so the rule
+	// hangs off each and whatever it constrains below goes unindexed. Affixes
+	// are these -- a prefix trie cannot point several leaves at one node.
+	alternationTerminal
+)
+
+// alternate records that a rule reaches ref by more than one value, and what
+// that costs. The worse kind recorded for a ref wins. Only the values
+// surviving insertPath's var-stripping count.
+func (i *refindices) alternate(ref Ref, kind alternation) {
+	if was, ok := i.alternated.Get(ref); ok && was >= kind {
+		return
+	}
+	i.alternated.Put(ref, kind)
 }
 
-func (i *refindices) isAlternated(ref Ref) bool {
-	_, ok := i.alternated.Get(ref)
-	return ok
+func (i *refindices) alternationOf(ref Ref) alternation {
+	if kind, ok := i.alternated.Get(ref); ok {
+		return kind
+	}
+	return alternationNone
 }
 
 func (i *refindices) insert(rule *Rule, index *refindex) {
@@ -1009,7 +1043,13 @@ func (i *refindices) insert(rule *Rule, index *refindex) {
 				return
 			}
 			if !indexValueIsVar && !otherValueIsVar {
-				i.alternate(index.Ref)
+				// insertPath cannot converge a level that any affix reaches,
+				// so one on either side makes this pair a terminal one.
+				kind := alternationConverging
+				if index.Affix != affixNone || other.Affix != affixNone {
+					kind = alternationTerminal
+				}
+				i.alternate(index.Ref, kind)
 			}
 		}
 	}
@@ -1119,18 +1159,43 @@ func (a *ruleNode) prioEqual(b *ruleNode) bool {
 // index, every field here is set on 0 or 1 of the 500002 nodes.
 //
 // Where the boundaries fall decides how much that is worth. Inline, these
-// fields put trieNode in Go's 144-byte size class; out of line it is 56 bytes,
+// fields put trieNode in Go's 160-byte size class; out of line it is 56 bytes,
 // which rounds to 64. Moving them out a few at a time buys nothing -- 136 and
 // 112 bytes both round up to a class the struct already occupied.
+//
+// The same reasoning applies once more within levelDetail: alternatives is set
+// on the few levels some rule reaches by more than one value, so it costs 8
+// bytes here rather than the 32 its two fields would inline.
 type levelDetail struct {
-	ref       Ref
-	any       *trieNode
-	undefined *trieNode
-	array     *trieNode
-	scalars   *util.HasherMap[Value, *trieNode]
-	mappers   []*valueMapper
-	prefixes  *prefixTrie
-	suffixes  *prefixTrie
+	ref          Ref
+	any          *trieNode
+	undefined    *trieNode
+	array        *trieNode
+	scalars      *util.HasherMap[Value, *trieNode]
+	mappers      []*valueMapper
+	prefixes     *prefixTrie
+	suffixes     *prefixTrie
+	alternatives *alternativeChildren
+}
+
+// alternativeChildren are the nodes that rules reaching a level by several
+// values continue from. The two fields hold the same nodes for two different
+// jobs, and neither does the other's:
+//
+// members answers "which nodes does this value reach", which is what a lookup
+// asks. A node is in it under every one of the values that reaches it, so a
+// rule with a thousand-member collection puts its one node under a thousand
+// keys, and several rules sharing a value put several nodes under that one.
+//
+// converged answers "which nodes are below this level", which is what the
+// walks over the whole trie ask -- traverseUnknown, Do and compact. Reading
+// that off members would visit a node once per value that reaches it: correct,
+// since trieTraversalResult.Add folds a rule reached twice into one, but a
+// thousand times the work for the collection above. So the nodes are listed
+// once each here as they are created.
+type alternativeChildren struct {
+	members   *util.HasherMap[Value, []*trieNode]
+	converged []*trieNode
 }
 
 func newTrieNodeImpl() *trieNode {
@@ -1184,6 +1249,20 @@ func (node *trieNode) suffixes() *prefixTrie {
 		return nil
 	}
 	return node.detail.suffixes
+}
+
+func (node *trieNode) alternatives() *alternativeChildren {
+	if node.detail == nil {
+		return nil
+	}
+	return node.detail.alternatives
+}
+
+func (node *trieNode) converged() []*trieNode {
+	if alt := node.alternatives(); alt != nil {
+		return alt.converged
+	}
+	return nil
 }
 
 func (node *trieNode) mappers() []*valueMapper {
@@ -1242,6 +1321,10 @@ func (node *trieNode) Do(walker trieWalker) {
 		return false
 	})
 
+	for _, child := range node.converged() {
+		child.Do(next)
+	}
+
 	node.prefixes().do(next)
 	node.suffixes().do(next)
 	node.array().Do(next)
@@ -1263,10 +1346,52 @@ func (node *trieNode) compact() {
 	node.array().compact()
 	node.next.compact()
 
+	for _, child := range node.converged() {
+		child.compact()
+	}
+
 	node.scalars().Iter(func(_ Value, child *trieNode) bool {
 		child.compact()
 		return false
 	})
+
+	if alt := node.alternatives(); alt != nil {
+		alt.converged = slices.Clip(alt.converged)
+	}
+}
+
+// insertAlternatives adds a level a rule reaches by any one of several values,
+// and returns the one node the rest of its path continues from. Every value
+// keys to that node, so what the rule constrains below is built once instead of
+// repeated under each alternative.
+func (node *trieNode) insertAlternatives(ref Ref, values []*refindex) *trieNode {
+	if node.next == nil {
+		node.next = newTrieNodeImpl()
+		node.next.levelDetail().ref = ref
+	}
+
+	level := node.next.levelDetail()
+	level.alternatives = util.Or(level.alternatives, newAlternativeChildren)
+	alt := level.alternatives
+
+	converge := newTrieNodeImpl()
+	alt.converged = append(alt.converged, converge)
+
+	for _, val := range values {
+		if val.Mapper != nil {
+			node.next.addMapper(val.Mapper)
+		}
+		nodes, _ := alt.members.Get(val.Value)
+		alt.members.Put(val.Value, append(nodes, converge))
+	}
+
+	return converge
+}
+
+func newAlternativeChildren() *alternativeChildren {
+	return &alternativeChildren{
+		members: util.NewHasherMap[Value, []*trieNode](ValueEqual),
+	}
 }
 
 func (node *trieNode) Insert(ref Ref, value Value, mapper *valueMapper) *trieNode {
@@ -1440,8 +1565,36 @@ func (node *trieNode) traverseValue(resolver ValueResolver, tr *trieTraversalRes
 			return node.traverseCollectionMembership(resolver, tr, value)
 		}
 	case Null, Boolean, Number, String:
-		if child, ok := node.scalars().Get(value); ok {
-			return child.Traverse(resolver, tr)
+		// One load of detail for both, so that a level with no alternatives --
+		// almost all of them -- pays a branch and nothing more.
+		detail := node.detail
+		if detail == nil {
+			return nil
+		}
+		if child, ok := detail.scalars.Get(value); ok {
+			if err := child.Traverse(resolver, tr); err != nil {
+				return err
+			}
+		}
+		if detail.alternatives != nil {
+			return detail.alternatives.traverse(resolver, tr, value)
+		}
+	}
+
+	return nil
+}
+
+// traverse visits the nodes that the rules reaching this level by value
+// continue from.
+func (alt *alternativeChildren) traverse(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+	nodes, ok := alt.members.Get(value)
+	if !ok {
+		return nil
+	}
+
+	for _, child := range nodes {
+		if err := child.Traverse(resolver, tr); err != nil {
+			return err
 		}
 	}
 
@@ -1449,10 +1602,16 @@ func (node *trieNode) traverseValue(resolver ValueResolver, tr *trieTraversalRes
 }
 
 func (node *trieNode) traverseCollectionMembership(resolver ValueResolver, tr *trieTraversalResult, collection Value) error {
+	alt := node.alternatives()
 	checkMember := func(t *Term) error {
 		if IsScalar(t.Value) {
 			child, _ := node.scalars().Get(t.Value)
-			return child.Traverse(resolver, tr)
+			if err := child.Traverse(resolver, tr); err != nil {
+				return err
+			}
+			if alt != nil {
+				return alt.traverse(resolver, tr, t.Value)
+			}
 		}
 		return nil
 	}
@@ -1518,6 +1677,12 @@ func (node *trieNode) traverseUnknown(resolver ValueResolver, tr *trieTraversalR
 
 	if err := node.suffixes().traverseUnknown(resolver, tr); err != nil {
 		return err
+	}
+
+	for _, child := range node.converged() {
+		if err := child.traverseUnknown(resolver, tr); err != nil {
+			return err
+		}
 	}
 
 	var iterErr error

--- a/v1/ast/index.go
+++ b/v1/ast/index.go
@@ -365,7 +365,12 @@ type refindices struct {
 	// operand body: resolvable from inside, but not the operand's own.
 	outer     []*refindex
 	frequency *util.HasherMap[Ref, int]
-	sorted    []Ref
+	// alternated holds the refs some rule reaches by more than one value, which
+	// insertPath ends that rule's path on. Sorted ranks them last. An `or` is
+	// not recorded: its alternatives are separate paths, and only meet a second
+	// value for one ref once paths() combines them, after Sorted has run.
+	alternated *util.HasherMap[Ref, struct{}]
+	sorted     []Ref
 }
 
 // maxIndexPaths caps the ways a single rule may be reached: `or` expressions
@@ -375,9 +380,10 @@ const maxIndexPaths = 32
 
 func newrefindices(isVirtual func(Ref) bool) *refindices {
 	return &refindices{
-		isVirtual: isVirtual,
-		rules:     map[*Rule][]*refindex{},
-		frequency: util.NewHasherMap[Ref, int](RefEqual),
+		isVirtual:  isVirtual,
+		rules:      map[*Rule][]*refindex{},
+		frequency:  util.NewHasherMap[Ref, int](RefEqual),
+		alternated: util.NewHasherMap[Ref, struct{}](RefEqual),
 	}
 }
 
@@ -595,6 +601,14 @@ func (i *refindices) isValidIndexRef(ref Ref) bool {
 func (i *refindices) Sorted() []Ref {
 	if i.sorted == nil {
 		i.sorted = util.SortedFunc(i.frequency.Keys(), func(a, b Ref) int {
+			// A ref that ends some rule's path is worth less as an early level,
+			// however often it was recorded, so it outranks frequency.
+			if altA, altB := i.isAlternated(a), i.isAlternated(b); altA != altB {
+				if altA {
+					return 1
+				}
+				return -1
+			}
 			countsA, _ := i.frequency.Get(a)
 			countsB, _ := i.frequency.Get(b)
 			if countsA < countsB { // descending, we want highest-freq first
@@ -856,17 +870,28 @@ func (i *refindices) countN(ref Ref, n int) {
 	i.frequency.Put(ref, count+n)
 }
 
+// alternate records that a rule reaches ref by more than one value. Only the
+// values surviving insertPath's var-stripping count.
+func (i *refindices) alternate(ref Ref) {
+	i.alternated.Put(ref, struct{}{})
+}
+
+func (i *refindices) isAlternated(ref Ref) bool {
+	_, ok := i.alternated.Get(ref)
+	return ok
+}
+
 func (i *refindices) insert(rule *Rule, index *refindex) {
 	i.count(index.Ref)
 
-	_, indexValueIsVar := index.Value.(Var)
+	indexValueIsVar := index.isVar()
 
 	for pos, other := range i.rules[rule] {
 		if other.Ref.Equal(index.Ref) {
 			if other.Prefix == index.Prefix && ValueEqual(other.Value, index.Value) {
 				return
 			}
-			_, otherValueIsVar := other.Value.(Var)
+			otherValueIsVar := other.isVar()
 			// A prefix constraint does not take the place of the "ref is
 			// anything" entry the way a concrete value does: that entry is what
 			// lets a later expression resolve the same local back to this ref
@@ -875,6 +900,9 @@ func (i *refindices) insert(rule *Rule, index *refindex) {
 			if !indexValueIsVar && !index.Prefix && otherValueIsVar {
 				i.rules[rule][pos] = index
 				return
+			}
+			if !indexValueIsVar && !otherValueIsVar {
+				i.alternate(index.Ref)
 			}
 		}
 	}

--- a/v1/ast/index_affix.go
+++ b/v1/ast/index_affix.go
@@ -10,6 +10,12 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
+// This file holds the indexing of both ends of a string: `startswith` and
+// `strings.any_prefix_match`, and `endswith` and `strings.any_suffix_match`.
+// One structure answers both -- a suffix trie is a prefixTrie over the base
+// strings reversed (see InsertSuffix and traverseSuffix) -- so prefixTrie is
+// what the file is named after.
+//
 // prefixTrie holds the string-prefix constraints recorded for one level of the
 // rule index: what `startswith(input.x, "/api/")` and
 // `strings.any_prefix_match(input.x, [...])` contribute.

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -108,6 +108,18 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
+	// A suffix trie holds its bases reversed (see trieNode.suffixes), so what it
+	// walks back is what was written.
+	for _, p := range node.suffixes.walk() {
+		label := "*" + reverseString(p.prefix)
+		if childID, childExists := nodeIDs[p.node]; childExists {
+			fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(label), childID)
+		} else {
+			p.node.mermaidFormat(sb, counter, nodeIDs, "")
+			fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(label), nodeIDs[p.node])
+		}
+	}
+
 	if node.next != nil {
 		node.next.mermaidFormat(sb, counter, nodeIDs, currentID)
 	}
@@ -233,6 +245,14 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		sb.WriteString(indent)
 		sb.WriteString(`  prefix "`)
 		sb.WriteString(p.prefix)
+		sb.WriteString("\":\n")
+		p.node.format(sb, depth+2)
+	}
+
+	for _, p := range node.suffixes.walk() {
+		sb.WriteString(indent)
+		sb.WriteString(`  suffix "`)
+		sb.WriteString(reverseString(p.prefix))
 		sb.WriteString("\":\n")
 		p.node.format(sb, depth+2)
 	}

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -39,31 +39,31 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		return
 	}
 
-	if node.undefined != nil {
-		if childID, childExists := nodeIDs[node.undefined]; childExists {
+	if node.undefined() != nil {
+		if childID, childExists := nodeIDs[node.undefined()]; childExists {
 			fmt.Fprintf(sb, "  %s -->|undefined| %s\n", currentID, childID)
 		} else {
-			node.undefined.mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|undefined| %s\n", currentID, nodeIDs[node.undefined])
+			node.undefined().mermaidFormat(sb, counter, nodeIDs, "")
+			fmt.Fprintf(sb, "  %s -->|undefined| %s\n", currentID, nodeIDs[node.undefined()])
 		}
 	}
 
-	if node.any != nil {
-		if childID, childExists := nodeIDs[node.any]; childExists {
+	if node.any() != nil {
+		if childID, childExists := nodeIDs[node.any()]; childExists {
 			fmt.Fprintf(sb, "  %s -->|any| %s\n", currentID, childID)
 		} else {
-			node.any.mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|any| %s\n", currentID, nodeIDs[node.any])
+			node.any().mermaidFormat(sb, counter, nodeIDs, "")
+			fmt.Fprintf(sb, "  %s -->|any| %s\n", currentID, nodeIDs[node.any()])
 		}
 	}
 
-	if node.scalars.Len() > 0 {
+	if node.scalars().Len() > 0 {
 		type scalarPair struct {
 			key  Value
 			node *trieNode
 		}
-		pairs := make([]scalarPair, 0, node.scalars.Len())
-		node.scalars.Iter(func(key Value, val *trieNode) bool {
+		pairs := make([]scalarPair, 0, node.scalars().Len())
+		node.scalars().Iter(func(key Value, val *trieNode) bool {
 			pairs = append(pairs, scalarPair{key, val})
 			return false
 		})
@@ -90,12 +90,12 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
-	if node.array != nil {
-		if childID, childExists := nodeIDs[node.array]; childExists {
+	if node.array() != nil {
+		if childID, childExists := nodeIDs[node.array()]; childExists {
 			fmt.Fprintf(sb, "  %s -->|array| %s\n", currentID, childID)
 		} else {
-			node.array.mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|array| %s\n", currentID, nodeIDs[node.array])
+			node.array().mermaidFormat(sb, counter, nodeIDs, "")
+			fmt.Fprintf(sb, "  %s -->|array| %s\n", currentID, nodeIDs[node.array()])
 		}
 	}
 
@@ -128,8 +128,8 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 func (node *trieNode) mermaidLabel() string {
 	var parts []string
 
-	if len(node.ref) > 0 {
-		parts = append(parts, node.ref.String())
+	if len(node.ref()) > 0 {
+		parts = append(parts, node.ref().String())
 	}
 
 	if len(node.rules) > 0 {
@@ -174,9 +174,9 @@ func (node *trieNode) String() string {
 func (node *trieNode) format(sb *strings.Builder, depth int) {
 	indent := strings.Repeat("  ", depth)
 
-	if len(node.ref) > 0 {
+	if len(node.ref()) > 0 {
 		sb.WriteString(indent)
-		sb.WriteString(node.ref.String())
+		sb.WriteString(node.ref().String())
 	} else if depth == 0 {
 		sb.WriteString("root")
 	}
@@ -200,22 +200,22 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 	}
 	sb.WriteByte('\n')
 
-	if node.undefined != nil {
+	if node.undefined() != nil {
 		sb.WriteString(indent)
 		sb.WriteString("  undefined:\n")
-		node.undefined.format(sb, depth+2)
+		node.undefined().format(sb, depth+2)
 	}
 
-	if node.any != nil {
+	if node.any() != nil {
 		sb.WriteString(indent)
 		sb.WriteString("  any:\n")
-		node.any.format(sb, depth+2)
+		node.any().format(sb, depth+2)
 	}
 
-	if node.scalars.Len() > 0 {
-		scalars := make([]Value, 0, node.scalars.Len())
-		nodes := make([]*trieNode, 0, node.scalars.Len())
-		node.scalars.Iter(func(key Value, val *trieNode) bool {
+	if node.scalars().Len() > 0 {
+		scalars := make([]Value, 0, node.scalars().Len())
+		nodes := make([]*trieNode, 0, node.scalars().Len())
+		node.scalars().Iter(func(key Value, val *trieNode) bool {
 			scalars = append(scalars, key)
 			nodes = append(nodes, val)
 			return false
@@ -235,10 +235,10 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		}
 	}
 
-	if node.array != nil {
+	if node.array() != nil {
 		sb.WriteString(indent)
 		sb.WriteString("  array:\n")
-		node.array.format(sb, depth+2)
+		node.array().format(sb, depth+2)
 	}
 
 	for _, p := range node.prefixes().walk() {

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -99,7 +99,7 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
-	for _, p := range node.prefixes.walk() {
+	for _, p := range node.prefixes().walk() {
 		if childID, childExists := nodeIDs[p.node]; childExists {
 			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), childID)
 		} else {
@@ -108,9 +108,9 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
-	// A suffix trie holds its bases reversed (see trieNode.suffixes), so what it
+	// A suffix trie holds its bases reversed (see affixTries), so what it
 	// walks back is what was written.
-	for _, p := range node.suffixes.walk() {
+	for _, p := range node.suffixes().walk() {
 		label := "*" + reverseString(p.prefix)
 		if childID, childExists := nodeIDs[p.node]; childExists {
 			fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(label), childID)
@@ -146,8 +146,8 @@ func (node *trieNode) mermaidLabel() string {
 		}
 	}
 
-	if len(node.mappers) > 0 {
-		parts = append(parts, fmt.Sprintf("%d mapper(s)", len(node.mappers)))
+	if len(node.mappers()) > 0 {
+		parts = append(parts, fmt.Sprintf("%d mapper(s)", len(node.mappers())))
 	}
 	if node.multiple {
 		parts = append(parts, "multiple")
@@ -186,9 +186,9 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		util.WriteInt(sb, len(node.rules))
 		sb.WriteString(" rule(s)]")
 	}
-	if len(node.mappers) > 0 {
+	if len(node.mappers()) > 0 {
 		sb.WriteString(" [")
-		util.WriteInt(sb, len(node.mappers))
+		util.WriteInt(sb, len(node.mappers()))
 		sb.WriteString(" mapper(s)]")
 	}
 	if node.value != nil {
@@ -241,7 +241,7 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		node.array.format(sb, depth+2)
 	}
 
-	for _, p := range node.prefixes.walk() {
+	for _, p := range node.prefixes().walk() {
 		sb.WriteString(indent)
 		sb.WriteString(`  prefix "`)
 		sb.WriteString(p.prefix)
@@ -249,7 +249,7 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		p.node.format(sb, depth+2)
 	}
 
-	for _, p := range node.suffixes.walk() {
+	for _, p := range node.suffixes().walk() {
 		sb.WriteString(indent)
 		sb.WriteString(`  suffix "`)
 		sb.WriteString(reverseString(p.prefix))

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -27,8 +27,7 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		currentID = fmt.Sprintf("n%d", *counter)
 		*counter++
 		nodeIDs[node] = currentID
-		label := node.mermaidLabel()
-		fmt.Fprintf(sb, "  %s[\"%s\"]\n", currentID, label)
+		fmt.Fprintf(sb, "  %s[\"%s\"]\n", currentID, node.mermaidLabel())
 	}
 
 	if parentID != "" {
@@ -39,142 +38,96 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		return
 	}
 
-	if node.undefined() != nil {
-		if childID, childExists := nodeIDs[node.undefined()]; childExists {
-			fmt.Fprintf(sb, "  %s -->|undefined| %s\n", currentID, childID)
-		} else {
-			node.undefined().mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|undefined| %s\n", currentID, nodeIDs[node.undefined()])
-		}
+	node.next.mermaidFormat(sb, counter, nodeIDs, currentID)
+}
+
+// mermaidEdge draws one way of matching the level's reference, emitting the
+// child first if this is where it is reached from.
+func mermaidEdge(sb *strings.Builder, counter *int, nodeIDs map[*trieNode]string, from, label string, child *trieNode) {
+	if child == nil {
+		return
+	}
+	if _, exists := nodeIDs[child]; !exists {
+		child.mermaidFormat(sb, counter, nodeIDs, "")
+	}
+	fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", from, mermaidEscape(label), nodeIDs[child])
+}
+
+func (d *levelDetail) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs map[*trieNode]string, from string) {
+	if d == nil {
+		return
 	}
 
-	if node.any() != nil {
-		if childID, childExists := nodeIDs[node.any()]; childExists {
-			fmt.Fprintf(sb, "  %s -->|any| %s\n", currentID, childID)
-		} else {
-			node.any().mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|any| %s\n", currentID, nodeIDs[node.any()])
-		}
-	}
+	mermaidEdge(sb, counter, nodeIDs, from, "undefined", d.undefined)
+	mermaidEdge(sb, counter, nodeIDs, from, "any", d.any)
 
-	if node.scalars().Len() > 0 {
-		type scalarPair struct {
-			key  Value
-			node *trieNode
-		}
-		pairs := make([]scalarPair, 0, node.scalars().Len())
-		node.scalars().Iter(func(key Value, val *trieNode) bool {
-			pairs = append(pairs, scalarPair{key, val})
+	d.scalars.Iter(func(key Value, child *trieNode) bool {
+		mermaidEdge(sb, counter, nodeIDs, from, key.String(), child)
+		return false
+	})
+
+	if d.alternatives != nil {
+		d.alternatives.members.Iter(func(key Value, nodes []*trieNode) bool {
+			for _, child := range nodes {
+				mermaidEdge(sb, counter, nodeIDs, from, key.String(), child)
+			}
 			return false
 		})
-		slices.SortFunc(pairs, func(a, b scalarPair) int {
-			return a.key.Compare(b.key)
-		})
-		for _, pair := range pairs {
-			var scalarLabel string
-			if s, ok := pair.key.(String); ok {
-				scalarLabel = string(s)
-			} else {
-				scalarLabel = pair.key.String()
-			}
-			if len(scalarLabel) > 20 {
-				scalarLabel = scalarLabel[:20] + "..."
-			}
-			scalarLabel = mermaidEscape(scalarLabel)
-			if childID, childExists := nodeIDs[pair.node]; childExists {
-				fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, scalarLabel, childID)
-			} else {
-				pair.node.mermaidFormat(sb, counter, nodeIDs, "")
-				fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, scalarLabel, nodeIDs[pair.node])
-			}
-		}
 	}
 
-	if node.array() != nil {
-		if childID, childExists := nodeIDs[node.array()]; childExists {
-			fmt.Fprintf(sb, "  %s -->|array| %s\n", currentID, childID)
-		} else {
-			node.array().mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|array| %s\n", currentID, nodeIDs[node.array()])
-		}
-	}
-
-	if alt := node.alternatives(); alt != nil {
-		for _, conv := range alt.converged {
-			var keys []Value
-			alt.members.Iter(func(k Value, nodes []*trieNode) bool {
-				if slices.Contains(nodes, conv) {
-					keys = append(keys, k)
-				}
-				return false
-			})
-			slices.SortFunc(keys, Value.Compare)
-
-			if _, childExists := nodeIDs[conv]; !childExists {
-				conv.mermaidFormat(sb, counter, nodeIDs, "")
-			}
-			for _, k := range keys {
-				fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(k.String()), nodeIDs[conv])
-			}
-		}
-	}
-
-	for _, p := range node.prefixes().walk() {
-		if childID, childExists := nodeIDs[p.node]; childExists {
-			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), childID)
-		} else {
-			p.node.mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), nodeIDs[p.node])
-		}
+	for _, p := range d.prefixes.walk() {
+		mermaidEdge(sb, counter, nodeIDs, from, p.prefix+"*", p.node)
 	}
 
 	// A suffix trie holds its bases reversed (see affixTries), so what it
 	// walks back is what was written.
-	for _, p := range node.suffixes().walk() {
-		label := "*" + reverseString(p.prefix)
-		if childID, childExists := nodeIDs[p.node]; childExists {
-			fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(label), childID)
-		} else {
-			p.node.mermaidFormat(sb, counter, nodeIDs, "")
-			fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(label), nodeIDs[p.node])
-		}
+	for _, p := range d.suffixes.walk() {
+		mermaidEdge(sb, counter, nodeIDs, from, "*"+reverseString(p.prefix), p.node)
 	}
 
-	if node.next != nil {
-		node.next.mermaidFormat(sb, counter, nodeIDs, currentID)
+	d.array.mermaidFormat(sb, counter, nodeIDs, from, "array")
+}
+
+func (a *arrayTrie) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs map[*trieNode]string, from, label string) {
+	if a == nil {
+		return
 	}
+
+	mermaidEdge(sb, counter, nodeIDs, from, label, a.end)
+	a.any.mermaidFormat(sb, counter, nodeIDs, from, label+" any")
+	a.scalars.Iter(func(key Value, child *arrayTrie) bool {
+		child.mermaidFormat(sb, counter, nodeIDs, from, label+" "+key.String())
+		return false
+	})
 }
 
 func (node *trieNode) mermaidLabel() string {
 	var parts []string
 
-	if len(node.ref()) > 0 {
-		parts = append(parts, node.ref().String())
+	if node.next != nil && len(node.next.ref) > 0 {
+		parts = append(parts, node.next.ref.String())
 	}
 
-	if len(node.rules) > 0 {
-		for _, rn := range node.rules {
-			bodyStr := ""
-			if rn.rule.Body != nil {
-				bodyStr = rn.rule.Body.String()
-				if len(bodyStr) > 50 {
-					bodyStr = bodyStr[:50] + "..."
-				}
+	for _, rn := range node.rules {
+		bodyStr := ""
+		if rn.rule.Body != nil {
+			bodyStr = rn.rule.Body.String()
+			if len(bodyStr) > 50 {
+				bodyStr = bodyStr[:50] + "..."
 			}
-			bodyStr = mermaidEscape(bodyStr)
-			parts = append(parts, bodyStr)
 		}
+		parts = append(parts, mermaidEscape(bodyStr))
 	}
 
-	if len(node.mappers()) > 0 {
-		parts = append(parts, fmt.Sprintf("%d mapper(s)", len(node.mappers())))
+	if node.next != nil && len(node.next.mappers) > 0 {
+		parts = append(parts, fmt.Sprintf("%d mapper(s)", len(node.next.mappers)))
 	}
 	if node.multiple {
 		parts = append(parts, "multiple")
 	}
 
 	if len(parts) == 0 {
-		return "·"
+		return "\u00b7"
 	}
 
 	return strings.Join(parts, "<br/>")
@@ -192,24 +145,21 @@ func (node *trieNode) String() string {
 }
 
 func (node *trieNode) format(sb *strings.Builder, depth int) {
-	indent := strings.Repeat("  ", depth)
-
-	if len(node.ref()) > 0 {
-		sb.WriteString(indent)
-		sb.WriteString(node.ref().String())
-	} else if depth == 0 {
-		sb.WriteString("root")
+	if node == nil {
+		return
 	}
 
+	indent := strings.Repeat("  ", depth)
+
+	if depth == 0 {
+		sb.WriteString("root")
+	} else {
+		sb.WriteString(indent)
+	}
 	if len(node.rules) > 0 {
 		sb.WriteString(" [")
 		util.WriteInt(sb, len(node.rules))
 		sb.WriteString(" rule(s)]")
-	}
-	if len(node.mappers()) > 0 {
-		sb.WriteString(" [")
-		util.WriteInt(sb, len(node.mappers()))
-		sb.WriteString(" mapper(s)]")
 	}
 	if node.value != nil {
 		sb.WriteString(" value=")
@@ -220,53 +170,64 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 	}
 	sb.WriteByte('\n')
 
-	if node.undefined() != nil {
+	node.next.format(sb, depth)
+}
+
+// format prints the level below a node: the reference it resolves, and a line
+// per way of matching it.
+func (d *levelDetail) format(sb *strings.Builder, depth int) {
+	if d == nil {
+		return
+	}
+
+	indent := strings.Repeat("  ", depth)
+
+	if len(d.ref) > 0 {
+		sb.WriteString(indent)
+		sb.WriteString(d.ref.String())
+		if len(d.mappers) > 0 {
+			sb.WriteString(" [")
+			util.WriteInt(sb, len(d.mappers))
+			sb.WriteString(" mapper(s)]")
+		}
+		sb.WriteByte('\n')
+	}
+
+	if d.undefined != nil {
 		sb.WriteString(indent)
 		sb.WriteString("  undefined:\n")
-		node.undefined().format(sb, depth+2)
+		d.undefined.format(sb, depth+2)
 	}
 
-	if node.any() != nil {
+	if d.any != nil {
 		sb.WriteString(indent)
 		sb.WriteString("  any:\n")
-		node.any().format(sb, depth+2)
+		d.any.format(sb, depth+2)
 	}
 
-	if node.scalars().Len() > 0 {
-		scalars := make([]Value, 0, node.scalars().Len())
-		nodes := make([]*trieNode, 0, node.scalars().Len())
-		node.scalars().Iter(func(key Value, val *trieNode) bool {
+	if d.scalars.Len() > 0 {
+		scalars := make([]Value, 0, d.scalars.Len())
+		d.scalars.Iter(func(key Value, _ *trieNode) bool {
 			scalars = append(scalars, key)
-			nodes = append(nodes, val)
 			return false
 		})
 		slices.SortFunc(scalars, Value.Compare)
-		for i := range scalars {
+		for _, k := range scalars {
+			child, _ := d.scalars.Get(k)
 			sb.WriteString(indent)
 			sb.WriteString("  ")
-			sb.WriteString(scalars[i].String())
+			sb.WriteString(k.String())
 			sb.WriteString(":\n")
-			for j := range nodes {
-				if ValueEqual(scalars[i], scalars[j]) {
-					nodes[j].format(sb, depth+2)
-					break
-				}
-			}
+			child.format(sb, depth+2)
 		}
 	}
 
-	if node.array() != nil {
-		sb.WriteString(indent)
-		sb.WriteString("  array:\n")
-		node.array().format(sb, depth+2)
-	}
-
-	// Several values reaching one node, so the node is printed under the first
-	// of them and the rest name it (see alternativeChildren).
-	if alt := node.alternatives(); alt != nil {
-		for i, conv := range alt.converged {
+	// Several values reaching one node, so the node is printed once and the
+	// values that reach it are named together (see alternativeChildren).
+	if d.alternatives != nil {
+		for i, conv := range d.alternatives.converged {
 			var keys []Value
-			alt.members.Iter(func(k Value, nodes []*trieNode) bool {
+			d.alternatives.members.Iter(func(k Value, nodes []*trieNode) bool {
 				if slices.Contains(nodes, conv) {
 					keys = append(keys, k)
 				}
@@ -287,7 +248,13 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		}
 	}
 
-	for _, p := range node.prefixes().walk() {
+	if d.array != nil {
+		sb.WriteString(indent)
+		sb.WriteString("  array:\n")
+		d.array.format(sb, depth+2)
+	}
+
+	for _, p := range d.prefixes.walk() {
 		sb.WriteString(indent)
 		sb.WriteString(`  prefix "`)
 		sb.WriteString(p.prefix)
@@ -295,15 +262,42 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		p.node.format(sb, depth+2)
 	}
 
-	for _, p := range node.suffixes().walk() {
+	for _, p := range d.suffixes.walk() {
 		sb.WriteString(indent)
 		sb.WriteString(`  suffix "`)
 		sb.WriteString(reverseString(p.prefix))
 		sb.WriteString("\":\n")
 		p.node.format(sb, depth+2)
 	}
+}
 
-	if node.next != nil {
-		node.next.format(sb, depth)
+func (a *arrayTrie) format(sb *strings.Builder, depth int) {
+	if a == nil {
+		return
+	}
+
+	indent := strings.Repeat("  ", depth)
+
+	a.end.format(sb, depth)
+
+	if a.any != nil {
+		sb.WriteString(indent)
+		sb.WriteString("  any:\n")
+		a.any.format(sb, depth+2)
+	}
+
+	keys := make([]Value, 0, a.scalars.Len())
+	a.scalars.Iter(func(k Value, _ *arrayTrie) bool {
+		keys = append(keys, k)
+		return false
+	})
+	slices.SortFunc(keys, Value.Compare)
+	for _, k := range keys {
+		child, _ := a.scalars.Get(k)
+		sb.WriteString(indent)
+		sb.WriteString("  ")
+		sb.WriteString(k.String())
+		sb.WriteString(":\n")
+		child.format(sb, depth+2)
 	}
 }

--- a/v1/ast/index_debug.go
+++ b/v1/ast/index_debug.go
@@ -99,6 +99,26 @@ func (node *trieNode) mermaidFormat(sb *strings.Builder, counter *int, nodeIDs m
 		}
 	}
 
+	if alt := node.alternatives(); alt != nil {
+		for _, conv := range alt.converged {
+			var keys []Value
+			alt.members.Iter(func(k Value, nodes []*trieNode) bool {
+				if slices.Contains(nodes, conv) {
+					keys = append(keys, k)
+				}
+				return false
+			})
+			slices.SortFunc(keys, Value.Compare)
+
+			if _, childExists := nodeIDs[conv]; !childExists {
+				conv.mermaidFormat(sb, counter, nodeIDs, "")
+			}
+			for _, k := range keys {
+				fmt.Fprintf(sb, "  %s -->|\"%s\"| %s\n", currentID, mermaidEscape(k.String()), nodeIDs[conv])
+			}
+		}
+	}
+
 	for _, p := range node.prefixes().walk() {
 		if childID, childExists := nodeIDs[p.node]; childExists {
 			fmt.Fprintf(sb, "  %s -->|\"%s*\"| %s\n", currentID, mermaidEscape(p.prefix), childID)
@@ -239,6 +259,32 @@ func (node *trieNode) format(sb *strings.Builder, depth int) {
 		sb.WriteString(indent)
 		sb.WriteString("  array:\n")
 		node.array().format(sb, depth+2)
+	}
+
+	// Several values reaching one node, so the node is printed under the first
+	// of them and the rest name it (see alternativeChildren).
+	if alt := node.alternatives(); alt != nil {
+		for i, conv := range alt.converged {
+			var keys []Value
+			alt.members.Iter(func(k Value, nodes []*trieNode) bool {
+				if slices.Contains(nodes, conv) {
+					keys = append(keys, k)
+				}
+				return false
+			})
+			slices.SortFunc(keys, Value.Compare)
+
+			sb.WriteString(indent)
+			sb.WriteString("  any of ")
+			for j, k := range keys {
+				if j > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(k.String())
+			}
+			fmt.Fprintf(sb, " -> #%d:\n", i)
+			conv.format(sb, depth+2)
+		}
 	}
 
 	for _, p := range node.prefixes().walk() {

--- a/v1/ast/index_member_bench_test.go
+++ b/v1/ast/index_member_bench_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// BenchmarkBuildMembershipIndex is the cost of putting `input.x in [k
+// literals]` into the index. Each element is a value the rule may reach
+// input.x by, and refindices.insert rescans the rule's indices on every one, so
+// recording k of them used to be O(k^2):
+//
+//	         rescanning    recorded together
+//	  100        121 us               20 us
+//	 1000       11.8 ms             0.22 ms
+//	10000       1128 ms             2.69 ms
+//
+// A decade of k cost 97x rescanning and costs 11x now. strings.any_prefix_match
+// had this fixed for its own base collection when it landed; insertAll is that
+// fix, shared.
+func BenchmarkBuildMembershipIndex(b *testing.B) {
+	for _, k := range []int{100, 1000, 10000} {
+		b.Run(strconv.Itoa(k), func(b *testing.B) {
+			c := MustCompileModules(map[string]string{"test.rego": membershipPolicy(k)})
+			rules := c.Modules["test.rego"].Rules
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				index := newBaseDocEqIndex(func(Ref) bool { return false })
+				if !index.Build(rules) {
+					b.Fatal("expected index build to succeed")
+				}
+			}
+		})
+	}
+}
+
+// membershipPolicy is one rule reaching input.x by k values, with a second
+// constraint below so that the rule has a path to lose if the k values are
+// mishandled (see refindices.alternated).
+func membershipPolicy(k int) string {
+	var sb strings.Builder
+
+	sb.WriteString("package test\n\np if {\n\tinput.x in [")
+	for i := range k {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "%d", i)
+	}
+	sb.WriteString("]\n\tinput.y == 1\n}\n")
+
+	return sb.String()
+}

--- a/v1/ast/index_member_bench_test.go
+++ b/v1/ast/index_member_bench_test.go
@@ -60,3 +60,81 @@ func membershipPolicy(k int) string {
 
 	return sb.String()
 }
+
+// alternatingPolicy is n rules, each reaching two references by several values:
+// a subject that every rule's collection holds, and an action that only one
+// does. The query names a subject and an action, so exactly one rule can hold.
+//
+// insertPath used to stop a rule's path at the first such reference, so the
+// second was not indexed and every rule stayed a candidate. Ranking those
+// references last cannot help here -- both are ranked last, and one of them is
+// still first of the two.
+func alternatingPolicy(n int) (string, *Term) {
+	var sb strings.Builder
+	sb.WriteString("package test\n\n")
+
+	for i := range n {
+		fmt.Fprintf(&sb, "p if {\n\tinput.subject in [\"alice\", \"u%d\"]\n\tinput.action in [\"act%d\", \"x%d\"]\n}\n", i, i, i)
+	}
+
+	return sb.String(), MustParseTerm(`{"subject": "alice", "action": "act0"}`)
+}
+
+// BenchmarkLookupAlternatingIndex is the cost of a lookup against those rules.
+// What it measures is how many of them the traversal has to report: with only
+// the first reference indexed, the subject admits all n and the caller
+// evaluates them; with both, the action leaves one.
+func BenchmarkLookupAlternatingIndex(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			policy, input := alternatingPolicy(n)
+			c := MustCompileModules(map[string]string{"test.rego": policy})
+
+			index := newBaseDocEqIndex(func(Ref) bool { return false })
+			if !index.Build(c.Modules["test.rego"].Rules) {
+				b.Fatal("expected index build to succeed")
+			}
+			resolver := testResolver{input: input}
+
+			res, err := index.Lookup(resolver)
+			if err != nil {
+				b.Fatal(err)
+			}
+			candidates := float64(len(res.Rules))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if _, err := index.Lookup(resolver); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			// After ResetTimer, which drops user metrics reported before it.
+			b.ReportMetric(candidates, "candidates")
+		})
+	}
+}
+
+// BenchmarkBuildAlternatingIndex is what indexing the second reference costs to
+// build: one node per rule that the alternatives of the first converge on.
+func BenchmarkBuildAlternatingIndex(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			policy, _ := alternatingPolicy(n)
+			c := MustCompileModules(map[string]string{"test.rego": policy})
+			rules := c.Modules["test.rego"].Rules
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				index := newBaseDocEqIndex(func(Ref) bool { return false })
+				if !index.Build(rules) {
+					b.Fatal("expected index build to succeed")
+				}
+			}
+		})
+	}
+}

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -308,6 +308,11 @@ func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[
 // rule's indices on every call, which is fine for the handful an ordinary rule
 // contributes but quadratic for the thousands strings.any_prefix_match exists
 // to carry, so the scan happens once here instead.
+//
+// insertMembers is the same function for `in`. They stay apart because the base
+// is always strings and can dedup in a plain map, where `in` holds arbitrary
+// values and needs a HasherMap; one shared copy costs this path 27% of its
+// build.
 func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
 	i.countN(ref, len(prefixes))
 

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -311,9 +311,19 @@ func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[
 func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
 	i.countN(ref, len(prefixes))
 
+	// concrete counts the values this rule already reaches ref by that survive
+	// insertPath's var-stripping, so that the alternatives the base adds can be
+	// weighed against them without a second scan (see refindices.alternate).
+	concrete := 0
 	seen := make(map[String]struct{}, len(prefixes))
 	for _, other := range i.rules[rule] {
-		if other.Prefix && other.Ref.Equal(ref) {
+		if !other.Ref.Equal(ref) {
+			continue
+		}
+		if !other.isVar() {
+			concrete++
+		}
+		if other.Prefix {
 			if s, ok := other.Value.(String); ok {
 				seen[s] = struct{}{}
 			}
@@ -326,9 +336,14 @@ func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
 			continue
 		}
 		seen[prefix] = struct{}{}
+		concrete++
 		indices = append(indices, &refindex{Ref: ref, Value: prefix, Prefix: true})
 	}
 	i.rules[rule] = indices
+
+	if concrete > 1 {
+		i.alternate(ref)
+	}
 }
 
 // constantString resolves term to a string literal, following one level of

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -7,6 +7,8 @@ package ast
 import (
 	"errors"
 	"slices"
+
+	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // prefixTrie holds the string-prefix constraints recorded for one level of the
@@ -41,7 +43,8 @@ type prefixEdge struct {
 }
 
 // edge locates the edge labelled with first byte b, or the position a new one
-// would be inserted at to keep edges sorted.
+// would be inserted at to keep edges sorted. Only that byte is matched; labels
+// are compressed, so comparing the rest of one is left to the caller.
 func (p *prefixTrie) edge(b byte) (int, bool) {
 	return slices.BinarySearchFunc(p.edges, b, func(e prefixEdge, b byte) int {
 		return int(e.label[0]) - int(b)
@@ -116,6 +119,60 @@ func (p *prefixTrie) traverse(s string, resolver ValueResolver, tr *trieTraversa
 	}
 
 	return nil
+}
+
+// traverseSuffix is traverse over the end of s. A suffix trie holds its base
+// strings reversed (see trieNode.suffixes), so the walk consumes s from its
+// last byte back -- which needs no reversed copy of s to be made per lookup.
+func (p *prefixTrie) traverseSuffix(s string, resolver ValueResolver, tr *trieTraversalResult) error {
+	for node := p; node != nil; {
+		if node.child != nil {
+			if err := node.child.Traverse(resolver, tr); err != nil {
+				return err
+			}
+		}
+
+		if s == "" {
+			return nil
+		}
+
+		pos, found := node.edge(s[len(s)-1])
+		if !found {
+			return nil
+		}
+
+		edge := node.edges[pos]
+		if len(edge.label) > len(s) || !equalReversed(s[len(s)-len(edge.label):], edge.label) {
+			return nil
+		}
+
+		s = s[:len(s)-len(edge.label)]
+		node = edge.node
+	}
+
+	return nil
+}
+
+// equalReversed reports whether tail read backwards is reversed.
+func equalReversed(tail, reversed string) bool {
+	for i := range reversed {
+		if reversed[i] != tail[len(tail)-1-i] {
+			return false
+		}
+	}
+	return true
+}
+
+// reverseString returns s with its bytes reversed. A base string is reversed
+// once, when it is recorded; `endswith` is a byte comparison, so reversing
+// bytes rather than runes is what makes a suffix of s a prefix of reversed s.
+func reverseString(s string) string {
+	b := []byte(s)
+	slices.Reverse(b)
+
+	// b was made here and is not written to again, so it can be handed over
+	// rather than copied a second time.
+	return util.ByteSliceToString(b)
 }
 
 func (p *prefixTrie) do(walker trieWalker) {
@@ -211,6 +268,26 @@ func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
 	return node.next.prefixes.insert(string(s))
 }
 
+// InsertSuffix records that the rules below this node require the value at ref
+// to be a string ending with suffix.
+func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
+	if node.next == nil {
+		node.next = newTrieNodeImpl()
+		node.next.ref = ref
+	}
+
+	s, ok := suffix.(String)
+	if !ok {
+		panic("illegal suffix value")
+	}
+
+	if node.next.suffixes == nil {
+		node.next.suffixes = &prefixTrie{}
+	}
+
+	return node.next.suffixes.insert(reverseString(string(s)))
+}
+
 // traversePrefixes visits the rules whose prefix constraints value satisfies.
 //
 // strings.any_prefix_match takes a collection of search strings as readily as a
@@ -248,20 +325,52 @@ func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversal
 	return nil
 }
 
+// traverseSuffixes visits the rules whose suffix constraints value satisfies.
+// A collection is tested element by element, as for prefixes.
+func (node *trieNode) traverseSuffixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+	if node.suffixes == nil {
+		return nil
+	}
+
+	if s, ok := value.(String); ok {
+		return node.suffixes.traverseSuffix(string(s), resolver, tr)
+	}
+
+	checkMember := func(t *Term) error {
+		if s, ok := t.Value.(String); ok {
+			return node.suffixes.traverseSuffix(string(s), resolver, tr)
+		}
+		return nil
+	}
+
+	switch col := value.(type) {
+	case *Array:
+		return col.Iter(checkMember)
+	case Set:
+		return col.Iter(checkMember)
+	case Object:
+		return col.Iter(func(_, v *Term) error {
+			return checkMember(v)
+		})
+	}
+
+	return nil
+}
+
 // updateStartsWith indexes `startswith(x, "base")`: x has to be a string
 // starting with base for the rule to hold.
-func (i *refindices) updateStartsWith(rule *Rule, expr *Expr, constants map[Var]Value) {
+func (i *refindices) updateAffix(rule *Rule, expr *Expr, constants map[Var]Value, a affix) {
 	ref := i.resolveAndValidateRef(rule, rule.Head.Args, expr.Operand(0))
 	if ref == nil {
 		return
 	}
 
-	prefix, ok := constantString(expr.Operand(1), constants)
+	base, ok := constantString(expr.Operand(1), constants)
 	if !ok {
 		return
 	}
 
-	i.insert(rule, &refindex{Ref: ref, Value: prefix, Prefix: true})
+	i.insert(rule, &refindex{Ref: ref, Value: base, Affix: a})
 }
 
 // updateAnyPrefixMatch indexes `strings.any_prefix_match(x, base)`, which is
@@ -272,7 +381,7 @@ func (i *refindices) updateStartsWith(rule *Rule, expr *Expr, constants map[Var]
 // The search operand has to be a single ref: a collection of search strings
 // would need every element of one collection tested against the other, which
 // is not a constraint on the value at any one ref.
-func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[Var]Value) {
+func (i *refindices) updateAnyAffixMatch(rule *Rule, expr *Expr, constants map[Var]Value, a affix) {
 	ref := i.resolveAndValidateRef(rule, rule.Head.Args, expr.Operand(0))
 	if ref == nil {
 		return
@@ -288,7 +397,7 @@ func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[
 	}
 
 	if s, ok := base.(String); ok {
-		i.insert(rule, &refindex{Ref: ref, Value: s, Prefix: true})
+		i.insert(rule, &refindex{Ref: ref, Value: s, Affix: a})
 		return
 	}
 
@@ -296,31 +405,32 @@ func (i *refindices) updateAnyPrefixMatch(rule *Rule, expr *Expr, constants map[
 	// the dropped ones would have matched -- so a base that isn't a collection
 	// of ground strings throughout leaves the rule unindexed rather than
 	// partly indexed.
-	prefixes, ok := groundStrings(base)
-	if !ok || len(prefixes) == 0 {
+	bases, ok := groundStrings(base)
+	if !ok || len(bases) == 0 {
 		return
 	}
 
-	i.insertPrefixes(rule, ref, prefixes)
+	i.insertAffixes(rule, ref, bases, a)
 }
 
-// insertPrefixes records a whole base collection at once. insert() rescans the
-// rule's indices on every call, which is fine for the handful an ordinary rule
-// contributes but quadratic for the thousands strings.any_prefix_match exists
-// to carry, so the scan happens once here instead.
+// insertAffixes records a whole base collection at once, for either end of the
+// value. insert() rescans the rule's indices on every call, which is fine for
+// the handful an ordinary rule contributes but quadratic for the thousands
+// strings.any_prefix_match exists to carry, so the scan happens once here
+// instead.
 //
-// insertMembers is the same function for `in`. They stay apart because the base
+// insertMembers is the same function for `in`. They stay apart because a base
 // is always strings and can dedup in a plain map, where `in` holds arbitrary
 // values and needs a HasherMap; one shared copy costs this path 27% of its
 // build.
-func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
-	i.countN(ref, len(prefixes))
+func (i *refindices) insertAffixes(rule *Rule, ref Ref, bases []String, a affix) {
+	i.countN(ref, len(bases))
 
 	// concrete counts the values this rule already reaches ref by that survive
 	// insertPath's var-stripping, so that the alternatives the base adds can be
 	// weighed against them without a second scan (see refindices.alternate).
 	concrete := 0
-	seen := make(map[String]struct{}, len(prefixes))
+	seen := make(map[String]struct{}, len(bases))
 	for _, other := range i.rules[rule] {
 		if !other.Ref.Equal(ref) {
 			continue
@@ -328,7 +438,7 @@ func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
 		if !other.isVar() {
 			concrete++
 		}
-		if other.Prefix {
+		if other.Affix == a {
 			if s, ok := other.Value.(String); ok {
 				seen[s] = struct{}{}
 			}
@@ -336,13 +446,13 @@ func (i *refindices) insertPrefixes(rule *Rule, ref Ref, prefixes []String) {
 	}
 
 	indices := i.rules[rule]
-	for _, prefix := range prefixes {
-		if _, ok := seen[prefix]; ok {
+	for _, base := range bases {
+		if _, ok := seen[base]; ok {
 			continue
 		}
-		seen[prefix] = struct{}{}
+		seen[base] = struct{}{}
 		concrete++
-		indices = append(indices, &refindex{Ref: ref, Value: prefix, Prefix: true})
+		indices = append(indices, &refindex{Ref: ref, Value: base, Affix: a})
 	}
 	i.rules[rule] = indices
 

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -174,6 +174,29 @@ func reverseString(s string) string {
 	return util.ByteSliceToString(b)
 }
 
+// compact releases the spare capacity in the edge slices. Edges arrive in
+// arbitrary order, so they are placed by insertion and grow the way append does
+// -- which leaves 60% of the slots unused across a large prefix set -- and
+// nothing inserts once the index is built. slices.Clip only caps the capacity;
+// releasing the block means copying out of it.
+func (p *prefixTrie) compact() {
+	if p == nil {
+		return
+	}
+
+	if cap(p.edges) > len(p.edges) {
+		exact := make([]prefixEdge, len(p.edges))
+		copy(exact, p.edges)
+		p.edges = exact
+	}
+
+	p.child.compact()
+
+	for _, edge := range p.edges {
+		edge.node.compact()
+	}
+}
+
 func (p *prefixTrie) do(walker trieWalker) {
 	if p == nil {
 		return

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -214,7 +214,7 @@ func (p *prefixTrie) traverseUnknown(resolver ValueResolver, tr *trieTraversalRe
 		return nil
 	}
 
-	if err := p.child.traverseUnknown(resolver, tr); err != nil {
+	if err := p.child.Traverse(resolver, tr); err != nil {
 		return err
 	}
 
@@ -273,33 +273,29 @@ func commonPrefixLen(a, b string) int {
 // InsertPrefix records that the rules below this node require the value at ref
 // to be a string starting with prefix.
 func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
-	if node.next == nil {
-		node.next = newTrieNodeImpl()
-		node.next.levelDetail().ref = ref
-	}
+	level := node.level()
+	level.ref = ref
 
 	s, ok := prefix.(String)
 	if !ok {
 		panic("illegal prefix value")
 	}
 
-	return node.next.affixTrie(affixPrefix).insert(string(s))
+	return level.affixTrie(affixPrefix).insert(string(s))
 }
 
 // InsertSuffix records that the rules below this node require the value at ref
 // to be a string ending with suffix.
 func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
-	if node.next == nil {
-		node.next = newTrieNodeImpl()
-		node.next.levelDetail().ref = ref
-	}
+	level := node.level()
+	level.ref = ref
 
 	s, ok := suffix.(String)
 	if !ok {
 		panic("illegal suffix value")
 	}
 
-	return node.next.affixTrie(affixSuffix).insert(reverseString(string(s)))
+	return level.affixTrie(affixSuffix).insert(reverseString(string(s)))
 }
 
 // traversePrefixes visits the rules whose prefix constraints value satisfies.
@@ -309,8 +305,8 @@ func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
 // a collection is tested element by element -- the same way a scalar constraint
 // is matched against the members of a collection (see
 // traverseCollectionMembership).
-func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
-	prefixes := node.prefixes()
+func (d *levelDetail) traversePrefixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+	prefixes := d.prefixes
 	if prefixes == nil {
 		return nil
 	}
@@ -342,8 +338,8 @@ func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversal
 
 // traverseSuffixes visits the rules whose suffix constraints value satisfies.
 // A collection is tested element by element, as for prefixes.
-func (node *trieNode) traverseSuffixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
-	suffixes := node.suffixes()
+func (d *levelDetail) traverseSuffixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
+	suffixes := d.suffixes
 	if suffixes == nil {
 		return nil
 	}

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -38,7 +38,10 @@ type prefixTrie struct {
 
 type prefixEdge struct {
 	label string
-	node  *prefixTrie
+	// node is the trie under this edge; leaf stands in for it when nothing is
+	// recorded past the edge's label, which is almost every edge.
+	node *prefixTrie
+	leaf *trieNode
 }
 
 // edge locates the edge labelled with first byte b, or the position a new one
@@ -65,21 +68,36 @@ func (p *prefixTrie) insert(prefix string) *trieNode {
 
 		pos, found := node.edge(prefix[0])
 		if !found {
-			leaf := &prefixTrie{child: newTrieNodeImpl()}
-			node.edges = slices.Insert(node.edges, pos, prefixEdge{label: prefix, node: leaf})
-			return leaf.child
+			leaf := newTrieNodeImpl()
+			node.edges = slices.Insert(node.edges, pos, prefixEdge{label: prefix, leaf: leaf})
+			return leaf
 		}
 
 		edge := node.edges[pos]
 		common := commonPrefixLen(edge.label, prefix)
 
+		switch {
 		// The two diverge inside this edge -- "/api/v1" meeting "/api/v2" --
 		// so the edge is split where they stop agreeing and what used to hang
-		// off it moves down onto the tail.
-		if common < len(edge.label) {
+		// off it moves down onto the tail, whichever kind it is.
+		case common < len(edge.label):
+			tail := prefixEdge{label: edge.label[common:], node: edge.node, leaf: edge.leaf}
 			node.edges[pos] = prefixEdge{
 				label: edge.label[:common],
-				node:  &prefixTrie{edges: []prefixEdge{{label: edge.label[common:], node: edge.node}}},
+				node:  &prefixTrie{edges: []prefixEdge{tail}},
+			}
+
+		// The prefix ends where an edge does with nothing past it, so its
+		// continuation is already the answer.
+		case common == len(prefix) && edge.leaf != nil:
+			return edge.leaf
+
+		// Something is recorded past the edge now, so its continuation becomes
+		// the child of a trie of its own.
+		case edge.node == nil:
+			node.edges[pos] = prefixEdge{
+				label: edge.label,
+				node:  &prefixTrie{child: edge.leaf},
 			}
 		}
 
@@ -114,6 +132,9 @@ func (p *prefixTrie) traverse(s string, resolver ValueResolver, tr *trieTraversa
 		}
 
 		s = s[len(edge.label):]
+		if edge.node == nil {
+			return edge.leaf.Traverse(resolver, tr)
+		}
 		node = edge.node
 	}
 
@@ -146,6 +167,9 @@ func (p *prefixTrie) traverseSuffix(s string, resolver ValueResolver, tr *trieTr
 		}
 
 		s = s[:len(s)-len(edge.label)]
+		if edge.node == nil {
+			return edge.leaf.Traverse(resolver, tr)
+		}
 		node = edge.node
 	}
 
@@ -194,6 +218,7 @@ func (p *prefixTrie) compact() {
 
 	for _, edge := range p.edges {
 		edge.node.compact()
+		edge.leaf.compact()
 	}
 }
 
@@ -206,6 +231,7 @@ func (p *prefixTrie) do(walker trieWalker) {
 
 	for _, edge := range p.edges {
 		edge.node.do(walker)
+		edge.leaf.Do(walker)
 	}
 }
 
@@ -220,6 +246,9 @@ func (p *prefixTrie) traverseUnknown(resolver ValueResolver, tr *trieTraversalRe
 
 	for _, edge := range p.edges {
 		if err := edge.node.traverseUnknown(resolver, tr); err != nil {
+			return err
+		}
+		if err := edge.leaf.Traverse(resolver, tr); err != nil {
 			return err
 		}
 	}
@@ -252,6 +281,10 @@ func (p *prefixTrie) walk() []prefixEntry {
 			entries = append(entries, prefixEntry{prefix: prefix, node: node.child})
 		}
 		for _, edge := range node.edges {
+			if edge.node == nil {
+				entries = append(entries, prefixEntry{prefix: prefix + edge.label, node: edge.leaf})
+				continue
+			}
 			collect(edge.node, prefix+edge.label)
 		}
 	}

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -5,7 +5,6 @@
 package ast
 
 import (
-	"errors"
 	"slices"
 
 	"github.com/open-policy-agent/opa/v1/util"
@@ -414,16 +413,11 @@ func (i *refindices) updateAnyAffixMatch(rule *Rule, expr *Expr, constants map[V
 }
 
 // insertAffixes records a whole base collection at once, for either end of the
-// value. insert() rescans the rule's indices on every call, which is fine for
-// the handful an ordinary rule contributes but quadratic for the thousands
-// strings.any_prefix_match exists to carry, so the scan happens once here
-// instead.
-//
-// insertMembers is the same function for `in`. They stay apart because a base
-// is always strings and can dedup in a plain map, where `in` holds arbitrary
-// values and needs a HasherMap; one shared copy costs this path 27% of its
-// build.
-func (i *refindices) insertAffixes(rule *Rule, ref Ref, bases []String, a affix) {
+// value. insert() rescans the rule's indices on every call, which is quadratic
+// over the thousands strings.any_prefix_match carries, so the scan happens once
+// here instead. insertMembers is the same for `in`; the two dedup on different
+// key types.
+func (i *refindices) insertAffixes(rule *Rule, ref Ref, bases []Value, a affix) {
 	i.countN(ref, len(bases))
 
 	// concrete counts the values this rule already reaches ref by that survive
@@ -445,16 +439,26 @@ func (i *refindices) insertAffixes(rule *Rule, ref Ref, bases []String, a affix)
 		}
 	}
 
-	indices := i.rules[rule]
+	// One refindex per base, laid down in a single block rather than allocated
+	// one at a time: a base collection runs to thousands of them. Duplicates
+	// leave slack at the end of the block, which the reslice below drops.
+	pos := len(i.rules[rule])
+	indices := util.GrowPtrSlice(i.rules[rule], len(bases))
+
 	for _, base := range bases {
-		if _, ok := seen[base]; ok {
+		// groundStrings has established that every base is a String, and hands
+		// the Term's own Value over so that refindex.Value costs no second box.
+		key := base.(String)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[base] = struct{}{}
+		seen[key] = struct{}{}
 		concrete++
-		indices = append(indices, &refindex{Ref: ref, Value: base, Affix: a})
+
+		*indices[pos] = refindex{Ref: ref, Value: base, Affix: a}
+		pos++
 	}
-	i.rules[rule] = indices
+	i.rules[rule] = indices[:pos]
 
 	if concrete > 1 {
 		i.alternate(ref)
@@ -478,36 +482,39 @@ func constantString(term *Term, constants map[Var]Value) (String, bool) {
 }
 
 // groundStrings returns the members of an array or set literal, and reports
-// false unless every one of them is a string.
-func groundStrings(v Value) ([]String, bool) {
-	var iter func(func(*Term) error) error
+// false unless every one of them is a string. The member's own Value is what
+// comes back, not the String inside it: every caller puts it straight into a
+// refindex, and a Term is already holding it boxed.
+func groundStrings(v Value) ([]Value, bool) {
+	var (
+		until func(func(*Term) bool) bool
+		n     int
+	)
 
 	switch col := v.(type) {
 	case *Array:
-		iter = col.Iter
+		until, n = col.Until, col.Len()
 	case Set:
-		iter = col.Iter
+		until, n = col.Until, col.Len()
 	default:
 		return nil, false
 	}
 
-	var out []String
-	err := iter(func(t *Term) error {
-		s, ok := t.Value.(String)
-		if !ok {
-			return errNotAString
-		}
-		out = append(out, s)
-		return nil
-	})
+	// The base of a strings.any_prefix_match runs to thousands of strings, so
+	// the length is worth taking off the collection rather than growing into.
+	out := make([]Value, 0, n)
 
-	if err != nil {
+	// Until stops on the first member that is not a string, and reports having
+	// stopped -- which is the whole of "unless every one of them is a string".
+	if until(func(t *Term) bool {
+		_, ok := t.Value.(String)
+		if ok {
+			out = append(out, t.Value)
+		}
+		return !ok
+	}) {
 		return nil, false
 	}
 
 	return out, true
 }
-
-// errNotAString stops the iteration in groundStrings; it never reaches a
-// caller.
-var errNotAString = errors.New("not a string")

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -478,7 +478,7 @@ func (i *refindices) insertAffixes(rule *Rule, ref Ref, bases []Value, a affix) 
 	i.rules[rule] = indices[:pos]
 
 	if concrete > 1 {
-		i.alternate(ref)
+		i.alternate(ref, alternationTerminal)
 	}
 }
 

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -275,7 +275,7 @@ func commonPrefixLen(a, b string) int {
 func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
 	if node.next == nil {
 		node.next = newTrieNodeImpl()
-		node.next.ref = ref
+		node.next.levelDetail().ref = ref
 	}
 
 	s, ok := prefix.(String)
@@ -291,7 +291,7 @@ func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
 func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
 	if node.next == nil {
 		node.next = newTrieNodeImpl()
-		node.next.ref = ref
+		node.next.levelDetail().ref = ref
 	}
 
 	s, ok := suffix.(String)

--- a/v1/ast/index_prefix.go
+++ b/v1/ast/index_prefix.go
@@ -121,7 +121,7 @@ func (p *prefixTrie) traverse(s string, resolver ValueResolver, tr *trieTraversa
 }
 
 // traverseSuffix is traverse over the end of s. A suffix trie holds its base
-// strings reversed (see trieNode.suffixes), so the walk consumes s from its
+// strings reversed (see affixTries), so the walk consumes s from its
 // last byte back -- which needs no reversed copy of s to be made per lookup.
 func (p *prefixTrie) traverseSuffix(s string, resolver ValueResolver, tr *trieTraversalResult) error {
 	for node := p; node != nil; {
@@ -260,11 +260,7 @@ func (node *trieNode) InsertPrefix(ref Ref, prefix Value) *trieNode {
 		panic("illegal prefix value")
 	}
 
-	if node.next.prefixes == nil {
-		node.next.prefixes = &prefixTrie{}
-	}
-
-	return node.next.prefixes.insert(string(s))
+	return node.next.affixTrie(affixPrefix).insert(string(s))
 }
 
 // InsertSuffix records that the rules below this node require the value at ref
@@ -280,11 +276,7 @@ func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
 		panic("illegal suffix value")
 	}
 
-	if node.next.suffixes == nil {
-		node.next.suffixes = &prefixTrie{}
-	}
-
-	return node.next.suffixes.insert(reverseString(string(s)))
+	return node.next.affixTrie(affixSuffix).insert(reverseString(string(s)))
 }
 
 // traversePrefixes visits the rules whose prefix constraints value satisfies.
@@ -295,17 +287,18 @@ func (node *trieNode) InsertSuffix(ref Ref, suffix Value) *trieNode {
 // is matched against the members of a collection (see
 // traverseCollectionMembership).
 func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
-	if node.prefixes == nil {
+	prefixes := node.prefixes()
+	if prefixes == nil {
 		return nil
 	}
 
 	if s, ok := value.(String); ok {
-		return node.prefixes.traverse(string(s), resolver, tr)
+		return prefixes.traverse(string(s), resolver, tr)
 	}
 
 	checkMember := func(t *Term) error {
 		if s, ok := t.Value.(String); ok {
-			return node.prefixes.traverse(string(s), resolver, tr)
+			return prefixes.traverse(string(s), resolver, tr)
 		}
 		return nil
 	}
@@ -327,17 +320,18 @@ func (node *trieNode) traversePrefixes(resolver ValueResolver, tr *trieTraversal
 // traverseSuffixes visits the rules whose suffix constraints value satisfies.
 // A collection is tested element by element, as for prefixes.
 func (node *trieNode) traverseSuffixes(resolver ValueResolver, tr *trieTraversalResult, value Value) error {
-	if node.suffixes == nil {
+	suffixes := node.suffixes()
+	if suffixes == nil {
 		return nil
 	}
 
 	if s, ok := value.(String); ok {
-		return node.suffixes.traverseSuffix(string(s), resolver, tr)
+		return suffixes.traverseSuffix(string(s), resolver, tr)
 	}
 
 	checkMember := func(t *Term) error {
 		if s, ok := t.Value.(String); ok {
-			return node.suffixes.traverseSuffix(string(s), resolver, tr)
+			return suffixes.traverseSuffix(string(s), resolver, tr)
 		}
 		return nil
 	}

--- a/v1/ast/index_prefix_bench_test.go
+++ b/v1/ast/index_prefix_bench_test.go
@@ -40,9 +40,9 @@ var prefixGrids = []prefixGrid{
 // dimension.
 //
 //	                          any_prefix_match              startswith
-//	rules=1/prefixes=10000       1911242 ns    4.7 MB     5189837 ns    6.0 MB
-//	rules=10/prefixes=1000       1858745 ns    4.7 MB     5440199 ns    6.0 MB
-//	rules=250/prefixes=10000   499855312 ns   1172 MB  2252453729 ns   1518 MB
+//	rules=1/prefixes=10000       1779341 ns    4.2 MB     4988703 ns    5.6 MB
+//	rules=10/prefixes=1000       1777141 ns    4.2 MB     5087124 ns    5.6 MB
+//	rules=250/prefixes=10000   484128062 ns   1052 MB  2257324250 ns   1398 MB
 //
 // The first two rows hold 10000 prefixes each, split two ways, and cost the
 // same; the third holds 250 times as many and costs 250 times as much.

--- a/v1/ast/index_prefix_bench_test.go
+++ b/v1/ast/index_prefix_bench_test.go
@@ -40,9 +40,9 @@ var prefixGrids = []prefixGrid{
 // dimension.
 //
 //	                          any_prefix_match              startswith
-//	rules=1/prefixes=10000       2322533 ns    5.5 MB     5731426 ns    6.1 MB
-//	rules=10/prefixes=1000       2205267 ns    5.1 MB     5917098 ns    6.1 MB
-//	rules=250/prefixes=10000   577763666 ns   1387 MB  2344970750 ns   1531 MB
+//	rules=1/prefixes=10000       1907915 ns    4.7 MB     5029604 ns    6.1 MB
+//	rules=10/prefixes=1000       1850371 ns    4.7 MB     5052827 ns    6.1 MB
+//	rules=250/prefixes=10000   480645292 ns   1186 MB  2247822750 ns   1531 MB
 //
 // The first two rows hold 10000 prefixes each, split two ways, and cost the
 // same; the third holds 250 times as many and costs 250 times as much.

--- a/v1/ast/index_prefix_bench_test.go
+++ b/v1/ast/index_prefix_bench_test.go
@@ -40,9 +40,9 @@ var prefixGrids = []prefixGrid{
 // dimension.
 //
 //	                          any_prefix_match              startswith
-//	rules=1/prefixes=10000       1907915 ns    4.7 MB     5029604 ns    6.1 MB
-//	rules=10/prefixes=1000       1850371 ns    4.7 MB     5052827 ns    6.1 MB
-//	rules=250/prefixes=10000   480645292 ns   1186 MB  2247822750 ns   1531 MB
+//	rules=1/prefixes=10000       1911242 ns    4.7 MB     5189837 ns    6.0 MB
+//	rules=10/prefixes=1000       1858745 ns    4.7 MB     5440199 ns    6.0 MB
+//	rules=250/prefixes=10000   499855312 ns   1172 MB  2252453729 ns   1518 MB
 //
 // The first two rows hold 10000 prefixes each, split two ways, and cost the
 // same; the third holds 250 times as many and costs 250 times as much.
@@ -51,9 +51,11 @@ var prefixGrids = []prefixGrid{
 // single rule of 10000 prefixes -- because refindices.insert rescans the rule's
 // indices on every call. See insertPrefixes.
 //
-// The B/op column is close to what the trie costs to hold, since nothing it
-// allocates is released. At the top of the grid the startswith ruleset is 2.5M
-// rules and takes gigabytes; that ruleset is built once, outside the timer.
+// The B/op column is everything the build allocates, which is more than the
+// trie holds: compacting the edge slices copies out of the blocks they grew
+// into and releases those (see prefixTrie.compact). At the top of the grid the
+// startswith ruleset is 2.5M rules and takes gigabytes; that ruleset is built
+// once, outside the timer.
 func BenchmarkBuildPrefixIndex(b *testing.B) {
 	for _, tc := range prefixShapes {
 		b.Run(tc.note, func(b *testing.B) {

--- a/v1/ast/index_prefix_order_test.go
+++ b/v1/ast/index_prefix_order_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// methodPrefixPolicy is the shape this file is about: a rule per (method,
+// prefix set), the way an authorization policy admits a request by what it does
+// and where. The prefix set is the reference the rule reaches by more than one
+// value, so it is where insertPath stops building the rule's path -- and every
+// rule has a second constraint below it.
+func methodPrefixPolicy(methods, perRule int) string {
+	var sb strings.Builder
+
+	sb.WriteString("package test\n\n")
+	for m := range methods {
+		fmt.Fprintf(&sb, "allow if {\n\tinput.method == \"M%d\"\n\tstrings.any_prefix_match(input.path, [", m)
+		for p := range perRule {
+			if p > 0 {
+				sb.WriteString(", ")
+			}
+			fmt.Fprintf(&sb, "%q", fmt.Sprintf("/m%d/p%d/", m, p))
+		}
+		sb.WriteString("])\n}\n\n")
+	}
+
+	return sb.String()
+}
+
+func methodPrefixIndex(tb testing.TB, methods, perRule int) *baseDocEqIndex {
+	tb.Helper()
+
+	c := MustCompileModules(map[string]string{"test.rego": methodPrefixPolicy(methods, perRule)})
+	index := newBaseDocEqIndex(func(Ref) bool { return false })
+	if !index.Build(c.Modules["test.rego"].Rules) {
+		tb.Fatal("expected index build to succeed")
+	}
+
+	return index
+}
+
+// TestPrefixIndexKeepsSiblingConstraint pins what the ordering buys: a path
+// that one rule's prefix set admits, presented with a method that no rule
+// admits, is not a candidate for anything.
+//
+// Without ranking the prefix reference last (see refindices.alternated) the
+// index would return the rule whose prefixes match, since input.method never
+// made it onto that rule's path.
+func TestPrefixIndexKeepsSiblingConstraint(t *testing.T) {
+	index := methodPrefixIndex(t, 8, 4)
+
+	for _, tc := range []struct {
+		note, input string
+		expected    int
+	}{
+		{
+			note:     "method and prefix both match",
+			input:    `{"method": "M3", "path": "/m3/p2/x"}`,
+			expected: 1,
+		},
+		{
+			// The path is one this policy admits, but not for this method.
+			note:     "prefix matches, method does not",
+			input:    `{"method": "NOPE", "path": "/m3/p2/x"}`,
+			expected: 0,
+		},
+		{
+			note:     "method matches, prefix does not",
+			input:    `{"method": "M3", "path": "/nope/x"}`,
+			expected: 0,
+		},
+		{
+			// The prefixes belong to another method's rule.
+			note:     "method and prefix match different rules",
+			input:    `{"method": "M3", "path": "/m5/p1/x"}`,
+			expected: 0,
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			result, err := index.Lookup(testResolver{input: MustParseTerm(tc.input)})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.Rules) != tc.expected {
+				t.Errorf("expected %d rule(s), got %d", tc.expected, len(result.Rules))
+			}
+		})
+	}
+}
+
+// BenchmarkPrefixIndexLookupSiblingConstraint is the lookup on that policy for
+// a path one rule admits under a method none of them do. What the index has to
+// return is nothing; what it returned before the prefix reference was ranked
+// last is the rule the path matched, because input.method was not on its path.
+//
+//	                            ranked last            by frequency
+//	methods=10/prefixes=10    105 ns  0 rules      226 ns  1 rule
+//	methods=100/prefixes=10   114 ns  0 rules      241 ns  1 rule
+//	methods=100/prefixes=1000 105 ns  0 rules      241 ns  1 rule
+//
+// Both columns walk the same prefix trie; the difference is the level below it.
+// One candidate out of a hundred rules is not much on its own -- the trie was
+// already excluding the other ninety-nine -- and half of what shows here is the
+// candidate the lookup no longer has to collect. It is the rule the caller then
+// does not evaluate that this is for, which costs microseconds rather than
+// nanoseconds; BenchmarkRuleIndexPrefixMatchSibling in topdown measures that.
+func BenchmarkPrefixIndexLookupSiblingConstraint(b *testing.B) {
+	for _, tc := range []struct{ methods, perRule int }{
+		{10, 10}, {100, 10}, {100, 1000},
+	} {
+		b.Run(fmt.Sprintf("methods=%d/prefixes=%d", tc.methods, tc.perRule), func(b *testing.B) {
+			index := methodPrefixIndex(b, tc.methods, tc.perRule)
+			resolver := testResolver{input: MustParseTerm(`{"method": "NOPE", "path": "/m3/p2/x"}`)}
+
+			result, err := index.Lookup(resolver)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+			b.Logf("candidate rules returned: %d", len(result.Rules))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if _, err := index.Lookup(resolver); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/v1/ast/index_prefix_order_test.go
+++ b/v1/ast/index_prefix_order_test.go
@@ -10,11 +10,24 @@ import (
 	"testing"
 )
 
-// methodPrefixPolicy is the shape this file is about: a rule per (method,
+// methodPrefixPolicy is the shape this file is about -- a rule per (method,
 // prefix set), the way an authorization policy admits a request by what it does
-// and where. The prefix set is the reference the rule reaches by more than one
-// value, so it is where insertPath stops building the rule's path -- and every
-// rule has a second constraint below it.
+// and where. At methods=2, perRule=2:
+//
+//	allow if {
+//		input.method == "M0"
+//		strings.any_prefix_match(input.path, ["/m0/p0/", "/m0/p1/"])
+//	}
+//
+//	allow if {
+//		input.method == "M1"
+//		strings.any_prefix_match(input.path, ["/m1/p0/", "/m1/p1/"])
+//	}
+//
+// A rule's path ends at the prefix set, since affixes cannot converge, so
+// whatever it constrains after that goes unindexed. That is why the prefix
+// reference has to be the last level and input.method a level above it: the
+// other way round, no rule would have its method on its path at all.
 func methodPrefixPolicy(methods, perRule int) string {
 	var sb strings.Builder
 

--- a/v1/ast/index_prefix_test.go
+++ b/v1/ast/index_prefix_test.go
@@ -403,7 +403,7 @@ func TestIndexPrefixTrieStaysCompressed(t *testing.T) {
 		t.Fatalf("expected a baseDocEqIndex, got %T", index)
 	}
 
-	prefixes := root.root.next.prefixes
+	prefixes := root.root.next.prefixes()
 	if prefixes == nil {
 		t.Fatal("expected the prefixes to be indexed")
 	}

--- a/v1/ast/index_prefix_test.go
+++ b/v1/ast/index_prefix_test.go
@@ -403,7 +403,7 @@ func TestIndexPrefixTrieStaysCompressed(t *testing.T) {
 		t.Fatalf("expected a baseDocEqIndex, got %T", index)
 	}
 
-	prefixes := root.root.next.prefixes()
+	prefixes := root.root.next.prefixes
 	if prefixes == nil {
 		t.Fatal("expected the prefixes to be indexed")
 	}

--- a/v1/ast/index_suffix_test.go
+++ b/v1/ast/index_suffix_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package ast
+
+import "testing"
+
+// TestSuffixIndexing covers what recording a base reversed makes of it. What a
+// suffix statement has to be for the indexer to take it at all is shared with
+// the prefix statements, and tested with them.
+func TestSuffixIndexing(t *testing.T) {
+	c := MustCompileModules(map[string]string{"test.rego": `package test
+
+p if endswith(input.path, ".gz")
+
+p if endswith(input.path, ".tar.gz")
+
+p if strings.any_suffix_match(input.path, [".go", ".rego"])
+`})
+
+	index := newBaseDocEqIndex(func(Ref) bool { return false })
+	if !index.Build(c.Modules["test.rego"].Rules) {
+		t.Fatal("expected index build to succeed")
+	}
+
+	for _, tc := range []struct {
+		input string
+		exp   int
+	}{
+		// Every base the value ends with, not just one: ".tar.gz" and ".gz"
+		// both hold here, and share a stem reversed.
+		{`{"path": "a.tar.gz"}`, 2},
+		{`{"path": "a.gz"}`, 1},
+		{`{"path": "main.go"}`, 1},
+		{`{"path": "policy.rego"}`, 1},
+		{`{"path": "main.rs"}`, 0},
+		// Anchored to the end, and to the end of the value rather than the end
+		// of the base: "gz" is what ".gz" ends with, not the other way round.
+		{`{"path": "a.tar.gzip"}`, 0},
+		{`{"path": "gz"}`, 0},
+		{`{"path": ""}`, 0},
+		// The value is the base exactly, so the walk ends with nothing left of
+		// it on the node the rules hang off -- which is visited before the walk
+		// notices it has run out.
+		{`{"path": ".gz"}`, 1},
+		// Shares its last byte with ".gz" and nothing else. An edge is found on
+		// that byte alone, so the rest of its label is what rules the value out.
+		{`{"path": "abz"}`, 0},
+		{`{"path": "z"}`, 0},
+		// Read backwards it would match, which is the mistake to make here.
+		{`{"path": "zg.rat.a"}`, 0},
+		// As for prefixes, a value that is not a string satisfies no suffix.
+		{`{"path": 42}`, 0},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := index.Lookup(testResolver{input: MustParseTerm(tc.input)})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.Rules) != tc.exp {
+				t.Errorf("expected %d candidate(s), got %d", tc.exp, len(result.Rules))
+			}
+		})
+	}
+}

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -2426,3 +2426,190 @@ r = local0 if {
 		})
 	}
 }
+
+// TestBaseDocEqIndexingAlternatingRefs covers a rule that reaches two
+// references by several values each. insertPath used to stop a rule's path at
+// the first of them -- it hung the rule off every alternative and returned --
+// so the second was not indexed and every rule stayed a candidate for it.
+// Ranking such references last cannot help: both are ranked last, and one is
+// still first of the two.
+func TestBaseDocEqIndexingAlternatingRefs(t *testing.T) {
+	lookup := func(t *testing.T, index *baseDocEqIndex, resolver testResolver) int {
+		t.Helper()
+		result, err := index.Lookup(resolver)
+		if err != nil {
+			t.Fatalf("unexpected error during index lookup: %v", err)
+		}
+		return len(result.Rules)
+	}
+
+	// `x in <collection>` reaches the indexer as internal.member_2, which is
+	// the compiler's doing, so these go through it rather than the parser.
+	build := func(t *testing.T, module string) *baseDocEqIndex {
+		t.Helper()
+		c := MustCompileModules(map[string]string{"test.rego": module})
+		index := newBaseDocEqIndex(func(Ref) bool { return false })
+		if !index.Build(c.Modules["test.rego"].Rules) {
+			t.Fatal("expected index build to succeed")
+		}
+		return index
+	}
+
+	t.Run("both references prune", func(t *testing.T) {
+		index := build(t, `package test
+		p if {
+			input.subject in ["alice", "bob"]
+			input.action in ["read", "list"]
+		}
+		p if {
+			input.subject in ["alice", "carol"]
+			input.action in ["write", "delete"]
+		}`)
+
+		for _, tc := range []struct {
+			input string
+			exp   int
+		}{
+			{`{"subject": "alice", "action": "read"}`, 1},
+			{`{"subject": "alice", "action": "write"}`, 1},
+			{`{"subject": "bob", "action": "read"}`, 1},
+			{`{"subject": "bob", "action": "write"}`, 0},  // bob is not in the second rule
+			{`{"subject": "carol", "action": "read"}`, 0}, // carol is not in the first
+			{`{"subject": "alice", "action": "nope"}`, 0}, // neither action matches
+			{`{"subject": "dave", "action": "read"}`, 0},  // neither subject matches
+		} {
+			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+			}
+		}
+	})
+
+	t.Run("three references prune", func(t *testing.T) {
+		index := build(t, `package test
+		p if {
+			input.a in [1, 2]
+			input.b in [3, 4]
+			input.c in [5, 6]
+		}`)
+
+		for _, tc := range []struct {
+			input string
+			exp   int
+		}{
+			{`{"a": 1, "b": 3, "c": 5}`, 1},
+			{`{"a": 2, "b": 4, "c": 6}`, 1},
+			{`{"a": 1, "b": 3, "c": 7}`, 0},
+			{`{"a": 1, "b": 9, "c": 5}`, 0},
+			{`{"a": 9, "b": 3, "c": 5}`, 0},
+		} {
+			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+			}
+		}
+	})
+
+	// An affix's alternatives are leaves of the prefix trie, which cannot point
+	// several of them at one node, so a rule that reaches a reference by several
+	// of them still stops there. Two such references and the second is unindexed,
+	// so the lookup over-approximates -- it must never miss a rule that can hold.
+	t.Run("two references reached by affixes still stop the path", func(t *testing.T) {
+		index := build(t, `package test
+		p if {
+			strings.any_prefix_match(input.path, ["/a", "/b"])
+			strings.any_suffix_match(input.name, [".go", ".rego"])
+		}`)
+
+		for _, tc := range []struct {
+			input string
+			exp   int
+		}{
+			{`{"path": "/a/x", "name": "q.go"}`, 1},
+			{`{"path": "/c/x", "name": "q.go"}`, 0},
+			// The suffixes are not indexed below the prefixes, so the rule is
+			// still a candidate. Over-approximating is sound; missing it is not.
+			{`{"path": "/a/x", "name": "q.txt"}`, 1},
+		} {
+			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+			}
+		}
+	})
+
+	// A terminal reference is ranked after a converging one, so the `in` gets to
+	// converge and the affixes end the path once everything else is on it. Which
+	// the author wrote first does not decide it.
+	t.Run("an affix and an in collection are both indexed, either order", func(t *testing.T) {
+		for _, module := range []string{
+			`package test
+			p if {
+				strings.any_prefix_match(input.path, ["/a", "/b"])
+				input.x in {1, 2}
+			}`,
+			`package test
+			p if {
+				input.x in {1, 2}
+				strings.any_prefix_match(input.path, ["/a", "/b"])
+			}`,
+		} {
+			index := build(t, module)
+
+			for _, tc := range []struct {
+				input string
+				exp   int
+			}{
+				{`{"path": "/a/z", "x": 1}`, 1},
+				{`{"path": "/a/z", "x": 9}`, 0}, // the `in` prunes
+				{`{"path": "/c/z", "x": 1}`, 0}, // the prefixes prune
+			} {
+				if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+					t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+				}
+			}
+		}
+	})
+
+	// One affix is a single value, so it stays on the path and the alternatives
+	// that follow it are the ones that stop it.
+	t.Run("a single affix is indexed alongside the alternatives", func(t *testing.T) {
+		index := build(t, `package test
+		p if {
+			input.subject in ["alice", "bob"]
+			startswith(input.path, "/v1/")
+		}`)
+
+		for _, tc := range []struct {
+			input string
+			exp   int
+		}{
+			{`{"subject": "alice", "path": "/v1/things"}`, 1},
+			{`{"subject": "dave", "path": "/v1/things"}`, 0},
+			{`{"subject": "alice", "path": "/v2/things"}`, 0},
+		} {
+			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+			}
+		}
+	})
+
+	// The membership is the only thing the rule constrains, so there is no path
+	// to continue and the alternatives stay separate children -- which rules
+	// with overlapping collections share.
+	t.Run("nothing below the alternatives", func(t *testing.T) {
+		index := build(t, `package test
+		p if input.subject in ["alice", "bob"]
+		p if input.subject in ["alice", "carol"]`)
+
+		for _, tc := range []struct {
+			input string
+			exp   int
+		}{
+			{`{"subject": "alice"}`, 2},
+			{`{"subject": "bob"}`, 1},
+			{`{"subject": "dave"}`, 0},
+		} {
+			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
+				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
+			}
+		}
+	})
+}

--- a/v1/ast/index_test.go
+++ b/v1/ast/index_test.go
@@ -2428,11 +2428,14 @@ r = local0 if {
 }
 
 // TestBaseDocEqIndexingAlternatingRefs covers a rule that reaches two
-// references by several values each. insertPath used to stop a rule's path at
-// the first of them -- it hung the rule off every alternative and returned --
-// so the second was not indexed and every rule stayed a candidate for it.
-// Ranking such references last cannot help: both are ranked last, and one is
-// still first of the two.
+// references by several scalar values each. The first of them converges --
+// every alternative keys to one node, which the rest of the path is built from
+// -- so the second is indexed too. Ranking such references last is no help
+// here: both are ranked last, and one is still first of the two.
+//
+// Only scalars converge. Affixes and composite values end the rule's path, so
+// only the first of two such references is indexed; see oneAffixEnd and
+// isComposite.
 func TestBaseDocEqIndexingAlternatingRefs(t *testing.T) {
 	lookup := func(t *testing.T, index *baseDocEqIndex, resolver testResolver) int {
 		t.Helper()
@@ -2532,6 +2535,58 @@ func TestBaseDocEqIndexingAlternatingRefs(t *testing.T) {
 			if act := lookup(t, index, testResolver{input: MustParseTerm(tc.input)}); tc.exp != act {
 				t.Errorf("%s: expected %d rule(s), got %d", tc.input, tc.exp, act)
 			}
+		}
+	})
+
+	// Both ends of one reference are a conjunction the level cannot test: the
+	// tries hold leaves, so hanging the rule off both would admit it on either,
+	// which is looser than the rule. One end is indexed and the other left to
+	// evaluation -- the end whose shortest base string is longest, since that is
+	// the one admitting least. See oneAffixEnd.
+	t.Run("one reference reached by affixes at both ends indexes one end", func(t *testing.T) {
+		for _, tc := range []struct {
+			note   string
+			module string
+			// indexed names the end the lookups below expect to be tested.
+			cases map[string]int
+		}{
+			{
+				note: "suffixes are longer, so the suffixes are indexed",
+				module: `package test
+				p if {
+					strings.any_prefix_match(input.path, ["/a", "/b"])
+					strings.any_suffix_match(input.path, [".go", ".rego"])
+				}`,
+				cases: map[string]int{
+					`{"path": "/a/x.go"}`:  1,
+					`{"path": "/c/x.go"}`:  1,
+					`{"path": "/a/x.txt"}`: 0,
+					`{"path": "/c/x.txt"}`: 0,
+				},
+			},
+			{
+				// Counting the base strings would keep the single prefix here,
+				// and every absolute path matches "/".
+				note: "one short prefix loses to several longer suffixes",
+				module: `package test
+				p if {
+					strings.any_prefix_match(input.path, ["/"])
+					strings.any_suffix_match(input.path, [".go", ".rego"])
+				}`,
+				cases: map[string]int{
+					`{"path": "/x.go"}`:  1,
+					`{"path": "/x.txt"}`: 0,
+				},
+			},
+		} {
+			t.Run(tc.note, func(t *testing.T) {
+				index := build(t, tc.module)
+				for input, exp := range tc.cases {
+					if act := lookup(t, index, testResolver{input: MustParseTerm(input)}); exp != act {
+						t.Errorf("%s: expected %d rule(s), got %d", input, exp, act)
+					}
+				}
+			})
 		}
 	})
 

--- a/v1/ast/interning.go
+++ b/v1/ast/interning.go
@@ -19,6 +19,8 @@ type interned struct {
 
 type internedRefs struct {
 	AnyPrefixMatch    Ref
+	AnySuffixMatch    Ref
+	EndsWith          Ref
 	Equal             Ref
 	Equality          Ref
 	GlobMatch         Ref
@@ -42,6 +44,8 @@ var (
 	Interned = &interned{
 		Refs: &internedRefs{
 			AnyPrefixMatch:    AnyPrefixMatch.Ref(),
+			AnySuffixMatch:    AnySuffixMatch.Ref(),
+			EndsWith:          EndsWith.Ref(),
 			Equal:             Equal.Ref(),
 			Equality:          Equality.Ref(),
 			GlobMatch:         GlobMatch.Ref(),

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1624,6 +1624,11 @@ func (arr *Array) set(i int, v *Term) {
 // indicates the end of the array. The returned value array is not a
 // copy and any modifications to either of arrays may be reflected to
 // the other.
+//
+// Set on the returned slice writes through to arr's element and to its
+// hash, but not to arr's cached sum of those hashes, so arr.Hash() is
+// stale from then on and anything holding arr as a map key or set member
+// stops finding it. Copy the slice before writing to it.
 func (arr *Array) Slice(i, j int) *Array {
 	var elems []*Term
 	var hashs []int

--- a/v1/test/cases/testdata/v1/indexing/alternatives.yaml
+++ b/v1/test/cases/testdata/v1/indexing/alternatives.yaml
@@ -1,0 +1,46 @@
+---
+cases:
+  - note: indexing on a reference reached by several values, with more constrained below
+    query: data.indexing.p = x
+    modules:
+      - |
+        package indexing
+
+        p if {
+        	"a" in input.x
+        	"b" in input.x
+        	1 in input.y
+        	2 in input.y
+        }
+    data: {}
+    input_term: '{"x": ["a", "b"], "y": [1, 2]}'
+    want_result:
+      - x: true
+  - note: indexing on two references each reached by several composite values
+    query: data.indexing.q = x
+    modules:
+      - |
+        package indexing
+
+        q if {
+        	input.k in [[1], [2]]
+        	input.n in [[3], [4]]
+        }
+    data: {}
+    input_term: '{"k": [1], "n": [3]}'
+    want_result:
+      - x: true
+  - note: indexing on a reference reached by several object values
+    query: data.indexing.r = x
+    modules:
+      - |
+        package indexing
+
+        r if {
+        	input.k in [{"a": 1}, {"b": 2}]
+        	input.n in [{"c": 3}, {"d": 4}]
+        }
+    data: {}
+    input_term: '{"k": {"a": 1}, "n": {"c": 3}}'
+    want_result:
+      - x: true

--- a/v1/topdown/index_prefix_bench_test.go
+++ b/v1/topdown/index_prefix_bench_test.go
@@ -247,3 +247,138 @@ func writePrefixList(sb *strings.Builder, prefixes []string) {
 func benchPrefix(i int) string {
 	return fmt.Sprintf("/service/v1/tenant/%07d", i)
 }
+
+// siblingShapes write the rule's second, single-valued constraint either side
+// of its prefix set. Which comes first decides what a candidate costs when the
+// index hands topdown a rule that cannot hold: the method comparison fails on
+// the first expression, the prefix scan walks the rule's whole base first.
+var siblingShapes = []struct {
+	note        string
+	prefixFirst bool
+}{
+	{"method-first", false},
+	{"prefix-first", true},
+}
+
+// BenchmarkRuleIndexPrefixMatchSibling is the shape the rest of this file does
+// not have: a rule that constrains something besides its prefix set. Every rule
+// here admits a request by (method, path prefix), the way an authorization
+// policy does, and the query presents a path one rule admits under a method
+// none of them do.
+//
+// The prefix set gives the rule several values for input.path, which is where
+// insertPath stops building its path (see refindices.alternated) -- so whether
+// input.method is indexed at all depends on the two being ordered the right way
+// round. Where BenchmarkRuleIndexPrefixMatch measures the trie walk, this
+// measures what that ordering is worth: the rule topdown does not evaluate.
+//
+//	                 ranked last            by frequency
+//	method-first     527 ns  1097 B     1152 ns  2235 B
+//	prefix-first     532 ns  1097 B     2345 ns  4936 B
+//
+// Both shapes hold the same policy and return the same answer. That they cost
+// the same is the point: with input.method indexed the rule is not a candidate,
+// so it no longer matters which of its two constraints the author wrote first.
+// 1097 B and 20 allocs is what a query that reaches no rule at all costs -- the
+// same as the indexing=true rows of BenchmarkRuleIndexPrefixMatch, whose rules
+// have nothing besides their prefix set to be excluded on.
+//
+// Ranked by frequency the prefix reference comes first, because insertPrefixes
+// records one value per base string, so the rule is reached by its prefixes
+// alone and input.method never joins its path. What that costs is then down to
+// which constraint topdown evaluates first: the method comparison fails
+// immediately, the prefix scan walks all 100 base strings before it does.
+func BenchmarkRuleIndexPrefixMatchSibling(b *testing.B) {
+	const (
+		rules   = 250
+		perRule = 100
+	)
+
+	for _, shape := range siblingShapes {
+		b.Run(shape.note, func(b *testing.B) {
+			benchmarkPrefixMatchSibling(b, rules, perRule, shape.prefixFirst)
+		})
+	}
+}
+
+func benchmarkPrefixMatchSibling(b *testing.B, rules, perRule int, prefixFirst bool) {
+	b.Helper()
+
+	ctx := b.Context()
+
+	compiler := ast.NewCompiler()
+	mods := map[string]*ast.Module{
+		"policy": ast.MustParseModule(siblingPolicy(rules, perRule, prefixFirst)),
+	}
+	if compiler.Compile(mods); compiler.Failed() {
+		b.Fatalf("unexpected compiler error: %v", compiler.Errors)
+	}
+
+	store := inmem.New()
+	txn := storage.NewTransactionOrDie(ctx, store)
+
+	// A path the fourth rule admits, under a method no rule admits.
+	input := ast.NewTerm(ast.MustInterfaceToValue(map[string]any{
+		"path":   benchPrefix(3*perRule+7) + "/some/request",
+		"method": "NO_SUCH_METHOD",
+	}))
+
+	query := NewQuery(ast.MustParseBody("data.bench.allow = x")).
+		WithCompiler(compiler).
+		WithStore(store).
+		WithTransaction(txn).
+		WithInput(input).
+		WithIndexing(true)
+
+	rs, err := query.Run(ctx)
+	if err != nil {
+		b.Fatalf("unexpected topdown query error: %v", err)
+	}
+	if len(rs) != 0 {
+		b.Fatalf("expected the query to be undefined, got %v", rs)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := query.Run(ctx); err != nil {
+			b.Fatalf("unexpected topdown query error: %v", err)
+		}
+	}
+}
+
+// siblingPolicy renders a rule per (method, prefix set). The prefixes are
+// distinct across the whole policy, as in prefixMatchPolicy, and each rule
+// takes a method of its own so that a query naming none of them is a miss on
+// every rule.
+func siblingPolicy(rules, perRule int, prefixFirst bool) string {
+	var sb strings.Builder
+	sb.WriteString("package bench\n\nimport rego.v1\n\n")
+
+	batch := make([]string, perRule)
+	next := 0
+
+	for r := range rules {
+		for i := range batch {
+			batch[i] = benchPrefix(next)
+			next++
+		}
+
+		var prefix strings.Builder
+		prefix.WriteString("strings.any_prefix_match(input.path, [")
+		writePrefixList(&prefix, batch)
+		prefix.WriteString("])")
+
+		method := fmt.Sprintf("input.method == %q", fmt.Sprintf("METHOD_%d", r))
+
+		first, second := method, prefix.String()
+		if prefixFirst {
+			first, second = prefix.String(), method
+		}
+
+		fmt.Fprintf(&sb, "allow if {\n\t%s\n\t%s\n}\n\n", first, second)
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
Follow-ups to #9161 

* adds the corresponding suffix matching: `endswith` and `strings.any_suffix_match` using the same trie structure (with edge labels reversed)
* contains a whole lot of small tweaks for memory usage and performance

Please see the individual commits 👇 