### PR TITLE
ast: report violations from multiple compiler stages

### DIFF
--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -297,6 +297,44 @@ func TestCheckFailsOnInvalidRego(t *testing.T) {
 	})
 }
 
+func TestCheckStrictReportsAllViolations(t *testing.T) {
+	files := map[string]string{
+		"test.rego": `package test
+
+import data.foo
+import data.foo
+
+a := any([foo])
+b := all([true])
+
+f(x) if {
+	input.bar
+}`,
+	}
+
+	expected := []string{
+		"test.rego:4: rego_compile_error: import must not shadow import data.foo",
+		"test.rego:6: rego_type_error: deprecated built-in function calls in expression: any",
+		"test.rego:7: rego_type_error: deprecated built-in function calls in expression: all",
+		"test.rego:9: rego_compile_error: unused argument x. (hint: use _ (wildcard variable) instead)",
+	}
+
+	test.WithTempFS(files, func(root string) {
+		params := newCheckParams()
+		params.strict = true
+
+		err := checkModules(params, []string{root})
+		if err == nil {
+			t.Fatal("expected error but received none")
+		}
+
+		exp := "4 errors occurred:\n" + strings.Join(expected, "\n")
+		if got := strings.ReplaceAll(err.Error(), root+string(filepath.Separator), ""); got != exp {
+			t.Errorf("expected:\n\n%v\n\ngot:\n\n%v", exp, got)
+		}
+	})
+}
+
 func TestCheckJSONOutputBytes(t *testing.T) {
 	files := map[string]string{
 		"test.rego": `package test

--- a/v1/ast/compile.go
+++ b/v1/ast/compile.go
@@ -179,6 +179,8 @@ type Compiler struct {
 	defaultRegoVersion         RegoVersion
 	skipStages                 map[StageID]struct{} // stages to skip during compilation
 	plan                       *executionPlan       // computed execution plan (cached)
+	unusedImports              []*Import            // imports found unused during ref resolution, reported by CheckUnusedImports
+	unrecoverableErr           bool                 // at least one recorded error prevents the remaining stages from running
 }
 
 func (c *Compiler) DefaultRegoVersion() RegoVersion {
@@ -197,6 +199,7 @@ type StageID string
 // at least lets you know what your attention is needed when you depend on the stages.
 const (
 	StageResolveRefs                StageID = "ResolveRefs"
+	StageCheckUnusedImports         StageID = "CheckUnusedImports"
 	StageInitLocalVarGen            StageID = "InitLocalVarGen"
 	StageRewriteRuleHeadRefs        StageID = "RewriteRuleHeadRefs"
 	StageCheckKeywordOverrides      StageID = "CheckKeywordOverrides"
@@ -239,6 +242,7 @@ const (
 func AllStages() []StageID {
 	return []StageID{
 		StageResolveRefs,
+		StageCheckUnusedImports,
 		StageInitLocalVarGen,
 		StageRewriteRuleHeadRefs,
 		StageCheckKeywordOverrides,
@@ -457,6 +461,7 @@ func NewCompiler() *Compiler {
 		// load additional modules. If any stages run before resolution, they
 		// need to be re-run after resolution.
 		{StageResolveRefs, "compile_stage_resolve_refs", c.resolveAllRefs},
+		{StageCheckUnusedImports, "compile_stage_check_unused_imports", c.checkUnusedImports},
 		// The local variable generator must be initialized after references are
 		// resolved and the dynamic module loader has run but before subsequent
 		// stages that need to generate variables.
@@ -1906,9 +1911,7 @@ func (c *Compiler) checkTypes() {
 		as = c.annotationSet
 	}
 	env, errs := checker.CheckTypes(c.TypeEnv, sorted, as)
-	for _, err := range errs {
-		c.err(err)
-	}
+	c.errRecoverable(errs...)
 	c.TypeEnv = env
 }
 
@@ -1952,10 +1955,7 @@ func (c *Compiler) checkUnsafeBuiltins() {
 	}
 
 	for _, name := range c.sorted {
-		errs := checkUnsafeBuiltins(c.unsafeBuiltinsMap, c.Modules[name])
-		for _, err := range errs {
-			c.err(err)
-		}
+		c.errRecoverable(checkUnsafeBuiltins(c.unsafeBuiltinsMap, c.Modules[name])...)
 	}
 }
 
@@ -1973,7 +1973,7 @@ func (c *Compiler) checkDeprecatedBuiltins() {
 
 	for _, name := range c.sorted {
 		if c.strict || c.Modules[name].regoV1Compatible() {
-			c.err(checkDeprecatedBuiltins(c.deprecatedBuiltinsMap, c.Modules[name])...)
+			c.errRecoverable(checkDeprecatedBuiltins(c.deprecatedBuiltinsMap, c.Modules[name])...)
 		}
 	}
 }
@@ -1981,23 +1981,38 @@ func (c *Compiler) checkDeprecatedBuiltins() {
 func (c *Compiler) compile() {
 	plan := c.getOrBuildPlan()
 
+	defer c.sortErrors()
+
 	if c.metrics != nil {
 		for _, s := range plan.stages {
 			c.metrics.Timer(s.metricName).Start()
 			s.f()
 			c.metrics.Timer(s.metricName).Stop()
-			if c.Failed() {
+			if c.unrecoverableErr {
 				return
 			}
 		}
 	} else {
 		for _, s := range plan.stages {
 			s.f()
-			if c.Failed() {
+			if c.unrecoverableErr {
 				return
 			}
 		}
 	}
+}
+
+// sortErrors orders errors by location so reports read top-to-bottom. The error
+// limit marker has no location of its own and is swapped to the end to keep it
+// last, wherever it was recorded.
+func (c *Compiler) sortErrors() {
+	errs := c.Errors
+	if i := slices.Index(errs, errLimitReached); i >= 0 {
+		errs[i], errs[len(errs)-1] = errs[len(errs)-1], errs[i]
+		errs = errs[:len(errs)-1]
+	}
+
+	errs.Sort()
 }
 
 func (c *Compiler) init() {
@@ -2076,7 +2091,19 @@ func (c *Compiler) init() {
 	c.initialized = true
 }
 
+// err records an error that stops compilation after the current stage.
 func (c *Compiler) err(errs ...*Error) bool { // returns if we should continue
+	return c.recordErrs(false, errs...)
+}
+
+// errRecoverable records an error that lets the remaining stages run, so that one
+// compilation can report every violation it finds. Only for checks that leave the
+// modules in a state later stages can't produce bogus follow-up errors from.
+func (c *Compiler) errRecoverable(errs ...*Error) bool {
+	return c.recordErrs(true, errs...)
+}
+
+func (c *Compiler) recordErrs(recoverable bool, errs ...*Error) bool {
 	if len(errs) == 0 {
 		return true
 	}
@@ -2086,6 +2113,7 @@ func (c *Compiler) err(errs ...*Error) bool { // returns if we should continue
 
 	if c.maxErrs <= 0 {
 		c.Errors = append(c.Errors, errs...)
+		c.unrecoverableErr = c.unrecoverableErr || !recoverable
 		return true
 	}
 
@@ -2104,6 +2132,8 @@ func (c *Compiler) err(errs ...*Error) bool { // returns if we should continue
 
 	c.errCount += uint32(numToTake)
 	c.Errors = append(c.Errors, errs[:numToTake]...)
+	// Nothing left to collect once the limit is hit, so stop there too.
+	c.unrecoverableErr = c.unrecoverableErr || !recoverable || isLimitReachedInThisCall
 	if isLimitReachedInThisCall {
 		c.Errors = append(c.Errors, errLimitReached)
 	}
@@ -2155,7 +2185,7 @@ func (c *Compiler) checkImports() {
 	for _, name := range c.sorted {
 		for _, imp := range c.Modules[name].Imports {
 			if !supportsRegoV1Import && RegoV1CompatibleRef.Equal(imp.Path.Value) {
-				if !c.err(NewError(CompileErr, imp.Loc(), "rego.v1 import is not supported")) {
+				if !c.errRecoverable(NewError(CompileErr, imp.Loc(), "rego.v1 import is not supported")) {
 					continue
 				}
 			}
@@ -2166,13 +2196,25 @@ func (c *Compiler) checkImports() {
 		}
 	}
 
-	c.err(checkDuplicateImports(modules)...)
+	c.errRecoverable(checkDuplicateImports(modules)...)
+}
+
+// checkUnusedImports reports the imports resolveAllRefs found unused. Strict mode
+// only, and a stage of its own so these don't cut compilation short.
+func (c *Compiler) checkUnusedImports() {
+	for _, imp := range c.unusedImports {
+		if !c.errRecoverable(NewError(CompileErr, imp.Location, "%s unused", imp.String())) {
+			break
+		}
+	}
+
+	c.unusedImports = nil
 }
 
 func (c *Compiler) checkKeywordOverrides() {
 	for _, name := range c.sorted {
 		if c.strict || c.moduleIsRegoV1Compatible(c.Modules[name]) {
-			if !c.err(checkRootDocumentOverrides(c.Modules[name])...) {
+			if !c.errRecoverable(checkRootDocumentOverrides(c.Modules[name])...) {
 				continue
 			}
 		}
@@ -2226,6 +2268,7 @@ func (c *Compiler) moduleIsRegoV1Compatible(mod *Module) bool {
 // The reference "c.d.e" would be resolved to "data.a.b.c.d.e".
 func (c *Compiler) resolveAllRefs() {
 	exports := c.getExports()
+	c.unusedImports = nil
 
 	for _, name := range c.sorted {
 		mod := c.Modules[name]
@@ -2240,7 +2283,7 @@ func (c *Compiler) resolveAllRefs() {
 			return false
 		})
 
-		if c.strict { // check for unused imports
+		if c.strict { // collect unused imports, reported by the CheckUnusedImports stage
 			for _, imp := range mod.Imports {
 				path := imp.Path.Value.(Ref)
 				if FutureRootDocument.Equal(path[0]) || RegoRootDocument.Equal(path[0]) {
@@ -2249,9 +2292,7 @@ func (c *Compiler) resolveAllRefs() {
 
 				for v, u := range globals {
 					if v == imp.Name() && !u.used {
-						if !c.err(NewError(CompileErr, imp.Location, "%s unused", imp.String())) {
-							return
-						}
+						c.unusedImports = append(c.unusedImports, imp)
 					}
 				}
 			}
@@ -2372,6 +2413,8 @@ func (c *Compiler) rewriteRuleHeadRefs() {
 	}
 }
 
+// checkVoidCalls errors are not recoverable: the type checker has no type for an
+// expression using a void result, and reports a bogus "undefined function" for it.
 func (c *Compiler) checkVoidCalls() {
 	for _, name := range c.sorted {
 		c.err(checkVoidCalls(c.TypeEnv, c.Modules[name])...)
@@ -3279,6 +3322,9 @@ func (c *Compiler) rewriteLocalVars() {
 				if !c.err(errs...) {
 					return true
 				}
+				if !c.errRecoverable(stack.unused...) {
+					return true
+				}
 				if stack.assignment {
 					assignment = true
 				}
@@ -3300,7 +3346,7 @@ func (c *Compiler) rewriteLocalVars() {
 							"unused argument %v. (hint: use _ (wildcard variable) instead)",
 							arg,
 						)
-						if !c.err(err) {
+						if !c.errRecoverable(err) {
 							return true
 						}
 					}
@@ -3343,6 +3389,7 @@ func (c *Compiler) rewriteLocalVarsInRule(rule *Rule, unusedArgs VarSet, argsSta
 		nxfVis := NewGenericVisitor(nestedXform.Visit)
 		nxfVis.Walk(rule.Head)
 		c.err(nestedXform.errs...) // NB(sr): This is a bit bogus -- Why not return them?
+		c.errRecoverable(nestedXform.unused...)
 
 		// Rewrite assignments in body.
 		vis := varVisitorPool.Get()
@@ -3477,6 +3524,7 @@ func headMayHaveVars(head *Head) bool {
 type rewriteNestedHeadVarLocalTransform struct {
 	gen           *localVarGenerator
 	errs          Errors
+	unused        Errors // strict-mode "unused var" diagnostics, see localDeclaredVars.unused
 	RewrittenVars map[Var]Var
 	strict        bool
 }
@@ -3528,6 +3576,7 @@ func (xform *rewriteNestedHeadVarLocalTransform) Visit(x any) bool {
 		}
 
 		maps.Copy(xform.RewrittenVars, stack.rewritten)
+		xform.unused = append(xform.unused, stack.unused...)
 
 		return stop
 	}
@@ -3854,6 +3903,7 @@ func (qc *queryCompiler) rewriteLocalVars(_ *QueryContext, body Body) (Body, err
 	gen := newLocalVarGenerator("q", body)
 	stack := newLocalDeclaredVars()
 	body, _, err := rewriteLocalVars(gen, stack, nil, body, qc.compiler.strict)
+	err = append(err, stack.unused...)
 	if len(err) != 0 {
 		return nil, err
 	}
@@ -6526,6 +6576,10 @@ type localDeclaredVars struct {
 
 	// indicates if an assignment (:= operator) has been seen *ever*
 	assignment bool
+
+	// strict-mode diagnostics for assigned and declared vars that are never used,
+	// kept apart from the rewrite errors because they're recoverable
+	unused Errors
 }
 
 type varOccurrence uint8
@@ -6577,6 +6631,7 @@ func (s *localDeclaredVars) Clear() {
 	clear(s.rewritten)
 
 	s.vars = s.vars[:0]
+	s.unused = nil
 
 	if vs != nil {
 		s.vars = append(s.vars, vs.clear())
@@ -6730,13 +6785,15 @@ func rewriteDeclaredVarsInBody(g *localVarGenerator, stack *localDeclaredVars, u
 		cpy.Append(NewExpr(BooleanTerm(true)))
 	}
 
-	errs = checkUnusedAssignedVars(body, stack, used, errs, strict)
-	return cpy, checkUnusedDeclaredVars(body, stack, used, cpy, errs)
+	checkUnusedAssignedVars(body, stack, used, errs, strict)
+	checkUnusedDeclaredVars(body, stack, used, cpy, errs)
+
+	return cpy, errs
 }
 
-func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, errs Errors, strict bool) Errors {
-	if !strict || len(errs) > 0 {
-		return errs
+func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, errs Errors, strict bool) {
+	if !strict || len(errs) > 0 || len(stack.unused) > 0 {
+		return
 	}
 
 	dvs := stack.Peek()
@@ -6748,7 +6805,7 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 		}
 	}
 	if !hasAssignedVars {
-		return errs
+		return
 	}
 
 	var unused VarSet
@@ -6772,7 +6829,7 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 	}
 
 	if len(unused) == 0 {
-		return errs
+		return
 	}
 
 	reversed := make(map[Var]Var, len(dvs.vs))
@@ -6784,24 +6841,22 @@ func checkUnusedAssignedVars(body Body, stack *localDeclaredVars, used VarSet, e
 		found := false
 		for i := range body {
 			if body[i].Vars(VarVisitorParams{}).Contains(gv) {
-				errs = append(errs, NewError(CompileErr, body[i].Loc(), "assigned var %v unused", reversed[gv]))
+				stack.unused = append(stack.unused, NewError(CompileErr, body[i].Loc(), "assigned var %v unused", reversed[gv]))
 				found = true
 				break
 			}
 		}
 		if !found {
-			errs = append(errs, NewError(CompileErr, body[0].Loc(), "assigned var %v unused", reversed[gv]))
+			stack.unused = append(stack.unused, NewError(CompileErr, body[0].Loc(), "assigned var %v unused", reversed[gv]))
 		}
 	}
-
-	return errs
 }
 
-func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, cpy Body, errs Errors) Errors {
+func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, cpy Body, errs Errors) {
 	// NOTE(tsandall): Do not generate more errors if there are existing
 	// declaration errors.
-	if len(errs) > 0 {
-		return errs
+	if len(errs) > 0 || len(stack.unused) > 0 {
+		return
 	}
 
 	dvs := stack.Peek()
@@ -6813,7 +6868,7 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 		}
 	}
 	if !hasDeclaredVars {
-		return errs
+		return
 	}
 
 	declared := NewVarSet()
@@ -6836,7 +6891,7 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 
 	dbv := declared.Diff(bodyvars)
 	if dbv.DiffCount(used) == 0 {
-		return errs
+		return
 	}
 
 	reversed := make(map[Var]Var, len(dvs.vs))
@@ -6862,19 +6917,17 @@ func checkUnusedDeclaredVars(body Body, stack *localDeclaredVars, used VarSet, c
 				if varsDeclaredInExpr.Contains(rv) {
 					// TODO(philipc): Clean up the offset logic here when the parser
 					// reports more accurate locations.
-					errs = append(errs, NewError(CompileErr, body[i].Loc(), "declared var %v unused", rv))
+					stack.unused = append(stack.unused, NewError(CompileErr, body[i].Loc(), "declared var %v unused", rv))
 					foundUnusedVarByName = true
 					break
 				}
 			}
 			// Default error location returned.
 			if !foundUnusedVarByName {
-				errs = append(errs, NewError(CompileErr, body[0].Loc(), "declared var %v unused", rv))
+				stack.unused = append(stack.unused, NewError(CompileErr, body[0].Loc(), "declared var %v unused", rv))
 			}
 		}
 	}
-
-	return errs
 }
 
 func rewriteEveryStatement(g *localVarGenerator, stack *localDeclaredVars, expr *Expr, errs Errors, strict bool) (*Expr, Errors) {

--- a/v1/ast/compile_stage_test.go
+++ b/v1/ast/compile_stage_test.go
@@ -193,7 +193,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to SetRuleTree",
 			target:        StageSetRuleTree,
-			expectedCount: 8,
+			expectedCount: 9,
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageSetModuleTree,
@@ -207,7 +207,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to BuildRuleIndices",
 			target:        StageBuildRuleIndices,
-			expectedCount: 32, // includes "after" stage from init()
+			expectedCount: 33, // includes "after" stage from init()
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageCheckTypes,
@@ -221,7 +221,7 @@ func TestWithOnlyStagesUpToInternal(t *testing.T) {
 		{
 			name:          "up to last stage",
 			target:        StageBuildRequiredCapabilities,
-			expectedCount: 34, // includes "after" stage from init()
+			expectedCount: 35, // includes "after" stage from init()
 			shouldContain: []StageID{
 				StageResolveRefs,
 				StageBuildRequiredCapabilities,

--- a/v1/ast/compile_test.go
+++ b/v1/ast/compile_test.go
@@ -1495,6 +1495,120 @@ func TestCompilerErrorLimit(t *testing.T) {
 	}
 }
 
+func TestCompilerReportsViolationsFromMultipleStages(t *testing.T) {
+	tests := []struct {
+		note       string
+		module     string
+		errorLimit int
+		expected   []string
+	}{
+		{
+			note: "shadowed import, deprecated built-ins, unused argument",
+			module: `package p
+
+import data.foo
+import data.foo
+
+a := any([foo])
+b := all([true])
+
+f(x) if {
+	input.bar
+}`,
+			expected: []string{
+				"4:1: rego_compile_error: import must not shadow import data.foo",
+				"6:6: rego_type_error: deprecated built-in function calls in expression: any",
+				"7:6: rego_type_error: deprecated built-in function calls in expression: all",
+				"9:1: rego_compile_error: unused argument x. (hint: use _ (wildcard variable) instead)",
+			},
+		},
+		{
+			note: "unused import, unused var, keyword override, deprecated built-in",
+			module: `package p
+
+import data.foo
+
+a if {
+	input := 1
+	any([true])
+}`,
+			expected: []string{
+				"3:1: rego_compile_error: import data.foo unused",
+				"6:2: rego_compile_error: assigned var input unused",
+				"6:2: rego_compile_error: variables must not shadow input (use a different variable name)",
+				"7:2: rego_type_error: deprecated built-in function calls in expression: any",
+			},
+		},
+		{
+			note: "unsafe var stops compilation",
+			module: `package p
+
+a := any([x])`,
+			expected: []string{
+				"3:6: rego_unsafe_var_error: var x is unsafe",
+			},
+		},
+		{
+			note: "error limit applies across stages",
+			module: `package p
+
+import data.foo
+import data.foo
+
+a := any([foo])
+b := all([true])`,
+			errorLimit: 2,
+			expected: []string{
+				"4:1: rego_compile_error: import must not shadow import data.foo",
+				"6:6: rego_type_error: deprecated built-in function calls in expression: any",
+				"rego_compile_error: error limit reached",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			c := NewCompiler().WithStrict(true)
+			if tc.errorLimit > 0 {
+				c.SetErrorLimit(tc.errorLimit)
+			}
+			c.Compile(map[string]*Module{"test.rego": MustParseModule(tc.module)})
+
+			if !c.Failed() {
+				t.Fatal("expected compilation to fail")
+			}
+
+			result := util.Map(c.Errors, (*Error).Error)
+			if !slices.Equal(tc.expected, result) {
+				t.Errorf("expected errors:\n\n%v\n\ngot:\n\n%v", strings.Join(tc.expected, "\n"), strings.Join(result, "\n"))
+			}
+		})
+	}
+}
+
+func TestCompilerSortErrorsKeepsErrorLimitMarkerLast(t *testing.T) {
+	c := NewCompiler()
+	c.Errors = Errors{
+		errLimitReached,
+		NewError(CompileErr, NewLocation(nil, "b.rego", 1, 1), "later file"),
+		newErrorString(CompileErr, nil, "failed to load module"),
+		NewError(CompileErr, NewLocation(nil, "a.rego", 9, 1), "earlier file"),
+	}
+
+	c.sortErrors()
+
+	expected := []string{
+		"a.rego:9: rego_compile_error: earlier file",
+		"b.rego:1: rego_compile_error: later file",
+		"rego_compile_error: failed to load module",
+		"rego_compile_error: error limit reached",
+	}
+
+	if result := util.Map(c.Errors, (*Error).Error); !slices.Equal(expected, result) {
+		t.Errorf("expected errors:\n\n%v\n\ngot:\n\n%v", strings.Join(expected, "\n"), strings.Join(result, "\n"))
+	}
+}
+
 func TestCompilerCheckSafetyHead(t *testing.T) {
 	c := NewCompiler()
 	c.Modules = getCompilerTestModules()
@@ -3954,6 +4068,22 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 					Location: NewLocation([]byte("input := 4"), "", 9, 6),
 					Message:  "variables must not shadow input (use a different variable name)",
 				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 3, 6),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("x := 2"), "", 4, 6),
+					Message:  "assigned var x unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 3"), "", 6, 6),
+					Message:  "assigned var data unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("input := 4"), "", 9, 6),
+					Message:  "assigned var input unused",
+				},
 			},
 		},
 		{
@@ -3973,6 +4103,14 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 				&Error{
 					Location: NewLocation([]byte("data := 3"), "", 5, 6),
 					Message:  "variables must not shadow data (use a different variable name)",
+				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 3, 6),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 3"), "", 5, 6),
+					Message:  "assigned var data unused",
 				},
 			},
 		},
@@ -3994,6 +4132,14 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 					Location: NewLocation([]byte("data := 3"), "", 5, 6),
 					Message:  "variables must not shadow data (use a different variable name)",
 				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 3, 6),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 3"), "", 5, 6),
+					Message:  "assigned var data unused",
+				},
 			},
 		},
 		{
@@ -4014,6 +4160,14 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 					Location: NewLocation([]byte("data := 3"), "", 5, 6),
 					Message:  "variables must not shadow data (use a different variable name)",
 				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 3, 6),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 3"), "", 5, 6),
+					Message:  "assigned var data unused",
+				},
 			},
 		},
 		{
@@ -4032,6 +4186,14 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 				&Error{
 					Location: NewLocation([]byte("data := 2"), "", 4, 24),
 					Message:  "variables must not shadow data (use a different variable name)",
+				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 4, 12),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 2"), "", 4, 24),
+					Message:  "assigned var data unused",
 				},
 			},
 		},
@@ -4052,6 +4214,10 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 					Location: NewLocation([]byte("data := 2"), "", 4, 27),
 					Message:  "variables must not shadow data (use a different variable name)",
 				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 4, 8),
+					Message:  "assigned var input unused",
+				},
 			},
 		},
 		{
@@ -4070,6 +4236,10 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 				&Error{
 					Location: NewLocation([]byte("data := 2"), "", 4, 26),
 					Message:  "variables must not shadow data (use a different variable name)",
+				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 4, 8),
+					Message:  "assigned var input unused",
 				},
 			},
 		},
@@ -4092,6 +4262,14 @@ func TestCompilerCheckKeywordOverrides(t *testing.T) {
 				&Error{
 					Location: NewLocation([]byte("data := 3"), "", 6, 7),
 					Message:  "variables must not shadow data (use a different variable name)",
+				},
+				&Error{
+					Location: NewLocation([]byte("input := 1"), "", 4, 7),
+					Message:  "assigned var input unused",
+				},
+				&Error{
+					Location: NewLocation([]byte("data := 3"), "", 6, 7),
+					Message:  "assigned var data unused",
 				},
 			},
 		},
@@ -13142,8 +13320,8 @@ deny if {
 	compiler.Compile(modules)
 	if !compiler.Failed() {
 		t.Fatal("Expected error for unsafe built-in")
-	} else if !strings.Contains(compiler.Errors[0].Error(), "unsafe built-in function") {
-		t.Fatalf("Expected error for unsafe built-in but got %v", err)
+	} else if !strings.Contains(compiler.Errors.Error(), "unsafe built-in function") {
+		t.Fatalf("Expected error for unsafe built-in but got %v", compiler.Errors)
 	}
 }
 


### PR DESCRIPTION
Compilation stopped at the first stage that recorded an error, so a policy with several violations only ever surfaced one. Errors from checks that leave the modules intact can now be marked as recoverable, so later stages still run, and the collected errors are sorted by location.

The only errors that have been marked recoverable are from stages that are read only and won't have the cascading error issue @johanfylling pointed out.

| Message | Stage |
|---|---|
| `import data.foo unused` | `CheckUnusedImports` (new stage) |
| `import must not shadow import data.foo` | `CheckDuplicateImports` |
| `rules must not shadow input\|data (use a different rule name)` | `CheckKeywordOverrides` |
| `variables must not shadow input\|data (use a different variable name)` | `CheckKeywordOverrides` |
| `args must not shadow input\|data (use a different variable name)` | `CheckKeywordOverrides` |
| `unused argument x. (hint: use _ (wildcard variable) instead)` | `RewriteLocalVars` |
| `assigned var x unused` | `RewriteLocalVars` |
| `declared var x unused` | `RewriteLocalVars` |

The policy from the issue will now print out 3 errors:

```rego
package p

import data.foo

a := any([foo])
b := all([true])

f(x) {
    input.foo
}
```

```
BEFORE  1 error occurred: p.rego:8: rego_compile_error: unused argument x. (hint: use _ ...)

AFTER   3 errors occurred:
        p.rego:5: rego_type_error: deprecated built-in function calls in expression: any
        p.rego:6: rego_type_error: deprecated built-in function calls in expression: all
        p.rego:8: rego_compile_error: unused argument x. (hint: use _ ...)
```


Fixes: #5815
