### PR TITLE
yaml: parse against the YAML 1.2 core schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### YAML is now parsed against the 1.2 core schema ([#5754](https://github.com/open-policy-agent/opa/issues/5754))
+
+OPA parsed YAML with a library pinned to go-yaml v2, which implements YAML 1.1. Under
+1.1, the bare words `y`, `n`, `yes`, `no`, `on` and `off` resolve to booleans, so a
+GitHub Actions workflow loaded with `--data` came back with `true` where it should have
+had `on`:
+
+```yaml
+on: push
+```
+
+```json
+{ "true": "push" }
+```
+
+These words are now plain strings, as the YAML 1.2 core schema specifies. `true` and
+`false` are unaffected. This applies everywhere OPA reads YAML: `--data`, bundles,
+config files, and the `yaml.unmarshal` builtin.
+
+If you were relying on `yes`/`no`/`on`/`off` being read as booleans, quote the value and
+use `true`/`false` instead.
+
 ## 1.20.2
 
 This release includes a bug fix for a parser regression introduced in v1.20.0, and dependency

--- a/build/generate-extended-cases/extended_cases.go
+++ b/build/generate-extended-cases/extended_cases.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"sigs.k8s.io/yaml"
 
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/ir"
 	"github.com/open-policy-agent/opa/v1/rego"

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	gopkg.in/ini.v1 v1.67.3
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	oras.land/oras-go/v2 v2.6.2
-	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -113,7 +112,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.46.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,5 +339,3 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
 oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
-sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
-sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,8 @@ import (
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/open-policy-agent/opa/internal/strvals"
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/keys"
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/plugins/rest"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,8 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"sigs.k8s.io/yaml"
-
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/util/test"
 )
 

--- a/internal/strvals/parser.go
+++ b/internal/strvals/parser.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"sigs.k8s.io/yaml"
+	"github.com/open-policy-agent/opa/internal/yaml"
 )
 
 // ErrNotList indicates that a non-list was treated as a list.

--- a/internal/strvals/parser_test.go
+++ b/internal/strvals/parser_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"testing"
 
