### PR TITLE
Topdown: fix regex cache leak

### DIFF
--- a/v1/topdown/regex.go
+++ b/v1/topdown/regex.go
@@ -173,12 +173,7 @@ func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, e
 		return nil, err
 	}
 
-	re, err := regexpCacheGet(gen)
-	if err != nil {
-		return nil, err
-	}
-
-	return re, nil
+	return regexpCacheGet(gen)
 }
 
 func builtinGlobsMatch(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {

--- a/v1/topdown/regex.go
+++ b/v1/topdown/regex.go
@@ -54,8 +54,9 @@ func regexpCacheGet(pat string) (*regexp.Regexp, error) {
 		}
 	}
 
-	regexpCacheLock.Unlock()
 	regexpCache[pat] = re
+
+	regexpCacheLock.Unlock()
 	return re, nil
 
 }

--- a/v1/topdown/regex.go
+++ b/v1/topdown/regex.go
@@ -26,6 +26,40 @@ var (
 	regexpCache     = make(map[string]*regexp.Regexp)
 )
 
+func regexpCacheGet(pat string) (*regexp.Regexp, error) {
+	regexpCacheLock.RLock()
+	v, ok := regexpCache[pat]
+	regexpCacheLock.RUnlock()
+	if ok {
+		return v, nil
+	}
+
+	// cache miss!
+	re, err := regexp.Compile(pat)
+	if err != nil {
+		return nil, err
+	}
+
+	regexpCacheLock.Lock()
+
+	// Ensure the cache is below the max size.
+	for len(regexpCache) >= regexCacheMaxSize {
+		// Since every caller inserts at most one item, we expect this
+		// loop to run for at most one iteration.
+		for k := range regexpCache {
+			// Go map iteration is semi-random, so this deletes a
+			// more or less arbitrary key.
+			delete(regexpCache, k)
+			break
+		}
+	}
+
+	regexpCacheLock.Unlock()
+	regexpCache[pat] = re
+	return re, nil
+
+}
+
 func builtinRegexIsValid(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
 	if s, err := builtins.StringOperand(operands[0].Value, 1); err == nil {
 		if _, err = syntax.Parse(string(s), syntax.Perl); err == nil {
@@ -129,45 +163,20 @@ func getRegexp(bctx BuiltinContext, pat string) (*regexp.Regexp, error) {
 		return re, nil
 	}
 
-	regexpCacheLock.RLock()
-	re, ok := regexpCache[pat]
-	numCached := len(regexpCache)
-	regexpCacheLock.RUnlock()
-	if !ok {
-		var err error
-		re, err = regexp.Compile(pat)
-		if err != nil {
-			return nil, err
-		}
-
-		regexpCacheLock.Lock()
-		if numCached >= regexCacheMaxSize {
-			// Delete a (semi-)random key to make room for the new one.
-			for k := range regexpCache {
-				delete(regexpCache, k)
-				break
-			}
-		}
-		regexpCache[pat] = re
-		regexpCacheLock.Unlock()
-	}
-	return re, nil
+	return regexpCacheGet(pat)
 }
 
 func getRegexpTemplate(pat string, delimStart, delimEnd byte) (*regexp.Regexp, error) {
-	regexpCacheLock.RLock()
-	re, ok := regexpCache[pat]
-	regexpCacheLock.RUnlock()
-	if !ok {
-		var err error
-		re, err = compileRegexTemplate(pat, delimStart, delimEnd)
-		if err != nil {
-			return nil, err
-		}
-		regexpCacheLock.Lock()
-		regexpCache[pat] = re
-		regexpCacheLock.Unlock()
+	gen, err := generateRegexTemplate(pat, delimStart, delimEnd)
+	if err != nil {
+		return nil, err
 	}
+
+	re, err := regexpCacheGet(gen)
+	if err != nil {
+		return nil, err
+	}
+
 	return re, nil
 }
 

--- a/v1/topdown/regex_template.go
+++ b/v1/topdown/regex_template.go
@@ -67,19 +67,13 @@ func delimiterIndices(s string, delimiterStart, delimiterEnd byte) ([]int, error
 	return idxs, nil
 }
 
-// compileRegexTemplate parses a template and returns a Regexp.
-//
-// You can define your own delimiters. It is e.g. common to use curly braces {} but I recommend using characters
-// which have no special meaning in Regex, e.g.: <, >
-//
-//	reg, err := compiler.CompileRegex("foo:bar.baz:<[0-9]{2,10}>", '<', '>')
-//	// if err != nil ...
-//	reg.MatchString("foo:bar.baz:123")
-func compileRegexTemplate(tpl string, delimiterStart, delimiterEnd byte) (*regexp.Regexp, error) {
+// generateRegexTemplate creates and returns the pattern string compiled by
+// compileRegexTemplate().
+func generateRegexTemplate(tpl string, delimiterStart, delimiterEnd byte) (string, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := delimiterIndices(tpl, delimiterStart, delimiterEnd)
 	if errBraces != nil {
-		return nil, errBraces
+		return "", errBraces
 	}
 	varsR := make([]*regexp.Regexp, len(idxs)/2)
 	pattern := bytes.NewBufferString("^")
@@ -96,7 +90,7 @@ func compileRegexTemplate(tpl string, delimiterStart, delimiterEnd byte) (*regex
 		fmt.Fprintf(pattern, "%s(%s)", regexp.QuoteMeta(raw), patt)
 		varsR[varIdx], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 	}
 
@@ -109,6 +103,23 @@ func compileRegexTemplate(tpl string, delimiterStart, delimiterEnd byte) (*regex
 	// WriteByte's error value is always nil for bytes.Buffer, no need to check it.
 	pattern.WriteByte('$')
 
+	return pattern.String(), nil
+}
+
+// compileRegexTemplate parses a template and returns a Regexp.
+//
+// You can define your own delimiters. It is e.g. common to use curly braces {} but I recommend using characters
+// which have no special meaning in Regex, e.g.: <, >
+//
+//	reg, err := compiler.CompileRegex("foo:bar.baz:<[0-9]{2,10}>", '<', '>')
+//	// if err != nil ...
+//	reg.MatchString("foo:bar.baz:123")
+func compileRegexTemplate(tpl string, delimiterStart, delimiterEnd byte) (*regexp.Regexp, error) {
+	pattern, err := generateRegexTemplate(tpl, delimiterStart, delimiterEnd)
+	if err != nil {
+		return nil, err
+	}
+
 	// Compile full regexp.
-	return regexp.Compile(pattern.String())
+	return regexp.Compile(pattern)
 }

--- a/v1/topdown/regex_test.go
+++ b/v1/topdown/regex_test.go
@@ -60,6 +60,20 @@ func TestRegexBuiltinCache(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	// Both builtins which interact with the cache should correctly evict
+	// cache items.
+	regex3 := "ba<[zx]>.*"
+	operands = []*ast.Term{
+		ast.NewTerm(ast.String(regex3)),
+		ast.NewTerm(ast.String("barbaz")),
+		ast.NewTerm(ast.String("<")),
+		ast.NewTerm(ast.String(">")),
+	}
+	err = builtinRegexMatchTemplate(ctx, operands, iter)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	if len(regexpCache) != regexCacheMaxSize {
 		t.Fatalf("Expected cache be capped at %d, was %d", regexCacheMaxSize, len(regexpCache))
 	}


### PR DESCRIPTION
* Add unit test reproducing issue reported in #9087.
* Centralize regex cache management for topdown to a helper function.
  * As defensive programming, we now keep iterating the cache eviction loop until the cache is drained to below the max size.
* PR bonus: fix a latent bug where a regex template could shadow a normal regex.
  * Speculative, I did not reproduce this and it wasn't immediately obvious to me how to do so, but in [`getRegexTemplate()`](https://github.com/open-policy-agent/opa/blob/cfc343711c04bf7a735a80f440dc5fc20e696039/v1/topdown/regex.go#L168), I noticed that the regex cache key was `pat`, not actually the regex pattern string that `compileRegexTemplate()` generated internally, so a normal regex could theoretically share the same logical pattern but consume a separate cache entry.
* Slight refactoring of regex template helper to support above.

AI usage statement: no AI of any kind used in this patch. 

Apologies for the delay getting this out, I have been busy.

fixes #9087
