### PR TITLE
rego: don't run leaktest checks in a parallel test

### DIFF
--- a/v1/rego/rego_wasmtarget_test.go
+++ b/v1/rego/rego_wasmtarget_test.go
@@ -139,7 +139,9 @@ func TestWasmTimeOfDay(t *testing.T) {
 }
 
 func TestEvalWithContextTimeout(t *testing.T) {
-	t.Parallel()
+	// Deliberately not parallel: the subtests below use leaktest, which
+	// inspects process-wide goroutines and would otherwise attribute the
+	// goroutines of concurrently running tests to this one.
 	test.Skip(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
leaktest inspects process-wide goroutines, so running this test in parallel let it report another test's goroutines as leaks.

This should fix this flaky failure: https://github.com/open-policy-agent/opa/actions/runs/34274967383/job/102226929099
