### PR TITLE
runtime: only log diagnostic API access at DEBUG

### DIFF
--- a/v1/runtime/logging.go
+++ b/v1/runtime/logging.go
@@ -39,9 +39,10 @@ func (h loggingPrintHook) Print(pctx print.Context, msg string) error {
 // LoggingHandler returns an http.Handler that will print log messages
 // containing the request information as well as response status and latency.
 type LoggingHandler struct {
-	logger    logging.Logger
-	inner     http.Handler
-	requestID uint64
+	logger     logging.Logger
+	inner      http.Handler
+	requestID  uint64
+	diagnostic bool
 }
 
 // NewLoggingHandler returns a new http.Handler.
@@ -53,8 +54,31 @@ func NewLoggingHandler(logger logging.Logger, inner http.Handler) http.Handler {
 	}
 }
 
+// NewDiagnosticLoggingHandler returns a new http.Handler for the read-only
+// diagnostic API's (eg /health, /metrics, etc). Access to these is only
+// logged at DEBUG since they are typically polled frequently by things like
+// Kubernetes probes and Prometheus scrapers, and would otherwise flood logs
+// at the default INFO level.
+func NewDiagnosticLoggingHandler(logger logging.Logger, inner http.Handler) http.Handler {
+	return &LoggingHandler{
+		logger:     logger,
+		inner:      inner,
+		requestID:  uint64(0),
+		diagnostic: true,
+	}
+}
+
 func (h *LoggingHandler) loggingEnabled(level logging.Level) bool {
 	return level <= h.logger.GetLevel()
+}
+
+// reqRespLoggingEnabled reports whether the "Received request."/"Sent
+// response." log lines should be emitted for this handler.
+func (h *LoggingHandler) reqRespLoggingEnabled() bool {
+	if h.diagnostic {
+		return h.loggingEnabled(logging.Debug)
+	}
+	return h.loggingEnabled(logging.Info)
 }
 
 func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +94,7 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	recorder := newRecorder(h.logger, w, r, rctx.ReqID, h.loggingEnabled(logging.Debug))
 	t0 := time.Now()
 
-	if h.loggingEnabled(logging.Info) {
+	if h.reqRespLoggingEnabled() {
 
 		rctx.ClientAddr = r.RemoteAddr
 		rctx.ReqMethod = r.Method
@@ -128,7 +152,7 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		statusCode = recorder.statusCode
 	}
 
-	if h.loggingEnabled(logging.Info) {
+	if h.reqRespLoggingEnabled() {
 		fields := map[string]any{
 			"client_addr":   rctx.ClientAddr,
 			"req_id":        rctx.ReqID,

--- a/v1/runtime/logging_test.go
+++ b/v1/runtime/logging_test.go
@@ -348,6 +348,69 @@ func TestRequestLogging(t *testing.T) {
 	}
 }
 
+func TestDiagnosticHandlerLoggingLevel(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	cases := []struct {
+		name        string
+		newHandler  func(logging.Logger, http.Handler) http.Handler
+		wantAtInfo  bool
+		wantAtDebug bool
+	}{
+		{name: "main", newHandler: NewLoggingHandler, wantAtInfo: true, wantAtDebug: true},
+		{name: "diagnostic", newHandler: NewDiagnosticLoggingHandler, wantAtInfo: false, wantAtDebug: true},
+	}
+
+	for _, tc := range cases {
+		for _, lvl := range []struct {
+			name  string
+			level logging.Level
+		}{
+			{"info", logging.Info},
+			{"debug", logging.Debug},
+		} {
+			t.Run(tc.name+"/"+lvl.name, func(t *testing.T) {
+				logger := test.New()
+				logger.SetLevel(lvl.level)
+
+				handler := tc.newHandler(logger, inner)
+
+				// /health is served by both the main and diagnostic handlers
+				// (depending on which listener accepted the connection), so
+				// the log level decision must be driven by which handler is
+				// in play, not the request path.
+				req, err := http.NewRequest("GET", "/health", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				var gotReceived, gotSent bool
+				for _, ent := range logger.Entries() {
+					switch ent.Message {
+					case "Received request.":
+						gotReceived = true
+					case "Sent response.":
+						gotSent = true
+					}
+				}
+
+				want := tc.wantAtInfo
+				if lvl.level == logging.Debug {
+					want = tc.wantAtDebug
+				}
+
+				if gotReceived != want || gotSent != want {
+					t.Errorf("expected logged=%v at level %s, got received=%v sent=%v", want, lvl.name, gotReceived, gotSent)
+				}
+			})
+		}
+	}
+}
+
 func entriesForReq(ents []test.LogEntry, n uint64) []test.LogEntry {
 	var ret []test.LogEntry
 	for _, e := range ents {

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -783,7 +783,7 @@ func (rt *Runtime) Serve(ctx context.Context) (err error) {
 	}()
 
 	rt.server.Handler = NewLoggingHandler(rt.logger, rt.server.Handler)
-	rt.server.DiagnosticHandler = NewLoggingHandler(rt.logger, rt.server.DiagnosticHandler)
+	rt.server.DiagnosticHandler = NewDiagnosticLoggingHandler(rt.logger, rt.server.DiagnosticHandler)
 
 	rt.setServerStatus(ServerWaitingForPlugins)
 


### PR DESCRIPTION
/health and /metrics are polled frequently by things like Kubernetes liveness/readiness probes and Prometheus scrapers. Logging every such request at INFO floods logs in typical deployments.

Distinguish diagnostic access by which handler served the request (main vs. diagnostic listener) rather than by URL path, since /health and /metrics are also exposed on the main API listener when no separate diagnostic address is configured, and should keep logging at INFO there.

Fixes #8419. At least a part of it! Will this be enough? 🤔 