### PR TITLE
plugins/logs: Report upload failures when retrying requeued chunks

### DIFF
--- a/v1/plugins/logs/eventBuffer.go
+++ b/v1/plugins/logs/eventBuffer.go
@@ -237,6 +237,7 @@ func (b *eventBuffer) read() {
 // Upload reads events from the buffer and uploads them to the configured client.
 // All the events currently in the buffer are read and written to a gzip compressed JSON array to create a chunk of data.
 // Each chunk is limited by the uploadSizeLimitBytes.
+// Chunks that fail to upload are requeued onto the buffer and the first failure is returned.
 func (b *eventBuffer) Upload(ctx context.Context) error {
 	b.uploadLock.Lock()
 	defer b.uploadLock.Unlock()
@@ -248,6 +249,12 @@ func (b *eventBuffer) Upload(ctx context.Context) error {
 
 	eventLen := len(b.buffer)
 
+	// uploadErr holds the first upload failure so that the rest of the buffer is
+	// still drained before returning. Failed chunks are requeued by uploadChunks,
+	// so the caller has to see the error to report the plugin status and back off
+	// before the next attempt.
+	var uploadErr error
+
 	for range eventLen {
 		item := b.readBufItem()
 		if item == nil {
@@ -256,10 +263,8 @@ func (b *eventBuffer) Upload(ctx context.Context) error {
 
 		result := b.processBufferItem(item)
 		if result != nil {
-			if err := b.uploadChunks(ctx, result, b.client, b.uploadPath); err != nil {
-				if b.logger != nil {
-					b.logger.Error("Failed to upload decision logs, events have been buffered an will be retried. Error: %v", err)
-				}
+			if err := b.uploadChunks(ctx, result, b.client, b.uploadPath); err != nil && uploadErr == nil {
+				uploadErr = err
 			}
 		}
 	}
@@ -271,14 +276,18 @@ func (b *eventBuffer) Upload(ctx context.Context) error {
 		if b.logger != nil {
 			b.logger.Error("Failed to upload decision logs, events have been buffered an will be retried.")
 		}
-		return nil
+		return uploadErr
 	}
 
 	if result == nil {
-		return nil
+		return uploadErr
 	}
 
-	return b.uploadChunks(ctx, result, b.client, b.uploadPath)
+	if err := b.uploadChunks(ctx, result, b.client, b.uploadPath); err != nil && uploadErr == nil {
+		uploadErr = err
+	}
+
+	return uploadErr
 }
 
 // uploadChunks attempts to upload multiple chunks to the configured client.

--- a/v1/plugins/logs/eventBuffer_test.go
+++ b/v1/plugins/logs/eventBuffer_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -287,6 +288,74 @@ func TestEventBuffer_Upload(t *testing.T) {
 				t.Fatalf("expected %d events, got %d", tc.numberOfEvents, len(allEvents))
 			}
 		})
+	}
+}
+
+// A chunk that fails to upload is requeued onto the buffer. Retrying it has to
+// keep reporting the failure, otherwise the plugin clears its error status and
+// resets the retry backoff while decisions are piling up undelivered.
+func TestEventBuffer_UploadRetryReportsFailure(t *testing.T) {
+	t.Parallel()
+
+	uploadPath := "/v1/test"
+
+	var (
+		mtx      sync.Mutex
+		uploaded []EventV1
+		failing  = true
+	)
+
+	client, ts := setupTestServer(t, uploadPath, func(w http.ResponseWriter, r *http.Request) {
+		mtx.Lock()
+		defer mtx.Unlock()
+
+		if failing {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		uploaded = append(uploaded, decodeLogEvent(t, r.Body)...)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	e := newEventBuffer(4, defaultUploadSizeLimitBytes, client, uploadPath, plugins.TriggerPeriodic).
+		WithLogger(logging.NewNoOpLogger())
+	e.WithMetrics(metrics.New())
+	e.Push(newTestEvent(t, "id1", false))
+
+	const wantErr = "log upload failed, server replied with HTTP 500 Internal Server Error"
+
+	// The first attempt encodes the event and fails to upload it.
+	err := e.Upload(t.Context())
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("first upload: expected %q, got %v", wantErr, err)
+	}
+
+	// The second attempt retries the chunk requeued by the first one. Before the
+	// fix this returned nil because only the trailing encoder flush could produce
+	// a return value, and by now the encoder is empty.
+	err = e.Upload(t.Context())
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("retry of a failed chunk: expected %q, got %v", wantErr, err)
+	}
+
+	mtx.Lock()
+	failing = false
+	mtx.Unlock()
+
+	if err := e.Upload(t.Context()); err != nil {
+		t.Fatalf("upload after the server recovered: %v", err)
+	}
+
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	if len(uploaded) != 1 {
+		t.Fatalf("expected the requeued event to be delivered once, got %d events", len(uploaded))
+	}
+	if uploaded[0].DecisionID != "id1" {
+		t.Fatalf("expected decision ID id1, got %q", uploaded[0].DecisionID)
 	}
 }
 


### PR DESCRIPTION
The event buffer only propagated an error from the trailing encoder flush, so retrying a chunk requeued by an earlier failure reported success, which cleared the plugin's error status and reset the retry backoff.