### PR TITLE
repl: compile pasted rules together so they can reference each other

### DIFF
--- a/v1/repl/repl.go
+++ b/v1/repl/repl.go
@@ -916,21 +916,28 @@ func (r *REPL) compileBody(_ context.Context, compiler *ast.Compiler, body ast.B
 	return body, qc.TypeEnv(), err
 }
 
-func (r *REPL) compileRule(ctx context.Context, rule *ast.Rule) error {
-
-	var unset bool
+// compileRules adds rules to the current module and compiles the result. The
+// rules are compiled together so that they may reference each other regardless
+// of the order they are defined in. If compilation fails none of them is added.
+func (r *REPL) compileRules(ctx context.Context, rules []*ast.Rule) error {
 
 	if r.regoVersion == ast.RegoV1 {
-		if errs := ast.CheckRegoV1(rule); errs != nil {
-			return errs
+		for _, rule := range rules {
+			if errs := ast.CheckRegoV1(rule); errs != nil {
+				return errs
+			}
 		}
 	}
 
-	if rule.Head.Assign {
-		var err error
-		unset, err = r.unsetRule(ctx, rule.Head.Ref())
-		if err != nil {
-			return err
+	unset := make([]bool, len(rules))
+
+	for i, rule := range rules {
+		if rule.Head.Assign {
+			var err error
+			unset[i], err = r.unsetRule(ctx, rule.Head.Ref())
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -943,11 +950,13 @@ func (r *REPL) compileRule(ctx context.Context, rule *ast.Rule) error {
 
 	mod := r.modules[r.currentModuleID]
 	prev := mod.Rules
-	mod.Rules = append(mod.Rules, rule)
-	ast.WalkRules(rule, func(r *ast.Rule) bool {
-		r.Module = mod
-		return false
-	})
+	mod.Rules = append(mod.Rules, rules...)
+	for _, rule := range rules {
+		ast.WalkRules(rule, func(r *ast.Rule) bool {
+			r.Module = mod
+			return false
+		})
+	}
 
 	policies, err := r.loadModules(ctx, r.txn)
 	if err != nil {
@@ -973,11 +982,13 @@ func (r *REPL) compileRule(ctx context.Context, rule *ast.Rule) error {
 	switch r.outputFormat {
 	case "json":
 	default:
-		msg := "defined"
-		if unset {
-			msg = "re-defined"
+		for i, rule := range rules {
+			msg := "defined"
+			if unset[i] {
+				msg = "re-defined"
+			}
+			fmt.Fprintf(r.output, "Rule '%v' %v in %v. Type 'show' to see rules.\n", rule.Head.Ref().String(), msg, mod.Package)
 		}
-		fmt.Fprintf(r.output, "Rule '%v' %v in %v. Type 'show' to see rules.\n", rule.Head.Ref().String(), msg, mod.Package)
 	}
 
 	return nil
@@ -1013,13 +1024,7 @@ func (r *REPL) evalBufferOne(ctx context.Context) error {
 
 	r.buffer = []string{}
 
-	for _, stmt := range stmts {
-		if err := r.evalStatement(ctx, stmt); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return r.evalStatements(ctx, stmts)
 }
 
 func (r *REPL) evalBufferMulti(ctx context.Context) error {
@@ -1044,13 +1049,7 @@ func (r *REPL) evalBufferMulti(ctx context.Context) error {
 		return err
 	}
 
-	for _, stmt := range stmts {
-		if err := r.evalStatement(ctx, stmt); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return r.evalStatements(ctx, stmts)
 }
 
 func (r *REPL) parserOptions() (ast.ParserOptions, error) {
@@ -1128,6 +1127,54 @@ func (r *REPL) loadInput(ctx context.Context, compiler *ast.Compiler) (ast.Value
 	return qrs[0][ast.Var("x")].Value, nil
 }
 
+// evalStatements evaluates the statements parsed from one input in order.
+// Consecutive rule definitions are compiled together so that a pasted block of
+// rules may reference rules defined later in the same block.
+func (r *REPL) evalStatements(ctx context.Context, stmts []ast.Statement) error {
+
+	var rules []*ast.Rule
+
+	compileRules := func() error {
+		if len(rules) == 0 {
+			return nil
+		}
+		err := r.compileRules(ctx, rules)
+		rules = nil
+		return err
+	}
+
+	for _, stmt := range stmts {
+		switch stmt := stmt.(type) {
+		case *ast.Rule:
+			rules = append(rules, stmt)
+			continue
+		case ast.Body:
+			// "p := 1" parses as a body but defines a rule. Equalities are left
+			// to evalStatement because "p = 1" may also be a query.
+			if len(stmt) == 1 && stmt[0].IsAssignment() {
+				rule, err := r.ruleFromExpr(stmt[0])
+				if err != nil {
+					return err
+				}
+				if rule != nil {
+					rules = append(rules, rule)
+					continue
+				}
+			}
+		}
+
+		if err := compileRules(); err != nil {
+			return err
+		}
+
+		if err := r.evalStatement(ctx, stmt); err != nil {
+			return err
+		}
+	}
+
+	return compileRules()
+}
+
 func (r *REPL) evalStatement(ctx context.Context, stmt any) error {
 	switch stmt := stmt.(type) {
 	case ast.Body:
@@ -1161,7 +1208,7 @@ func (r *REPL) evalStatement(ctx context.Context, stmt any) error {
 
 		return err
 	case *ast.Rule:
-		return r.compileRule(ctx, stmt)
+		return r.compileRules(ctx, []*ast.Rule{stmt})
 	case *ast.Import:
 		return r.evalImport(ctx, stmt)
 	case *ast.Package:
@@ -1367,23 +1414,38 @@ func (r *REPL) interpretAsRule(ctx context.Context, compiler *ast.Compiler, body
 		return false, nil
 	}
 
-	rule, err := ast.ParseRuleFromExpr(r.getCurrentOrDefaultModule(), expr)
+	rule, err := r.ruleFromExpr(expr)
 	if rule == nil || err != nil {
 		return false, err
+	}
+
+	if err := r.compileRules(ctx, []*ast.Rule{rule}); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ruleFromExpr returns the rule defined by an assignment or equality expression,
+// or nil if the expression is a query.
+func (r *REPL) ruleFromExpr(expr *ast.Expr) (*ast.Rule, error) {
+	if len(expr.Operands()) != 2 {
+		return nil, nil
+	}
+
+	rule, err := ast.ParseRuleFromExpr(r.getCurrentOrDefaultModule(), expr)
+	if rule == nil || err != nil {
+		return nil, err
 	}
 
 	// Statements about a root document are queries, never rule definitions:
 	// "data.foo.bar = 1" asks if data.foo.bar is 1. The single-term case is
 	// excluded so that `input = {...}` keeps defining a rule.
 	if ref := rule.Head.Ref(); len(ref) > 1 && ast.RootDocumentNames.Contains(ref[0]) {
-		return false, nil
+		return nil, nil
 	}
 
-	if err := r.compileRule(ctx, rule); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return rule, nil
 }
 
 func (r *REPL) getPrompt() string {

--- a/v1/repl/repl_test.go
+++ b/v1/repl/repl_test.go
@@ -2652,6 +2652,97 @@ func TestEvalRuleCompileError(t *testing.T) {
 	}
 }
 
+func TestEvalPastedRulesReferenceEachOther(t *testing.T) {
+	ctx := t.Context()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+
+	// We import rego.v1 to ensure we're compatible with both v0 and v1 as default rego-version.
+	if err := repl.OneShot(ctx, "import rego.v1"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// A bracketed paste hands the whole block to OneShot as one input. The
+	// first rule references a rule that is only defined later in the block.
+	policy := `default allow := false
+
+allow if user_is_owner
+
+user_is_owner if input.user == "bob"`
+
+	buffer.Reset()
+	if err := repl.OneShot(ctx, policy); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "Rule 'allow' defined in package repl. Type 'show' to see rules.\n"+
+		"Rule 'allow' defined in package repl. Type 'show' to see rules.\n"+
+		"Rule 'user_is_owner' defined in package repl. Type 'show' to see rules.\n")
+
+	buffer.Reset()
+	if err := repl.OneShot(ctx, `allow with input as {"user": "bob"}`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "true\n")
+
+	buffer.Reset()
+	if err := repl.OneShot(ctx, `allow with input as {"user": "alice"}`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "false\n")
+}
+
+func TestEvalPastedAssignmentRulesAndQuery(t *testing.T) {
+	ctx := t.Context()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+
+	// We import rego.v1 to ensure we're compatible with both v0 and v1 as default rego-version.
+	if err := repl.OneShot(ctx, "import rego.v1"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// "is_admin := ..." parses as a body, not a rule, and the trailing query
+	// must see both rules.
+	buffer.Reset()
+	if err := repl.OneShot(ctx, "allow if is_admin\n\nis_admin := input.role == \"admin\"\n\nallow with input as {\"role\": \"admin\"}"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "Rule 'allow' defined in package repl. Type 'show' to see rules.\n"+
+		"Rule 'is_admin' defined in package repl. Type 'show' to see rules.\n"+
+		"true\n")
+}
+
+func TestEvalPastedRulesCompileErrorRollsBack(t *testing.T) {
+	ctx := t.Context()
+	store := newTestStore()
+	var buffer bytes.Buffer
+	repl := newRepl(store, &buffer)
+
+	// We import rego.v1 to ensure we're compatible with both v0 and v1 as default rego-version.
+	if err := repl.OneShot(ctx, "import rego.v1"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	err := repl.OneShot(ctx, "p if true\n\nq contains x if { true }")
+	expected := "x is unsafe"
+	if err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("Expected OneShot to return error %v but got: %v", expected, err)
+	}
+
+	// A block that fails to compile must not leave any of its rules behind.
+	if rules := repl.modules[repl.currentModuleID].Rules; len(rules) != 0 {
+		t.Fatalf("Expected no rules to be defined after failed paste but got: %v", rules)
+	}
+
+	buffer.Reset()
+	if err := repl.OneShot(ctx, "p if true"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOutput(t, buffer.String(), "Rule 'p' defined in package repl. Type 'show' to see rules.\n")
+}
+
 func TestEvalBodyCompileError(t *testing.T) {
 	ctx := t.Context()
 	store := newTestStore()


### PR DESCRIPTION
### Why the changes in this PR are needed?

## Problem

Pasting a multi-rule policy into `opa run` (bracketed paste, enabled by #8882) fails when a rule references another rule that appears later in the same paste:

```
> default allow := false

allow if user_is_owner

user_is_owner if input.user == "bob"
1 error occurred: 3:10: rego_unsafe_var_error: var user_is_owner is unsafe
```

Typing the same three rules one at a time in a different order works, so the failure is purely about how a single pasted block is evaluated.

## Root cause

`OneShot` -> `evalBufferOne` (`v1/repl/repl.go:986`) parses the whole paste into statements and then calls `evalStatement` once per statement (`v1/repl/repl.go:1016-1020`). For a rule that calls `compileRule` (`v1/repl/repl.go:919`), which appends that one rule to the current module (`v1/repl/repl.go:946`) and runs a full `ast.Compiler` over it. When `allow if user_is_owner` is compiled, `user_is_owner` does not exist yet, so the compiler reports it as an unsafe var. The same happens on the multi-line buffer path in `evalBufferMulti`. The same applies to `p := 1` style definitions: those parse as a body and reach `compileRule` through `interpretAsRule`, again one at a time.

## Fix

- `compileRule` becomes `compileRules(ctx, []*ast.Rule)`: it applies the existing `:=` re-definition (`unsetRule`) per rule, appends all rules to the module, compiles once, and on failure restores the previous rule list so a bad block leaves nothing behind. The per-rule `Rule '...' defined in package ...` output is unchanged.
- New `evalStatements` replaces the two identical per-statement loops in `evalBufferOne` and `evalBufferMulti`. It collects consecutive rule definitions (`*ast.Rule` statements, plus single `:=` assignment bodies, which are what `interpretAsRule` would have turned into rules) and compiles them as one batch; any other statement (package, import, query, `=` equality) first flushes the pending batch and is then evaluated exactly as before, so a query at the end of a paste sees the rules defined above it.
- The rule-from-expression logic in `interpretAsRule` is extracted into `ruleFromExpr` so both paths share it. `=` equalities are deliberately left on the existing path because `p = 1` can be either a rule or a query and needs the compiler to tell them apart.

A single rule or a single statement entered at the prompt goes through `compileRules` with one rule and behaves as it did before.

### Pointers and Further Information

One intentional behaviour change: when a pasted block of rules fails to compile, none of its rules is added. Previously the rules before the offending one were kept. Compiling the block as a unit is what makes forward references possible, and all-or-nothing matches how a policy file is loaded. The `:=` re-definition of a rule that already existed before the paste is still applied before compiling, as it was for single rules.

## How tested

Three new tests in `v1/repl/repl_test.go`: the example from the issue (paste, then query with `with input as`), a paste mixing an `if` rule, a `:=` rule and a trailing query, and a negative case asserting that a block containing an unsafe rule adds nothing to the module.

Before the fix (`go test ./v1/repl/ -run TestEvalPasted -v`):

```
    repl_test.go:2676: Unexpected error: 1 error occurred: 3:10: rego_unsafe_var_error: var user_is_owner is unsafe
--- FAIL: TestEvalPastedRulesReferenceEachOther (0.00s)
    repl_test.go:2710: Unexpected error: 1 error occurred: 1:10: rego_unsafe_var_error: var is_admin is unsafe
--- FAIL: TestEvalPastedAssignmentRulesAndQuery (0.00s)
    repl_test.go:2736: Expected no rules to be defined after failed paste but got: [p = true if { true }]
--- FAIL: TestEvalPastedRulesCompileErrorRollsBack (0.00s)
FAIL
```

After the fix:

```
--- PASS: TestEvalPastedRulesReferenceEachOther (0.00s)
--- PASS: TestEvalPastedAssignmentRulesAndQuery (0.00s)
--- PASS: TestEvalPastedRulesCompileErrorRollsBack (0.00s)
PASS
ok  	github.com/open-policy-agent/opa/v1/repl	0.012s
```

`go test ./v1/repl/...` passes, `gofmt`, `go vet` and `golangci-lint run ./v1/repl/...` report no issues, and `go build ./cmd/...` succeeds.

## Links

- Issue: https://github.com/open-policy-agent/opa/issues/8896
- Bracketed paste enablement this follows up on: https://github.com/open-policy-agent/opa/pull/8882

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
