### PR TITLE
perf: General performance improvements  in compiler

### DIFF
--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -22,13 +22,31 @@ import (
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
-// CompileErrorLimitDefault is the default number errors a compiler will allow before
-// exiting.
-const CompileErrorLimitDefault = 10
+const (
+	// CompileErrorLimitDefault is the default number
+	// of errors a compiler will allow before exiting.
+	CompileErrorLimitDefault = 10
+	LocalVarPrefix           = "__local"
+
+	errAssignInNegated    = "cannot assign vars inside negated expression"
+	errAssignInAndOperand = "cannot assign vars inside implicit and operand"
+	errAssignInOrOperand  = "cannot assign vars inside implicit or operand"
+)
 
 var (
-	errLimitReached = newErrorString(CompileErr, nil, "error limit reached")
-	emptyPackage    = &Package{Path: Ref{VarTerm("")}}
+	// SafetyCheckVisitorParams defines the AST visitor parameters to use for collecting
+	// variables during the safety check. This has to be exported because it's relied on
+	// by the copy propagation implementation in topdown.
+	SafetyCheckVisitorParams = VarVisitorParams{SkipRefCallHead: true, SkipClosures: true}
+	// TODO(tsandall): Improve this so that users can either supply this list explicitly
+	// or the information is maintained on the built-in function declaration. What we really
+	// need to know is whether the built-in function allows callers to push down output
+	// values or not. It's unlikely that anything outside of OPA does this today so this
+	// solution is fine for now.
+	comprehensionIndexDenylist = map[string]int{WalkBuiltin.Name: len(WalkBuiltin.Decl.FuncArgs().Args)}
+	errLimitReached            = newErrorString(CompileErr, nil, "error limit reached")
+	emptyPackage               = &Package{Path: Ref{VarTerm("")}}
+	futureKeywordsPrefix       = Ref{FutureRootDocument, InternedTerm("keywords")}
 )
 
 // Compiler contains the state of a compilation process.
@@ -260,7 +278,7 @@ func AllStages() []StageID {
 // CompilerEvalMode allows toggling certain stages that are only
 // needed for certain modes, Concretely, only "topdown" mode will
 // have the compiler build comprehension and rule indices.
-type CompilerEvalMode int
+type CompilerEvalMode uint8
 
 const (
 	// EvalModeTopdown (default) instructs the compiler to build rule
@@ -376,7 +394,7 @@ type QueryCompiler interface {
 	// WithStageAfter registers a stage to run during query compilation after
 	// the named stage.
 	//
-	// Caution: Use [ast.QueryCompiler.WithStageAfterID] instead. It provides
+	// Caution: Use [QueryCompiler.WithStageAfterID] instead. It provides
 	// more (Golang) compile-time safety
 	WithStageAfter(after string, stage QueryCompilerStageDefinition) QueryCompiler
 
@@ -515,7 +533,7 @@ func (c *Compiler) WithPathConflictsCheckRoots(rootPaths []string) *Compiler {
 // WithStageAfter registers a stage to run during compilation after
 // the named stage.
 //
-// Caution: Consider using [ast.QueryCompiler.WithStageAfterID] instead. It provides
+// Caution: Consider using [Compiler.WithStageAfterID] instead. It provides
 // more (Golang) compile-time safety
 func (c *Compiler) WithStageAfter(after string, stage CompilerStageDefinition) *Compiler {
 	c.after[after] = append(c.after[after], stage)
@@ -836,15 +854,12 @@ func (c *Compiler) GetRulesWithPrefix(ref Ref) (rules []*Rule) {
 //	GetRules("data.a.b.c")		=> [rule1, rule2]
 //	GetRules("data.a.b.d")		=> nil
 func (c *Compiler) GetRules(ref Ref) []*Rule {
-	set := map[*Rule]struct{}{}
+	virt := c.GetRulesForVirtualDocument(ref)
+	pref := c.GetRulesWithPrefix(ref)
 
-	for _, rule := range c.GetRulesForVirtualDocument(ref) {
-		set[rule] = struct{}{}
-	}
-
-	for _, rule := range c.GetRulesWithPrefix(ref) {
-		set[rule] = struct{}{}
-	}
+	set := make(map[*Rule]struct{}, len(virt)+len(pref))
+	insertRules(set, virt)
+	insertRules(set, pref)
 
 	return util.Keys(set)
 }
@@ -1180,8 +1195,6 @@ func (c *Compiler) buildComprehensionIndices() {
 	varVisitorPool.Put(vis)
 }
 
-var futureKeywordsPrefix = Ref{FutureRootDocument, InternedTerm("keywords")}
-
 // buildRequiredCapabilities updates the required capabilities on the compiler
 // to include any keyword and feature dependencies present in the modules. The
 // built-in function dependencies will have already been added by the type
@@ -1515,10 +1528,10 @@ func checkUndefinedFuncs(env *TypeEnv, x any, arity func(Ref) int, rwVars map[Va
 }
 
 func arityMismatchError(env *TypeEnv, f Ref, expr *Expr, exp, act int) *Error {
-	if want, ok := env.Get(f).(*types.Function); ok { // generate richer error for built-in functions
+	if want, ok := env.GetByRef(f).(*types.Function); ok { // generate richer error for built-in functions
 		have := make([]types.Type, len(expr.Operands()))
 		for i, op := range expr.Operands() {
-			have[i] = env.Get(op)
+			have[i] = env.GetByValue(op.Value)
 		}
 		return newArgError(expr.Loc(), f, "arity mismatch", have, want.NamedFuncArgs())
 	}
@@ -1535,18 +1548,19 @@ func (c *Compiler) checkSafetyRuleBodies() {
 	vis := varVisitorPool.Get()
 
 	for _, name := range c.sorted {
-		m := c.Modules[name]
-		scopes := ruleScopes{module: m}
-		WalkRules(m, func(r *Rule) bool {
-			vis = vis.Clear()
-			// vis.vars == safe
-			vis.vars.Update(ReservedVars)
-			if len(r.Head.Args) > 0 {
-				vis.WalkArgs(r.Head.Args)
-			}
-			r.Body = c.checkBodySafety(vis.vars, r.Body, r, &scopes)
-			return false
-		})
+		scopes := ruleScopes{module: c.Modules[name]}
+		for _, rule := range c.Modules[name].Rules {
+			WalkRules(rule, func(r *Rule) bool {
+				vis = vis.Clear()
+				// vis.vars == safe
+				vis.vars.Update(ReservedVars)
+				if len(r.Head.Args) > 0 {
+					vis.WalkArgs(r.Head.Args)
+				}
+				r.Body = c.checkBodySafety(vis.vars, r.Body, r, &scopes)
+				return false
+			})
+		}
 	}
 
 	varVisitorPool.Put(vis)
@@ -1562,15 +1576,6 @@ func (c *Compiler) checkBodySafety(safe VarSet, b Body, r *Rule, scopes *ruleSco
 		return b
 	}
 	return reordered
-}
-
-// SafetyCheckVisitorParams defines the AST visitor parameters to use for collecting
-// variables during the safety check. This has to be exported because it's relied on
-// by the copy propagation implementation in topdown.
-// TODO: deprecate?
-var SafetyCheckVisitorParams = VarVisitorParams{
-	SkipRefCallHead: true,
-	SkipClosures:    true,
 }
 
 // checkSafetyRuleHeads ensures that variables appearing in the head of a
@@ -2499,7 +2504,7 @@ func rewriteTemplateStrings(tsr *templateStringRewriter, globals VarSet, x any) 
 		safe = globals.Copy()
 	}
 
-	vis := &GenericVisitor{func(x any) bool {
+	vis := NewGenericVisitor(func(x any) bool {
 		var modrec bool
 		var errsrec Errors
 		switch x := x.(type) {
@@ -2556,7 +2561,7 @@ func rewriteTemplateStrings(tsr *templateStringRewriter, globals VarSet, x any) 
 		}
 		errs = append(errs, errsrec...)
 		return false
-	}}
+	})
 	vis.Walk(x)
 
 	return modified, safe, errs
@@ -2712,7 +2717,7 @@ func checkVoidCalls(env *TypeEnv, x any) Errors {
 	var errs Errors
 	WalkTerms(x, func(x *Term) bool {
 		if call, ok := x.Value.(Call); ok {
-			if tpe, ok := env.Get(call[0]).(*types.Function); ok && tpe.Result() == nil {
+			if tpe, ok := env.GetByValue(call[0].Value).(*types.Function); ok && tpe.Result() == nil {
 				errs = append(errs, NewError(TypeErr, x.Loc(), "%v used as value", call))
 			}
 		}
@@ -2865,7 +2870,7 @@ func containsNestedBody(x any) bool {
 
 func erasePrintCalls(node any) bool {
 	var modified bool
-	NewGenericVisitor(func(x any) bool {
+	vis := NewGenericVisitor(func(x any) bool {
 		var modrec bool
 		switch x := x.(type) {
 		case *Rule:
@@ -2895,7 +2900,8 @@ func erasePrintCalls(node any) bool {
 			modified = true
 		}
 		return false
-	}).Walk(node)
+	})
+	vis.Walk(node)
 	return modified
 }
 
@@ -3247,7 +3253,7 @@ func createMetadataChain(chain []*AnnotationsRef) (*Term, *Error) {
 func (c *Compiler) rewriteLocalVars() {
 	var assignment bool
 
-	args := NewVarVisitor()
+	args := varVisitorPool.Get()
 	argsStack := newLocalDeclaredVars()
 
 	for _, name := range c.sorted {
@@ -3288,7 +3294,13 @@ func (c *Compiler) rewriteLocalVars() {
 				// Report an error for each unused function argument
 				for arg := range unusedArgs {
 					if !arg.IsWildcard() {
-						if !c.err(NewError(CompileErr, rule.Head.Location, "unused argument %v. (hint: use _ (wildcard variable) instead)", arg)) {
+						err := NewError(
+							CompileErr,
+							rule.Head.Location,
+							"unused argument %v. (hint: use _ (wildcard variable) instead)",
+							arg,
+						)
+						if !c.err(err) {
 							return true
 						}
 					}
@@ -3302,6 +3314,8 @@ func (c *Compiler) rewriteLocalVars() {
 	if assignment {
 		c.Required.addBuiltinSorted(Assign)
 	}
+
+	varVisitorPool.Put(args)
 }
 
 func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsStack *localDeclaredVars, gen *localVarGenerator) (*localDeclaredVars, Errors) {
@@ -3326,11 +3340,13 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 			strict:        c.strict,
 		}
 
-		NewGenericVisitor(nestedXform.Visit).Walk(rule.Head)
+		nxfVis := NewGenericVisitor(nestedXform.Visit)
+		nxfVis.Walk(rule.Head)
 		c.err(nestedXform.errs...) // NB(sr): This is a bit bogus -- Why not return them?
 
 		// Rewrite assignments in body.
-		vis := NewVarVisitor()
+		vis := varVisitorPool.Get()
+		defer varVisitorPool.Put(vis)
 
 		for _, t := range rule.Head.Ref()[1:] {
 			if !IsScalar(t.Value) {
@@ -3367,31 +3383,32 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 	// references (stay unsafe-var errors), call operators (SkipRefCallHead),
 	// and `with` targets/values (possible function mocks).
 	if len(c.builtins) > 0 {
-		bodyVis := NewVarVisitor().WithParams(VarVisitorParams{
+		bodyVis := varVisitorPool.Get().WithParams(VarVisitorParams{
 			SkipRefCallHead: true,
 			SkipClosures:    true,
 		})
+		defer varVisitorPool.Put(bodyVis)
+
 		bodyVis.Walk(rule.Body)
 		bodyVars := bodyVis.Vars()
 
-		declaredInBody := declaredVars(rule.Body)
+		declaredInBody := declaredBodyVars(rule.Body)
 
-		withVars := NewVarSet()
-		NewGenericVisitor(func(x any) bool {
-			if w, ok := x.(*With); ok {
-				WalkVars(w, func(v Var) bool {
-					withVars.Add(v)
-					return false
-				})
-			}
+		withVis := varVisitorPool.Get().WithParams(VarVisitorParams{SkipRefCallHead: true})
+		defer varVisitorPool.Put(withVis)
+
+		f := func(w *With) bool {
+			withVis.Walk(w.Target.Value)
+			withVis.Walk(w.Value.Value)
 			return false
-		}).Walk(rule)
+		}
+		WalkWiths(rule, f)
 
 		for _, v := range bodyVars.Sorted() {
 			if _, ok := c.builtins[v.String()]; !ok {
 				continue
 			}
-			if declaredInBody.Contains(v) || withVars.Contains(v) {
+			if declaredInBody.Contains(v) || withVis.Vars().Contains(v) {
 				continue
 			}
 			if _, ok := stack.Declared(v); ok {
@@ -3466,29 +3483,35 @@ type rewriteNestedHeadVarLocalTransform struct {
 
 func (xform *rewriteNestedHeadVarLocalTransform) Visit(x any) bool {
 	if term, ok := x.(*Term); ok {
+		if IsScalar(term.Value) {
+			return false
+		}
+
 		stop := false
 		stack := newLocalDeclaredVars()
 
 		switch x := term.Value.(type) {
 		case *object:
-			vis := NewGenericVisitor(xform.Visit)
-			cpy, _ := x.Map(func(k, v *Term) (*Term, *Term, error) {
-				kcpy := k.Copy()
-				vis.Walk(kcpy)
-				vcpy := v.Copy()
-				vis.Walk(vcpy)
-				return kcpy, vcpy, nil
-			})
-			term.Value = cpy
+			if !x.IsGround() {
+				vis := NewGenericVisitor(xform.Visit)
+				term.Value, _ = x.Map(func(k, v *Term) (*Term, *Term, error) {
+					kcpy := k.Copy()
+					vis.Walk(kcpy)
+					vcpy := v.Copy()
+					vis.Walk(vcpy)
+					return kcpy, vcpy, nil
+				})
+			}
 			stop = true
 		case *set:
-			vis := NewGenericVisitor(xform.Visit)
-			cpy, _ := x.Map(func(v *Term) (*Term, error) {
-				vcpy := v.Copy()
-				vis.Walk(vcpy)
-				return vcpy, nil
-			})
-			term.Value = cpy
+			if !x.IsGround() {
+				vis := NewGenericVisitor(xform.Visit)
+				term.Value, _ = x.Map(func(v *Term) (*Term, error) {
+					vcpy := v.Copy()
+					vis.Walk(vcpy)
+					return vcpy, nil
+				})
+			}
 			stop = true
 		case *ArrayComprehension:
 			xform.errs = rewriteDeclaredVarsInArrayComprehension(xform.gen, stack, x, xform.errs, xform.strict)
@@ -3526,14 +3549,9 @@ func (xform rewriteHeadVarLocalTransform) Transform(x any) (any, error) {
 }
 
 func (c *Compiler) rewriteLocalArgVars(gen *localVarGenerator, stack *localDeclaredVars, rule *Rule) {
-	vis := &ruleArgLocalRewriter{
-		stack: stack,
-		gen:   gen,
-	}
-
-	for i := range rule.Head.Args {
-		Walk(vis, rule.Head.Args[i])
-	}
+	vis := &ruleArgLocalRewriter{stack: stack, gen: gen}
+	vis.gv = &GenericVisitor{f: vis.visit}
+	vis.gv.Walk(rule.Head.Args)
 
 	c.err(vis.errs...)
 }
@@ -3541,16 +3559,15 @@ func (c *Compiler) rewriteLocalArgVars(gen *localVarGenerator, stack *localDecla
 type ruleArgLocalRewriter struct {
 	stack *localDeclaredVars
 	gen   *localVarGenerator
+	gv    *GenericVisitor
 	errs  []*Error
 }
 
-func (vis *ruleArgLocalRewriter) Visit(x any) Visitor {
-
-	t, ok := x.(*Term)
+func (vis *ruleArgLocalRewriter) visit(a any) bool {
+	t, ok := a.(*Term)
 	if !ok {
-		return vis
+		return false
 	}
-
 	switch v := t.Value.(type) {
 	case Var:
 		gv, ok := vis.stack.Declared(v)
@@ -3561,30 +3578,28 @@ func (vis *ruleArgLocalRewriter) Visit(x any) Visitor {
 			vis.stack.Insert(v, gv, argVar)
 		}
 		t.Value = gv
-		return nil
+		return true
 	case *object:
 		if cpy, err := v.Map(func(k, v *Term) (*Term, *Term, error) {
 			vcpy := v.Copy()
-			Walk(vis, vcpy)
+			vis.gv.Walk(vcpy)
 			return k, vcpy, nil
 		}); err != nil {
 			vis.errs = append(vis.errs, newErrorString(CompileErr, t.Location, err.Error()))
 		} else {
 			t.Value = cpy
 		}
-		return nil
+		return true
 	case Null, Boolean, Number, String, *ArrayComprehension, *SetComprehension, *ObjectComprehension, Set, *TemplateString:
 		// Scalars are no-ops. Comprehensions and template-strings are handled above. Sets must not
 		// contain variables.
-		return nil
+		return true
 	case Call:
 		vis.errs = append(vis.errs, NewError(CompileErr, t.Location, "rule arguments cannot contain calls"))
-		return nil
-	default:
-		// Recurse on refs and arrays. Any embedded
-		// variables can be rewritten.
-		return vis
+		return true
 	}
+	// Recurse on refs and arrays. Any embedded variables can be rewritten.
+	return false
 }
 
 func (c *Compiler) rewriteWithModifiers() {
@@ -3805,7 +3820,7 @@ func (qc *queryCompiler) resolveRefs(qctx *QueryContext, body Body) (Body, error
 		}
 	}
 
-	ignore := &declaredVarStack{declaredVars(body)}
+	ignore := &declaredVarStack{declaredBodyVars(body)}
 
 	return resolveRefsInBody(globals, ignore, body), nil
 }
@@ -3968,16 +3983,21 @@ func (ci *ComprehensionIndex) String() string {
 	return fmt.Sprintf("<keys: %v>", NewArray(ci.Keys...))
 }
 
-func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, node Body, result map[*Term]*ComprehensionIndex) uint64 {
-	var n uint64
+func buildComprehensionIndices(
+	dbg debug.Debug,
+	arity func(Ref) int,
+	candidates VarSet,
+	rwVars map[Var]Var,
+	node Body,
+	result map[*Term]*ComprehensionIndex,
+) (n uint64) {
 	cpy := candidates.Copy()
 	vis := varVisitorPool.Get()
-
 	defer varVisitorPool.Put(vis)
 
 	WalkBodies(node, func(b Body) bool {
 		for _, expr := range b {
-			index := getComprehensionIndex(dbg, arity, cpy, rwVars, expr)
+			index := getComprehensionIndex(dbg, arity, cpy, rwVars, expr, vis)
 			if index != nil {
 				result[index.Term] = index
 				n++
@@ -3985,15 +4005,24 @@ func buildComprehensionIndices(dbg debug.Debug, arity func(Ref) int, candidates 
 			// Any variables appearing in the expressions leading up to the comprehension
 			// are fair-game to be used as index keys.
 			vis = vis.Clear().WithParams(VarVisitorParams{SkipClosures: true, SkipRefCallHead: true})
+			old := vis.vars
+			vis.vars = cpy
 			vis.Walk(expr)
-			cpy.Update(vis.Vars())
+			vis.vars = old
 		}
 		return false
 	})
 	return n
 }
 
-func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarSet, rwVars map[Var]Var, expr *Expr) *ComprehensionIndex {
+func getComprehensionIndex(
+	dbg debug.Debug,
+	arity func(Ref) int,
+	candidates VarSet,
+	rwVars map[Var]Var,
+	expr *Expr,
+	vis *VarVisitor,
+) *ComprehensionIndex {
 	// Ignore everything except <var> = <comprehension> expressions. Extract
 	// the comprehension term from the expression.
 	if !expr.IsEquality() || expr.Negated || len(expr.With) > 0 {
@@ -4046,10 +4075,14 @@ func getComprehensionIndex(dbg debug.Debug, arity func(Ref) int, candidates VarS
 		body = x.Body
 	}
 
-	outputs := outputVarsForBody(body, arity, ReservedVars, nil)
-	unsafe := body.Vars(SafetyCheckVisitorParams).Diff(outputs).Diff(ReservedVars)
+	vis = vis.Clear().WithParams(SafetyCheckVisitorParams)
+	outputs := outputVarsForBody(body, arity, ReservedVars, vis)
 
-	if len(unsafe) > 0 {
+	vis.Clear().WithParams(SafetyCheckVisitorParams).Walk(body)
+	unsafe := vis.Vars().Diff(outputs)
+
+	if unsafe.DiffCount(ReservedVars) > 0 {
+		unsafe = unsafe.Diff(ReservedVars)
 		dbg.Printf("%s: comprehension index: unsafe vars: %v", expr.Location, unsafe)
 		return nil
 	}
@@ -4103,15 +4136,6 @@ type comprehensionIndexRegressionCheckVisitor struct {
 	worse      bool
 }
 
-// TODO(tsandall): Improve this so that users can either supply this list explicitly
-// or the information is maintained on the built-in function declaration. What we really
-// need to know is whether the built-in function allows callers to push down output
-// values or not. It's unlikely that anything outside of OPA does this today so this
-// solution is fine for now.
-var comprehensionIndexBlacklist = map[string]int{
-	WalkBuiltin.Name: len(WalkBuiltin.Decl.FuncArgs().Args),
-}
-
 func newComprehensionIndexRegressionCheckVisitor(candidates VarSet) *comprehensionIndexRegressionCheckVisitor {
 	return &comprehensionIndexRegressionCheckVisitor{
 		candidates: candidates,
@@ -4128,7 +4152,7 @@ func (vis *comprehensionIndexRegressionCheckVisitor) visit(x any) bool {
 		switch x := x.(type) {
 		case *Expr:
 			operands := x.Operands()
-			if pos := comprehensionIndexBlacklist[x.Operator().String()]; pos > 0 && pos < len(operands) {
+			if pos := comprehensionIndexDenylist[x.Operator().String()]; pos > 0 && pos < len(operands) {
 				vis.assertEmptyIntersection(operands[pos].Vars())
 			}
 		case Ref:
@@ -4972,17 +4996,19 @@ func (vs unsafeVars) Slice() (result []unsafePair) {
 // If the body cannot be reordered to ensure safety, the second return value
 // contains a mapping of expressions to unsafe variables in those expressions.
 func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, globals VarSet, body Body) (Body, unsafeVars) {
-	vis := varVisitorPool.Get().WithParams(SafetyCheckVisitorParamsWithArity(arity))
-	vis.WalkBody(body)
+	params := SafetyCheckVisitorParamsWithArity(arity)
 
+	vis := varVisitorPool.Get().WithParams(params)
 	defer varVisitorPool.Put(vis)
+
+	vis.WalkBody(body)
 
 	bodyVars := vis.Vars().Copy()
 	safe := bodyVars.Intersect(globals)
 	unsafe := make(unsafeVars, len(bodyVars)-len(safe))
 
 	for _, e := range body {
-		vis = vis.Clear().WithParams(SafetyCheckVisitorParamsWithArity(arity))
+		vis = vis.Clear().WithParams(params)
 		vis.Walk(e)
 		for v := range vis.Vars() {
 			if _, ok := safe[v]; !ok {
@@ -5045,19 +5071,20 @@ func reorderBodyForSafety(builtins map[string]*Builtin, arity func(Ref) int, glo
 	// Recursively visit closures and perform the safety checks on them.
 	// Update the globals at each expression to include the variables that could
 	// be closed over.
-	g := globals.Copy()
 	xform := newBodySafetyTransformer(builtins, arity)
 	xform.gv = NewGenericVisitor(xform.Visit)
 
+	xform.unsafe = unsafe
+	xform.globals = globals.Copy()
+
+	vis = vis.WithParams(params)
+	vis.vars = xform.globals
+
 	for i, e := range reordered {
 		if i > 0 {
-			vis = vis.Clear().WithParams(SafetyCheckVisitorParamsWithArity(arity))
 			vis.Walk(reordered[i-1])
-			g.Update(vis.Vars())
 		}
 		xform.current = e
-		xform.globals = g
-		xform.unsafe = unsafe
 		xform.gv.Walk(e)
 	}
 
@@ -5152,7 +5179,7 @@ func unsafeImplicitBodyVars(body Body, arity func(Ref) int) VarSet {
 		}
 
 		if e.IsEquality() {
-			for v := range outputVarsForExprEq(e, VarSet{}, VarSet{}) {
+			for v := range outputVarsForExprEq(e, VarSet{}, nil) {
 				bindings[v] = struct{}{}
 			}
 			continue
@@ -5220,22 +5247,24 @@ func (xform *bodySafetyTransformer) Visit(x any) bool {
 	case *Term:
 		switch x := term.Value.(type) {
 		case *object:
-			cpy, _ := x.Map(func(k, v *Term) (*Term, *Term, error) {
-				kcpy := k.Copy()
-				xform.gv.Walk(kcpy)
-				vcpy := v.Copy()
-				xform.gv.Walk(vcpy)
-				return kcpy, vcpy, nil
-			})
-			term.Value = cpy
+			if !x.IsGround() {
+				term.Value, _ = x.Map(func(k, v *Term) (*Term, *Term, error) {
+					kcpy := k.Copy()
+					xform.gv.Walk(kcpy)
+					vcpy := v.Copy()
+					xform.gv.Walk(vcpy)
+					return kcpy, vcpy, nil
+				})
+			}
 			return true
 		case *set:
-			cpy, _ := x.Map(func(v *Term) (*Term, error) {
-				vcpy := v.Copy()
-				xform.gv.Walk(vcpy)
-				return vcpy, nil
-			})
-			term.Value = cpy
+			if !x.IsGround() {
+				term.Value, _ = x.Map(func(v *Term) (*Term, error) {
+					vcpy := v.Copy()
+					xform.gv.Walk(vcpy)
+					return vcpy, nil
+				})
+			}
 			return true
 		case *ArrayComprehension:
 			xform.reorderArrayComprehensionSafety(x)
@@ -5454,8 +5483,15 @@ func outputVarsForExprCall(expr *Expr, arity int, safe VarSet, terms []*Term, vi
 	vis = ClearOrNewVarVisitor(vis).WithParams(params)
 	vis.WalkArgs(Args(terms[:numInputTerms]))
 
-	unsafe := vis.Vars().Diff(output).DiffCount(safe)
-	if unsafe > 0 {
+	unsafe := vis.Vars()
+	for i := range output {
+		delete(unsafe, i)
+	}
+	for i := range safe {
+		delete(unsafe, i)
+	}
+
+	if len(unsafe) > 0 {
 		return VarSet{}
 	}
 
@@ -5505,9 +5541,6 @@ func (f *equalityFactory) Generate(other *Term) *Expr {
 	expr.Location = other.Location
 	return expr
 }
-
-// TODO: Move to internal package?
-const LocalVarPrefix = "__local"
 
 type localVarGenerator struct {
 	exclude VarSet
@@ -5636,8 +5669,6 @@ type usedRef struct {
 }
 
 func resolveRefsInRule(globals map[Var]*usedRef, rule *Rule) error {
-	ignore := &declaredVarStack{}
-
 	vars := NewVarSet()
 	var vis *GenericVisitor
 	var err error
@@ -5676,15 +5707,14 @@ func resolveRefsInRule(globals map[Var]*usedRef, rule *Rule) error {
 		}
 		return false
 	})
-
 	vis.Walk(rule.Head.Args)
 
 	if err != nil {
 		return err
 	}
 
-	ignore.Push(vars)
-	ignore.Push(declaredVars(rule.Body))
+	ignore := &declaredVarStack{}
+	ignore.Push(vars, declaredBodyVars(rule.Body))
 
 	ref := rule.Head.Ref()
 	for i := 1; i < len(ref); i++ {
@@ -5729,12 +5759,12 @@ func resolveRefsInExpr(globals map[Var]*usedRef, ignore *declaredVarStack, expr 
 			}
 		}
 	case *Every:
-		locals := NewVarSet()
+		vis := varVisitorPool.Get()
 		if ts.Key != nil {
-			locals.Update(ts.Key.Vars())
+			vis.Walk(ts.Key)
 		}
-		locals.Update(ts.Value.Vars())
-		ignore.Push(locals)
+		vis.Walk(ts.Value)
+		ignore.Push(vis.Vars())
 		cpy.Terms = &Every{
 			Key:    ts.Key.Copy(),   // TODO(sr): do more?
 			Value:  ts.Value.Copy(), // TODO(sr): do more?
@@ -5742,6 +5772,7 @@ func resolveRefsInExpr(globals map[Var]*usedRef, ignore *declaredVarStack, expr 
 			Body:   resolveRefsInBody(globals, ignore, ts.Body),
 		}
 		ignore.Pop()
+		varVisitorPool.Put(vis)
 	case *Not:
 		cpy.Terms = &Not{
 			Body:         resolveRefsInBody(globals, ignore, ts.Body),
@@ -5785,9 +5816,8 @@ func resolveRefsInTerm(globals map[Var]*usedRef, ignore *declaredVarStack, term 
 		}
 		return term
 	case Ref:
-		fqn := resolveRef(globals, ignore, v)
 		cpy := *term
-		cpy.Value = fqn
+		cpy.Value = resolveRef(globals, ignore, v)
 		return &cpy
 	case *object:
 		cpy := *term
@@ -5806,38 +5836,37 @@ func resolveRefsInTerm(globals map[Var]*usedRef, ignore *declaredVarStack, term 
 		cpy.Value = Call(resolveRefsInTermSlice(globals, ignore, v))
 		return &cpy
 	case Set:
-		s, _ := v.Map(func(e *Term) (*Term, error) {
+		cpy := *term
+		cpy.Value, _ = v.Map(func(e *Term) (*Term, error) {
 			return resolveRefsInTerm(globals, ignore, e), nil
 		})
-		cpy := *term
-		cpy.Value = s
 		return &cpy
 	case *ArrayComprehension:
-		ac := &ArrayComprehension{}
-		ignore.Push(declaredVars(v.Body))
-		ac.Term = resolveRefsInTerm(globals, ignore, v.Term)
-		ac.Body = resolveRefsInBody(globals, ignore, v.Body)
+		ignore.Push(declaredBodyVars(v.Body))
 		cpy := *term
-		cpy.Value = ac
+		cpy.Value = &ArrayComprehension{
+			Term: resolveRefsInTerm(globals, ignore, v.Term),
+			Body: resolveRefsInBody(globals, ignore, v.Body),
+		}
 		ignore.Pop()
 		return &cpy
 	case *ObjectComprehension:
-		oc := &ObjectComprehension{}
-		ignore.Push(declaredVars(v.Body))
-		oc.Key = resolveRefsInTerm(globals, ignore, v.Key)
-		oc.Value = resolveRefsInTerm(globals, ignore, v.Value)
-		oc.Body = resolveRefsInBody(globals, ignore, v.Body)
+		ignore.Push(declaredBodyVars(v.Body))
 		cpy := *term
-		cpy.Value = oc
+		cpy.Value = &ObjectComprehension{
+			Key:   resolveRefsInTerm(globals, ignore, v.Key),
+			Value: resolveRefsInTerm(globals, ignore, v.Value),
+			Body:  resolveRefsInBody(globals, ignore, v.Body),
+		}
 		ignore.Pop()
 		return &cpy
 	case *SetComprehension:
-		sc := &SetComprehension{}
-		ignore.Push(declaredVars(v.Body))
-		sc.Term = resolveRefsInTerm(globals, ignore, v.Term)
-		sc.Body = resolveRefsInBody(globals, ignore, v.Body)
+		ignore.Push(declaredBodyVars(v.Body))
 		cpy := *term
-		cpy.Value = sc
+		cpy.Value = &SetComprehension{
+			Term: resolveRefsInTerm(globals, ignore, v.Term),
+			Body: resolveRefsInBody(globals, ignore, v.Body),
+		}
 		ignore.Pop()
 		return &cpy
 	case *TemplateString:
@@ -5887,12 +5916,8 @@ func (s declaredVarStack) Contains(v Var) bool {
 	return false
 }
 
-func (s declaredVarStack) Add(v Var) {
-	s[len(s)-1].Add(v)
-}
-
-func (s *declaredVarStack) Push(vs VarSet) {
-	*s = append(*s, vs)
+func (s *declaredVarStack) Push(vs ...VarSet) {
+	*s = append(*s, vs...)
 }
 
 func (s *declaredVarStack) Pop() {
@@ -5900,16 +5925,31 @@ func (s *declaredVarStack) Pop() {
 	*s = curr[:len(curr)-1]
 }
 
-func declaredVars(x any) VarSet {
+func declaredBodyVars(body Body) VarSet {
 	vars := NewVarSet()
+	for _, e := range body {
+		vars = declaredVars(e, vars)
+	}
+	return vars
+}
+
+func declaredVars(x any, vars VarSet) VarSet {
+	if vars == nil {
+		vars = NewVarSet()
+	}
 	vis := NewGenericVisitor(func(x any) bool {
 		switch x := x.(type) {
 		case *Expr:
 			if x.IsAssignment() && validEqAssignArgCount(x) {
-				WalkVars(x.Operand(0), func(v Var) bool {
+				lhs := x.Operand(0)
+				if v, ok := lhs.Value.(Var); ok {
 					vars.Add(v)
-					return false
-				})
+				} else {
+					WalkVars(lhs, func(v Var) bool {
+						vars.Add(v)
+						return false
+					})
+				}
 			} else if decl, ok := x.Terms.(*SomeDecl); ok {
 				for i := range decl.Symbols {
 					switch val := decl.Symbols[i].Value.(type) {
@@ -6003,8 +6043,7 @@ func rewriteEquals(x any) (modified bool) {
 	unifyOp := Equality.Ref()
 	t := GenericTransformer{f: func(x any) (any, error) {
 		if x, ok := x.(*Expr); ok && x.IsCall() {
-			operator := x.Operator()
-			if operator.Equal(Interned.Refs.Equal) && len(x.Operands()) == 2 {
+			if x.Operator().Equal(Interned.Refs.Equal) && len(x.Operands()) == 2 {
 				modified = true
 				x.SetOperator(NewTerm(unifyOp))
 			}
@@ -6028,7 +6067,8 @@ func rewriteTestEqualities(f *equalityFactory, body Body) Body {
 				result, terms[2] = rewriteDynamicsShallow(expr, f, terms[2], result)
 			case expr.IsEvery():
 				// We rewrite equalities inside of every-bodies as a fail here will be the cause of the test-rule fail.
-				// Failures inside other expressions with closures, such as comprehensions, won't cause the test-rule to fail, so we skip those.
+				// Failures inside other expressions with closures, such as comprehensions, won't cause the test-rule to
+				// fail, so we skip those.
 				every := expr.Terms.(*Every)
 				every.Body = rewriteTestEqualities(f, every.Body)
 			}
@@ -6711,26 +6751,26 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 		return errs
 	}
 
-	unused := NewVarSet()
+	var unused VarSet
 
 	for v, occ := range dvs.occurrence {
 		// A var that was assigned in this scope must have been seen (used) more than once (the time of assignment) in
 		// the same, or nested, scope to be counted as used.
-		if !v.IsWildcard() && stack.Count(v) <= 1 && occ == assignedVar {
+		if !v.IsWildcard() && stack.Count(v) <= 1 && occ == assignedVar && !used.Contains(dvs.vs[v]) {
+			if unused == nil {
+				unused = NewVarSet()
+			}
 			unused.Add(dvs.vs[v])
 		}
 	}
 
-	rewrittenUsed := NewVarSet()
+	// rewritten unused
 	for v := range used {
 		if gv, ok := stack.Declared(v); ok {
-			rewrittenUsed.Add(gv)
-		} else {
-			rewrittenUsed.Add(v)
+			delete(unused, gv)
 		}
 	}
 
-	unused = unused.Diff(rewrittenUsed)
 	if len(unused) == 0 {
 		return errs
 	}
@@ -6758,7 +6798,6 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 }
 
 func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, cpy Body, errs Errors) Errors {
-
 	// NOTE(tsandall): Do not generate more errors if there are existing
 	// declaration errors.
 	if len(errs) > 0 {
@@ -6805,14 +6844,21 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 		reversed[v] = k
 	}
 
+	var varsDeclaredInExpr VarSet
+
 	for _, gv := range dbv.Diff(used).Sorted() {
 		rv := reversed[gv]
 		if !rv.IsGenerated() {
 			// Scan through body exprs, looking for a match between the
 			// bad var's original name, and each expr's declared vars.
 			foundUnusedVarByName := false
+			if varsDeclaredInExpr == nil {
+				varsDeclaredInExpr = NewVarSet()
+			}
+
 			for i := range body {
-				varsDeclaredInExpr := declaredVars(body[i])
+				clear(varsDeclaredInExpr)
+				varsDeclaredInExpr = declaredVars(body[i], varsDeclaredInExpr)
 				if varsDeclaredInExpr.Contains(rv) {
 					// TODO(philipc): Clean up the offset logic here when the parser
 					// reports more accurate locations.
@@ -6914,12 +6960,6 @@ func rewriteSomeDeclStatement(g *localVarGenerator, stack *localDeclaredVars, ex
 	return nil, errs
 }
 
-const (
-	errAssignInNegated    = "cannot assign vars inside negated expression"
-	errAssignInAndOperand = "cannot assign vars inside implicit and operand"
-	errAssignInOrOperand  = "cannot assign vars inside implicit or operand"
-)
-
 func rewriteNotStatement(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {
 	if not := expr.Terms.(*Not); !not.ExplicitBody {
 		// Only explicit not bodies are allowed to declare vars.
@@ -7000,9 +7040,9 @@ func rewriteDeclaredVarsInImplicitBody(g *localVarGenerator, stack *localDeclare
 }
 
 func rewriteDeclaredVarsInExpr(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {
-	vis := NewGenericVisitor(func(x any) bool {
-		var stop bool
-		// Note: we don't include *Not nodes here, as such bodies are allowed to contain assignments; e.g. 'not {x := input.x; f(x)}'
+	vis := NewGenericVisitor(func(x any) (stop bool) {
+		// Note: we don't include *Not nodes here, as such bodies are
+		// allowed to contain assignments; e.g. 'not {x := input.x; f(x)}'
 		switch x := x.(type) {
 		case *Term:
 			stop, errs = rewriteDeclaredVarsInTerm(g, stack, x, errs, strict)
@@ -7016,17 +7056,15 @@ func rewriteDeclaredVarsInExpr(g *localVarGenerator, stack *localDeclaredVars, e
 }
 
 func rewriteDeclaredAssignment(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {
-
 	if expr.Negated {
-		errs = append(errs, newErrorString(CompileErr, expr.Location, errAssignInNegated))
-		return expr, errs
+		return expr, append(errs, newErrorString(CompileErr, expr.Location, errAssignInNegated))
 	}
-
-	numErrsBefore := len(errs)
 
 	if !validEqAssignArgCount(expr) {
 		return expr, errs
 	}
+
+	numErrsBefore := len(errs)
 
 	// Rewrite terms on right hand side capture seen vars and recursively
 	// process comprehensions before left hand side is processed. Also
@@ -7086,7 +7124,10 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 	switch v := term.Value.(type) {
 	case Var:
 		if gv, ok := stack.Declared(v); ok {
-			term.Value = gv
+			// don't allocate for boxing Var -> Value unless it changed
+			if gv != v {
+				term.Value = gv
+			}
 			stack.Seen(v)
 		} else if stack.Occurrence(v) == newVar {
 			stack.Insert(v, v, seenVar)
@@ -7095,8 +7136,10 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 		if RootDocumentRefs.Contains(term) {
 			x := v[0].Value.(Var)
 			if occ, ok := stack.GlobalOccurrence(x); ok && occ != seenVar {
-				gv, _ := stack.Declared(x)
-				term.Value = gv
+				// don't allocate for boxing Var -> Value unless it changed
+				if gv, _ := stack.Declared(x); gv != x {
+					term.Value = gv
+				}
 			}
 
 			return true, errs
@@ -7114,20 +7157,26 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 		})
 		return false, errs
 	case *object:
-		cpy, _ := v.Map(func(k, v *Term) (*Term, *Term, error) {
-			kcpy := k.Copy()
-			errs = rewriteDeclaredVarsInTermRecursive(g, stack, kcpy, errs, strict)
-			errs = rewriteDeclaredVarsInTermRecursive(g, stack, v, errs, strict)
+		term.Value, _ = v.Map(func(k, v *Term) (*Term, *Term, error) {
+			kcpy := k
+			if !IsScalar(k.Value) {
+				kcpy = k.Copy()
+				errs = rewriteDeclaredVarsInTermRecursive(g, stack, kcpy, errs, strict)
+			}
+			if !IsScalar(v.Value) {
+				errs = rewriteDeclaredVarsInTermRecursive(g, stack, v, errs, strict)
+			}
 			return kcpy, v, nil
 		})
-		term.Value = cpy
-	case Set:
-		cpy, _ := v.Map(func(elem *Term) (*Term, error) {
+	case *set:
+		term.Value, _ = v.Map(func(elem *Term) (*Term, error) {
+			if IsScalar(elem.Value) {
+				return elem, nil
+			}
 			elemcpy := elem.Copy()
 			errs = rewriteDeclaredVarsInTermRecursive(g, stack, elemcpy, errs, strict)
 			return elemcpy, nil
 		})
-		term.Value = cpy
 	case *ArrayComprehension:
 		errs = rewriteDeclaredVarsInArrayComprehension(g, stack, v, errs, strict)
 	case *SetComprehension:
@@ -7141,8 +7190,7 @@ func rewriteDeclaredVarsInTerm(g *localVarGenerator, stack *localDeclaredVars, t
 }
 
 func rewriteDeclaredVarsInTermRecursive(g *localVarGenerator, stack *localDeclaredVars, term *Term, errs Errors, strict bool) Errors {
-	WalkTerms(term, func(t *Term) bool {
-		var stop bool
+	WalkTerms(term, func(t *Term) (stop bool) {
 		stop, errs = rewriteDeclaredVarsInTerm(g, stack, t, errs, strict)
 		return stop
 	})

--- a/v1/ast/index_bench_test.go
+++ b/v1/ast/index_bench_test.go
@@ -180,10 +180,9 @@ func distinctRefInput(n int) Value {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
-		sb.WriteByte('"')
-		sb.WriteString("f" + strconv.Itoa(i))
-		sb.WriteString(`": `)
-		sb.WriteString(`"x"`)
+		sb.WriteString(`"f`)
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString(`": "x"`)
 	}
 	sb.WriteByte('}')
 	return MustParseTerm(sb.String()).Value

--- a/v1/ast/term.go
+++ b/v1/ast/term.go
@@ -1899,13 +1899,9 @@ func (s *set) Foreach(f func(*Term)) {
 
 // Map returns a new Set obtained by applying f to each value in s.
 func (s *set) Map(f func(*Term) (*Term, error)) (Set, error) {
-	mapped := make([]*Term, 0, len(s.keys))
-	for _, x := range s.sortedKeys() {
-		term, err := f(x)
-		if err != nil {
-			return nil, err
-		}
-		mapped = append(mapped, term)
+	mapped, err := util.TryMap(s.sortedKeys(), f)
+	if err != nil {
+		return nil, err
 	}
 	return NewSet(mapped...), nil
 }

--- a/v1/topdown/trace.go
+++ b/v1/topdown/trace.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	minLocationWidth      = 5 // len("query")
+	minLocationWidth      = len("query")
 	maxIdealLocationWidth = 64
 	columnPadding         = 4
 	maxExprVarWidth       = 32


### PR DESCRIPTION
A mixed bag, but pretty straightforward I would say. Mainly:

- Do not make deep copies of terms to have their vars rewritten unless they actually contain any vars
- Make better use/reuse of the various visitors

The result is a ~12% decrease in allocs/op and a ~5% decrease in compilation time, compiling the Regal bundle:

**BenchmarkCompileBundle-16**
```
74017903 ns/op	41793474 B/op	  879585 allocs/op // main
70071275 ns/op	37088672 B/op	  767943 allocs/op // this
```