### PR TITLE
format: keep parens around a nested two-operand in

### DIFF
--- a/v1/format/format.go
+++ b/v1/format/format.go
@@ -1556,24 +1556,24 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) ([]*
 	var err error
 	switch numCallArgs {
 	case numDeclArgs: // Print infix where result is unassigned (e.g., x != y)
-		comments, err = w.writeTerm(terms[1], comments)
+		comments, err = w.writeInfixOperand(bi, terms[1], comments)
 		if err != nil {
 			return nil, err
 		}
 		w.write(" " + bi.Infix + " ")
-		return w.writeTerm(terms[2], comments)
+		return w.writeInfixOperand(bi, terms[2], comments)
 	case numDeclArgs + 1: // Print infix where result is assigned (e.g., z = x + y)
 		comments, err = w.writeTerm(terms[3], comments)
 		if err != nil {
 			return nil, err
 		}
 		w.write(" " + ast.Equality.Infix + " ")
-		comments, err = w.writeTerm(terms[1], comments)
+		comments, err = w.writeInfixOperand(bi, terms[1], comments)
 		if err != nil {
 			return nil, err
 		}
 		w.write(" " + bi.Infix + " ")
-		comments, err = w.writeTerm(terms[2], comments)
+		comments, err = w.writeInfixOperand(bi, terms[2], comments)
 		if err != nil {
 			return nil, err
 		}
@@ -1583,6 +1583,29 @@ func (w *writer) writeFunctionCall(expr *ast.Expr, comments []*ast.Comment) ([]*
 	// wrong arity even when the assignment notation is used
 	w.errs = append(w.errs, ArityFormatMismatchError(terms[1:], terms[0].String(), terms[0].Location, bi.Decl))
 	return w.writeFunctionCallPlain(terms, comments)
+}
+
+// writeInfixOperand writes term as an operand of the infix operator bi, adding
+// parens when the operand is a two-operand `in` call. `in` binds looser than
+// every infix operator except `=` and `:=` (Parser.parseTermIn sits between
+// parseExpr and parseTermRelation), so written bare such an operand is read back
+// with the enclosing operator inside it: `1 in [1] == true` parses as
+// `internal.member_2(1, equal([1], true))`.
+func (w *writer) writeInfixOperand(bi *ast.Builtin, term *ast.Term, comments []*ast.Comment) ([]*ast.Comment, error) {
+	if bi.Infix != ast.Equality.Infix && bi.Infix != ast.Assign.Infix && isMemberCall(term) {
+		w.parenTerm = term
+	}
+	return w.writeTerm(term, comments)
+}
+
+// isMemberCall reports whether term is a call to the two-operand form of `in`.
+func isMemberCall(term *ast.Term) bool {
+	call, ok := term.Value.(ast.Call)
+	if !ok || len(call) != 3 {
+		return false
+	}
+	ref, ok := call[0].Value.(ast.Ref)
+	return ok && ast.Interned.Refs.Member.Equal(ref)
 }
 
 func (w *writer) writeFunctionCallPlain(terms []*ast.Term, comments []*ast.Comment) ([]*ast.Comment, error) {
@@ -1980,7 +2003,13 @@ func (w *writer) writeCall(parens bool, x ast.Call, loc *ast.Location, comments 
 	if bi.Infix == "in" {
 		// NOTE(sr): `in` requires special handling, mirroring what happens in the parser,
 		// since there can be one or two lhs arguments.
-		return w.writeInOperator(true, x[1:], comments, loc, bi.Decl)
+		//
+		// The three-operand form always needs parens in a term position, or its comma
+		// is read as an element or argument separator. The two-operand form only needs
+		// them where parens says so: as an operand of another infix call it would be
+		// re-associated, but in a collection literal or a call argument it is already
+		// delimited and the parens would be noise.
+		return w.writeInOperator(parens || bi.Decl.Arity() == 3, x[1:], comments, loc, bi.Decl)
 	}
 
 	// TODO(tsandall): improve to consider precedence?
@@ -2028,6 +2057,10 @@ func (w *writer) writeInOperator(parens bool, operands []*ast.Term, comments []*
 	var err error
 	switch len(operands) {
 	case 2:
+		if parens {
+			w.write("(")
+			defer w.write(")")
+		}
 		comments, err = w.writeTermParens(true, operands[0], comments)
 		if err != nil {
 			return nil, err

--- a/v1/format/testfiles/v0/test_in_operator_with_parenthesis.rego
+++ b/v1/format/testfiles/v0/test_in_operator_with_parenthesis.rego
@@ -13,6 +13,12 @@ z {
     { 1, (2 in [2, 2, 2]) }
     f(1, 2 in [2, 2])
     g((1, 2 in [2, 2]))
+    "foo", (2 in {"bar": 2}) in {"foo": true}
+    ("x" in ["x"]), 1 in {true: 1}
+    (1 in [1]) in [true]
+    (1 in [1]) == true
+    true == (1 in [1])
+    y = (1 in [1])
 }
 
 f(_, _) = true

--- a/v1/format/testfiles/v0/test_in_operator_with_parenthesis.rego.formatted
+++ b/v1/format/testfiles/v0/test_in_operator_with_parenthesis.rego.formatted
@@ -13,6 +13,12 @@ z {
 	{1, 2 in [2, 2, 2]}
 	f(1, 2 in [2, 2])
 	g((1, 2 in [2, 2]))
+	"foo", (2 in {"bar": 2}) in {"foo": true}
+	("x" in ["x"]), 1 in {true: 1}
+	(1 in [1]) in [true]
+	(1 in [1]) == true
+	true == (1 in [1])
+	y = 1 in [1]
 }
 
 f(_, _) = true

--- a/v1/format/testfiles/v1/test_in_operator_with_parenthesis.rego
+++ b/v1/format/testfiles/v1/test_in_operator_with_parenthesis.rego
@@ -11,6 +11,12 @@ z if {
     { 1, (2 in [2, 2, 2]) }
     f(1, 2 in [2, 2])
     g((1, 2 in [2, 2]))
+    "foo", (2 in {"bar": 2}) in {"foo": true}
+    ("x" in ["x"]), 1 in {true: 1}
+    (1 in [1]) in [true]
+    (1 in [1]) == true
+    true == (1 in [1])
+    y = (1 in [1])
 }
 
 f(_, _) = true

--- a/v1/format/testfiles/v1/test_in_operator_with_parenthesis.rego.formatted
+++ b/v1/format/testfiles/v1/test_in_operator_with_parenthesis.rego.formatted
@@ -11,6 +11,12 @@ z if {
 	{1, 2 in [2, 2, 2]}
 	f(1, 2 in [2, 2])
 	g((1, 2 in [2, 2]))
+	"foo", (2 in {"bar": 2}) in {"foo": true}
+	("x" in ["x"]), 1 in {true: 1}
+	(1 in [1]) in [true]
+	(1 in [1]) == true
+	true == (1 in [1])
+	y = 1 in [1]
 }
 
 f(_, _) := true


### PR DESCRIPTION
### Why the changes in this PR are needed?

`opa fmt` drops parentheses that decide how an expression is read, so formatting a policy can silently change what it evaluates to.

The tail of #8859 mentions this ("Even the formatter seems to agree, as it 'helpfully' removes the parens I tried to use to enforce the precedence order I expected"). This PR is that half of the issue, not the parser precedence question it opens with. On 855776c:

```console
$ cat p.rego
package p

precedence_in if (1 in [1, 2, 3]) == true

$ opa eval -d p.rego -f raw 'data.p.precedence_in'
true
$ opa fmt p.rego > f.rego && cat f.rego
package p

precedence_in if 1 in [1, 2, 3] == true

$ opa eval -d f.rego -f raw 'data.p.precedence_in'
$
```

The rule was true and is now undefined, because `1 in [1, 2, 3] == true` parses as `internal.member_2(1, equal([1, 2, 3], true))`.

An `in` nested in an `in` goes the same way. This module is in the shared test corpus as `aggregates/member object with key, nested`, and `data.test.p` is `true` before `opa fmt` and undefined after it:

```console
$ cat q.rego
package test

p if {
	"foo", (2 in {"bar": 2}) in {"foo": true}
}

$ opa fmt q.rego
package test

p if {
	"foo", 2 in {"bar": 2} in {"foo": true}
}
```

`internal.member_3("foo", internal.member_2(2, {"bar": 2}), {"foo": true})` became `internal.member_2(internal.member_3("foo", 2, {"bar": 2}), {"foo": true})`. Formatting the output again moves the parens to `("foo", 2 in {"bar": 2}) in {"foo": true}`, so `opa fmt` is not a fixpoint here either. And `("x" in ["x"]), 1 in {true: 1}` formats to `"x" in ["x"], 1 in {true: 1}`, which does not parse.

I found these by formatting every module in `v1/test/cases/testdata` twice and comparing the parsed rule bodies.

### What are the changes in this PR?

`writeInOperator` takes a `parens` argument but only acted on it for the three-operand form of `in`. The two-operand form was written bare in every position. `writeCall` passed `true` unconditionally, which hid the missing case, and `writeFunctionCall` wrote its infix operands with `writeTerm`, which never asks for parens.

`in` binds looser than every infix operator except `=` and `:=`: `Parser.parseTermIn` sits between `parseExpr` and `parseTermRelation`. So a two-operand `in` needs parens as an operand of another `in` and of `==`, `!=`, `<`, `>`, `<=`, `>=`, `|`, `&` and the arithmetic operators, and needs none inside a collection literal, in a call argument, or on the right of `=` and `:=`, where it is already delimited.

`writeInOperator` now honours `parens` for both forms. `writeCall` passes its own `parens` through for the two-operand form and keeps them unconditional for the three-operand form, whose comma would otherwise be read as an element or argument separator. `writeFunctionCall` marks the infix operands that need them, through the existing `w.parenTerm` slot.

### Notes to assist PR review:

The cases go into `testfiles/{v0,v1}/test_in_operator_with_parenthesis.rego`, which is not listed in `astAlteringTestFiles`, so `TestFormatV0Source` and `TestFormatV1Source` check the exact bytes, that the output reparses, that the AST is preserved, and that a second pass is a no-op. Both files fail on `main` and pass with this change.

The last added line, `y = (1 in [1])`, is deliberate: it formats to `y = 1 in [1]` before and after, because `=` binds looser than `in`. The existing lines in that file, the ones inside set literals and call arguments, are unchanged too.

`(1 in [1]) in [true]` is the one case that changes without having been wrong. It used to format to `1 in [1] in [true]`, which reparses the same way, and now keeps its parens.

`go test ./v1/format/... ./v1/ast/... ./cmd/... ./format/... ./v1/bundle/... ./v1/repl/... ./internal/presentation/...` passes. `gofmt -l v1/format` and `go vet ./v1/format/...` are clean, and `golangci-lint run ./v1/format/...` with the repo config reports 0 issues.

### Further comments:

The precedence itself is untouched, so `1 in [1, 2, 3] == true` written without parens still parses as `internal.member_2(1, equal([1, 2, 3], true))`, and #8859 stays open for that part.