-	"sigs.k8s.io/yaml"
+	"github.com/open-policy-agent/opa/internal/yaml"
 )
 
 func TestSetIndex(t *testing.T) {

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -1,0 +1,311 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package yaml provides YAML <-> JSON conversion for OPA, on top of
+// go.yaml.in/yaml/v3.
+//
+// It replaces sigs.k8s.io/yaml, which is pinned to go.yaml.in/yaml/v2 and
+// therefore resolves YAML 1.1 boolean spellings (on/off/yes/no) in positions
+// where the YAML 1.2 core schema calls for strings.
+package yaml
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Marshal serializes obj as YAML. obj is first round-tripped through
+// encoding/json so that `json` struct tags and json.Marshaler
+// implementations are honoured, matching the behaviour callers relied on
+// from sigs.k8s.io/yaml.
+func Marshal(obj any) ([]byte, error) {
+	bs, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling into JSON: %w", err)
+	}
+	var jsonObj any
+	if err := yaml.Unmarshal(bs, &jsonObj); err != nil {
+		return nil, err
+	}
+	return marshalYAML(jsonObj)
+}
+
+// marshalYAML emits YAML at 2-space indentation. go-yaml v3 defaults to 4,
+// where sigs.k8s.io/yaml (on go-yaml v2) emitted 2.
+func marshalYAML(obj any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(obj); err != nil {
+		_ = enc.Close()
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// JSONOpt configures the encoding/json decoder used by Unmarshal.
+type JSONOpt func(*json.Decoder) *json.Decoder
+
+// Unmarshal decodes a YAML document into obj, using encoding/json semantics
+// (`json` struct tags, json.Unmarshaler) rather than go-yaml's.
+func Unmarshal(bs []byte, obj any, opts ...JSONOpt) error {
+	js, err := YAMLToJSON(bs)
+	if err != nil {
+		return err
+	}
+	d := json.NewDecoder(bytes.NewReader(js))
+	for _, opt := range opts {
+		d = opt(d)
+	}
+	if err := d.Decode(obj); err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+	return nil
+}
+
+// YAMLToJSON converts a single YAML document to JSON.
+func YAMLToJSON(bs []byte) ([]byte, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(bs, &node); err != nil {
+		return nil, err
+	}
+
+	var obj any
+	if node.Kind != 0 { // an empty document decodes to the zero Node
+		normalize(&node, map[*yaml.Node]struct{}{})
+		if err := node.Decode(&obj); err != nil {
+			return nil, err
+		}
+	}
+
+	obj, err := jsonable(obj)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(obj)
+}
+
+// normalize rewrites the node tree before it is decoded, so that documents
+// go-yaml v2 accepted keep working under v3.
+//
+// Implicitly resolved !!timestamp scalars are re-tagged !!str. !!timestamp is
+// a YAML 1.1 type that go-yaml v3 still resolves in the core schema; leaving
+// it in place would silently rewrite `2023-01-01` to `2023-01-01T00:00:00Z`
+// on the way to JSON.
+//
+// Repeated merge keys are folded into the sequence form, and duplicate
+// mapping keys are collapsed to the last occurrence. go-yaml v3 rejects both
+// outright; go-yaml v2 accepted them, and turning documents that load today
+// into hard errors is a bigger change than this package is trying to make.
+//
+// Anchors make the node graph a DAG, so visited guards against re-walking a
+// shared subtree.
+func normalize(n *yaml.Node, visited map[*yaml.Node]struct{}) {
+	if n == nil {
+		return
+	}
+	if _, ok := visited[n]; ok {
+		return
+	}
+	visited[n] = struct{}{}
+
+	switch n.Kind {
+	case yaml.ScalarNode:
+		if n.Tag == "!!timestamp" && n.Style == 0 {
+			n.Tag = "!!str"
+		}
+	case yaml.MappingNode:
+		n.Content = collapseMergeKeys(n.Content)
+		n.Content = dedupeKeys(n.Content)
+	}
+
+	normalize(n.Alias, visited)
+	for _, c := range n.Content {
+		normalize(c, visited)
+	}
+}
+
+// collapseMergeKeys rewrites a mapping that repeats `<<` into the spec's
+// sequence form (`<<: [a, b]`), which go-yaml v3 accepts. go-yaml v2 applied
+// repeated merge keys in document order, so preserve that order.
+func collapseMergeKeys(content []*yaml.Node) []*yaml.Node {
+	first := -1
+	var merged []*yaml.Node
+
+	for i := 0; i+1 < len(content); i += 2 {
+		if content[i].Kind != yaml.ScalarNode || content[i].Tag != "!!merge" {
+			continue
+		}
+		if first < 0 {
+			first = i
+		}
+		if v := content[i+1]; v.Kind == yaml.SequenceNode {
+			merged = append(merged, v.Content...)
+		} else {
+			merged = append(merged, v)
+		}
+	}
+
+	if first < 0 || len(merged) < 2 {
+		return content
+	}
+
+	out := make([]*yaml.Node, 0, len(content))
+	for i := 0; i+1 < len(content); i += 2 {
+		switch {
+		case i == first:
+			out = append(out, content[i], &yaml.Node{
+				Kind:    yaml.SequenceNode,
+				Tag:     "!!seq",
+				Content: merged,
+			})
+		case content[i].Kind == yaml.ScalarNode && content[i].Tag == "!!merge":
+			// dropped; folded into the sequence above
+		default:
+			out = append(out, content[i], content[i+1])
+		}
+	}
+	return out
+}
+
+// dedupeKeys drops all but the last occurrence of each key in a mapping's
+// flattened key/value Content slice, preserving the position of the first
+// occurrence the way a last-wins map assignment would.
+//
+// go-yaml v3 rejects duplicate keys outright, but go-yaml v2 accepted them,
+// and turning documents that load today into hard errors is a bigger change
+// than this package is trying to make. Keys are compared by the string they
+// will occupy in the resulting JSON object, so `1` and `"1"` collide here the
+// same way they would there.
+func dedupeKeys(content []*yaml.Node) []*yaml.Node {
+	seen := make(map[string]int, len(content)/2)
+	dropped := false
+
+	for i := 0; i+1 < len(content); i += 2 {
+		k := content[i]
+		// Merge keys are not real keys, and non-scalar keys have no JSON
+		// representation - both are handled elsewhere.
+		if k.Kind != yaml.ScalarNode || k.Tag == "!!merge" {
+			continue
+		}
+		var kv any
+		if err := k.Decode(&kv); err != nil {
+			continue
+		}
+		id, ok := keyString(kv)
+		if !ok {
+			continue
+		}
+		if prevVal, ok := seen[id]; ok {
+			// Keep the earlier key node's position, take the later value.
+			content[prevVal] = content[i+1]
+			content[i], content[i+1] = nil, nil
+			dropped = true
+			continue
+		}
+		seen[id] = i + 1
+	}
+
+	if !dropped {
+		return content
+	}
+
+	out := content[:0]
+	for _, n := range content {
+		if n != nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// JSONToYAML converts JSON to YAML, preserving nothing but the value.
+func JSONToYAML(bs []byte) ([]byte, error) {
+	var obj any
+	// json.Number would be re-encoded as a quoted string by go-yaml, so decode
+	// numbers as float64 the way encoding/json does by default.
+	if err := json.Unmarshal(bs, &obj); err != nil {
+		return nil, err
+	}
+	return marshalYAML(obj)
+}
+
+// jsonable rewrites the result of a go-yaml decode into something
+// encoding/json can marshal: YAML permits mapping keys of any type, JSON
+// only permits strings.
+func jsonable(x any) (any, error) {
+	switch x := x.(type) {
+	case map[string]any:
+		for k, v := range x {
+			v, err := jsonable(v)
+			if err != nil {
+				return nil, err
+			}
+			x[k] = v
+		}
+		return x, nil
+	case map[any]any:
+		out := make(map[string]any, len(x))
+		for k, v := range x {
+			ks, ok := keyString(k)
+			if !ok {
+				return nil, fmt.Errorf("unsupported map key of type: %s, key: %+#v, value: %+#v", reflect.TypeOf(k), k, v)
+			}
+			v, err := jsonable(v)
+			if err != nil {
+				return nil, err
+			}
+			out[ks] = v
+		}
+		return out, nil
+	case []any:
+		for i, v := range x {
+			v, err := jsonable(v)
+			if err != nil {
+				return nil, err
+			}
+			x[i] = v
+		}
+		return x, nil
+	default:
+		return x, nil
+	}
+}
+
+func keyString(k any) (string, bool) {
+	switch k := k.(type) {
+	case string:
+		return k, true
+	case int:
+		return strconv.Itoa(k), true
+	case int64:
+		return strconv.FormatInt(k, 10), true
+	case uint64:
+		return strconv.FormatUint(k, 10), true
+	case float64:
+		// Match how go-yaml renders floats when marshaling.
+		switch s := strconv.FormatFloat(k, 'g', -1, 32); s {
+		case "+Inf":
+			return ".inf", true
+		case "-Inf":
+			return "-.inf", true
+		case "NaN":
+			return ".nan", true
+		default:
+			return s, true
+		}
+	case bool:
+		return strconv.FormatBool(k), true
+	default:
+		return "", false
+	}
+}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package yaml
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestYAMLToJSON(t *testing.T) {
+	tests := []struct {
+		note   string
+		yaml   string
+		exp    string
+		expErr string
+	}{
+		{
+			note: "YAML 1.1 boolean spellings stay strings (issue 5754)",
+			yaml: "on: push\noff: x\n",
+			exp:  `{"off":"x","on":"push"}`,
+		},
+		{
+			note: "YAML 1.1 boolean spellings as values",
+			yaml: "a: yes\nb: no\nc: y\nd: n\ne: On\nf: OFF\n",
+			exp:  `{"a":"yes","b":"no","c":"y","d":"n","e":"On","f":"OFF"}`,
+		},
+		{
+			note: "YAML 1.2 booleans still resolve",
+			yaml: "a: true\nb: FALSE\nc: True\n",
+			exp:  `{"a":true,"b":false,"c":true}`,
+		},
+		{
+			note: "non-string keys are stringified",
+			yaml: "1: a\ntrue: b\n1.5: c\n",
+			exp:  `{"1":"a","1.5":"c","true":"b"}`,
+		},
+		{
+			note:   "null keys are rejected",
+			yaml:   "null: a\n",
+			expErr: "unsupported map key of type",
+		},
+		{
+			note:   "sequence keys are rejected",
+			yaml:   "? [1, 2]\n: v\n",
+			expErr: "invalid map key",
+		},
+		{
+			note: "nested collections",
+			yaml: "a:\n  - on\n  - {off: 1}\n",
+			exp:  `{"a":["on",{"off":1}]}`,
+		},
+		{
+			note: "anchors and merge keys",
+			yaml: "base: &b\n  on: 1\nderived:\n  <<: *b\n  y: 2\n",
+			exp:  `{"base":{"on":1},"derived":{"on":1,"y":2}}`,
+		},
+		{
+			note: "empty document",
+			yaml: "",
+			exp:  `null`,
+		},
+		{
+			note: "timestamps stay strings",
+			yaml: "a: 2023-01-01\nb: 2023-01-01 10:00:00\nc: 2023-01-01T10:00:00Z\n",
+			exp:  `{"a":"2023-01-01","b":"2023-01-01 10:00:00","c":"2023-01-01T10:00:00Z"}`,
+		},
+		{
+			note: "timestamps behind an alias stay strings",
+			yaml: "a: &t 2023-01-01\nb: *t\n",
+			exp:  `{"a":"2023-01-01","b":"2023-01-01"}`,
+		},
+		{
+			note: "duplicate keys resolve last-wins",
+			yaml: "a: 1\nb: 9\na: 2\na: 3\n",
+			exp:  `{"a":3,"b":9}`,
+		},
+		{
+			note: "duplicate keys in a nested mapping",
+			yaml: "x:\n  a: 1\n  a: 2\n",
+			exp:  `{"x":{"a":2}}`,
+		},
+		{
+			note: "repeated merge keys are not deduplicated",
+			yaml: "p: &p\n  x: 1\nq: &q\n  y: 2\nr:\n  <<: *p\n  <<: *q\n  z: 3\n",
+			exp:  `{"p":{"x":1},"q":{"y":2},"r":{"x":1,"y":2,"z":3}}`,
+		},
+		{
+			note: "explicit key overrides a merged one",
+			yaml: "p: &p\n  x: 1\nq:\n  <<: *p\n  x: 2\n",
+			exp:  `{"p":{"x":1},"q":{"x":2}}`,
+		},
+		{
+			note: "keys colliding only after stringification are last-wins",
+			yaml: "1: a\n\"1\": b\n",
+			exp:  `{"1":"b"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			bs, err := YAMLToJSON([]byte(tc.yaml))
+			if tc.expErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got %s", tc.expErr, bs)
+				}
+				if !contains(err.Error(), tc.expErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.expErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(bs) != tc.exp {
+				t.Fatalf("expected %s, got %s", tc.exp, bs)
+			}
+		})
+	}
+}
+
+func TestUnmarshalUsesJSONTags(t *testing.T) {
+	var x struct {
+		On string `json:"on"`
+	}
+	if err := Unmarshal([]byte("on: push\n"), &x); err != nil {
+		t.Fatal(err)
+	}
+	if x.On != "push" {
+		t.Fatalf("expected push, got %q", x.On)
+	}
+}
+
+func TestUnmarshalJSONOpt(t *testing.T) {
+	var x any
+	useNumber := JSONOpt(func(d *json.Decoder) *json.Decoder {
+		d.UseNumber()
+		return d
+	})
+	if err := Unmarshal([]byte("a: 1\n"), &x, useNumber); err != nil {
+		t.Fatal(err)
+	}
+	exp := map[string]any{"a": json.Number("1")}
+	if !reflect.DeepEqual(x, exp) {
+		t.Fatalf("expected %#v, got %#v", exp, x)
+	}
+}
+
+func TestMarshalRoundTripsThroughJSON(t *testing.T) {
+	in := map[string]any{"n": json.Number("3"), "s": "on"}
+	bs, err := Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp := "\"n\": 3\ns: \"on\"\n"; string(bs) != exp {
+		t.Fatalf("expected %q, got %q", exp, bs)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/v1/loader/loader.go
+++ b/v1/loader/loader.go
@@ -15,10 +15,9 @@ import (
 	"runtime"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	fileurl "github.com/open-policy-agent/opa/internal/file/url"
 	"github.com/open-policy-agent/opa/internal/merge"
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/ast"
 	astJSON "github.com/open-policy-agent/opa/v1/ast/json"
 	"github.com/open-policy-agent/opa/v1/bundle"

--- a/v1/loader/loader_test.go
+++ b/v1/loader/loader_test.go
@@ -453,6 +453,36 @@ func TestLoadYAML(t *testing.T) {
 	})
 }
 
+func TestLoadYAMLKeywordKeys(t *testing.T) {
+	files := map[string]string{
+		"/foo.yaml": `
+on: push
+off: x
+a: yes
+b: no
+c: y
+d: n
+e: true
+f: FALSE
+`,
+	}
+
+	test.WithTempFS(files, func(rootDir string) {
+		loaded, err := NewFileLoader().All([]string{filepath.Join(rootDir, "foo.yaml")})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		expected := parseJSON(`{
+			"on": "push", "off": "x",
+			"a": "yes", "b": "no", "c": "y", "d": "n",
+			"e": true, "f": false
+		}`)
+		if !reflect.DeepEqual(loaded.Documents, expected) {
+			t.Fatalf("Expected %v but got: %v", expected, loaded.Documents)
+		}
+	})
+}
+
 func TestLoadGuessYAML(t *testing.T) {
 	files := map[string]string{
 		"/foo": `

--- a/v1/plugins/bundle/config_test.go
+++ b/v1/plugins/bundle/config_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/bundle"
 
-	"sigs.k8s.io/yaml"
+	"github.com/open-policy-agent/opa/internal/yaml"
 )
 
 func TestConfigValidation(t *testing.T) {

--- a/v1/topdown/encoding.go
+++ b/v1/topdown/encoding.go
@@ -12,8 +12,7 @@ import (
 	"net/url"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/topdown/builtins"
 	"github.com/open-policy-agent/opa/v1/util"

--- a/v1/topdown/encoding_test.go
+++ b/v1/topdown/encoding_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import "testing"
+
+func TestYAMLUnmarshalKeywordKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		note     string
+		doc      string
+		expected any
+	}{
+		{
+			note:     "on/off keys stay strings",
+			doc:      "on: push\noff: x\n",
+			expected: `{"on": "push", "off": "x"}`,
+		},
+		{
+			note:     "yes/no/y/n values stay strings",
+			doc:      "a: yes\nb: no\nc: y\nd: n\n",
+			expected: `{"a": "yes", "b": "no", "c": "y", "d": "n"}`,
+		},
+		{
+			note:     "1.2 booleans still resolve",
+			doc:      "a: true\nb: FALSE\n",
+			expected: `{"a": true, "b": false}`,
+		},
+		{
+			note:     "timestamps stay strings",
+			doc:      "a: 2023-01-01\n",
+			expected: `{"a": "2023-01-01"}`,
+		},
+		{
+			note:     "non-string keys are stringified",
+			doc:      "1: a\ntrue: b\n",
+			expected: `{"1": "a", "true": "b"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		rules := []string{
+			`p = x { yaml.unmarshal(` + quoteRego(tc.doc) + `, x) }`,
+		}
+		runTopDownTestCase(t, map[string]any{}, tc.note, rules, tc.expected)
+	}
+}
+
+// quoteRego renders s as a Rego string literal.
+func quoteRego(s string) string {
+	out := []byte{'"'}
+	for i := range len(s) {
+		switch c := s[i]; c {
+		case '"', '\\':
+			out = append(out, '\\', c)
+		case '\n':
+			out = append(out, '\\', 'n')
+		default:
+			out = append(out, c)
+		}
+	}
+	return string(append(out, '"'))
+}

--- a/v1/topdown/topdown_test.go
+++ b/v1/topdown/topdown_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/format"
-	"sigs.k8s.io/yaml"
 
 	iCache "github.com/open-policy-agent/opa/v1/topdown/cache"
 

--- a/v1/util/json.go
+++ b/v1/util/json.go
@@ -12,8 +12,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"sigs.k8s.io/yaml"
-
+	"github.com/open-policy-agent/opa/internal/yaml"
 	"github.com/open-policy-agent/opa/v1/loader/extension"
 )
 


### PR DESCRIPTION
Replace sigs.k8s.io/yaml, which is pinned to go-yaml v2 and resolves the YAML 1.1 bare words y/n/yes/no/on/off as booleans, with a small internal package over go-yaml v3. This also leaves go-yaml v3 as the module's only YAML library.

Fixes: #5754
Fixes: #6598