### PR TITLE
topdown: Fix sprintf formatting of floats with zero fraction

### DIFF
--- a/v1/test/cases/testdata/v0/sprintf/test-sprintf.yaml
+++ b/v1/test/cases/testdata/v0/sprintf/test-sprintf.yaml
@@ -24,3 +24,27 @@ cases:
     query: data.test.p = x
     want_result:
       - x: "1208925819614629174706175"
+  - data:
+    modules:
+      - |
+        package test
+
+        p = x {
+          x = sprintf("%f, %3.1f, %.3f", [0.0, 100.0, .0])
+        }
+    note: sprintf/float/zero_fraction
+    query: data.test.p = x
+    want_result:
+      - x: "0.000000, 100.0, 0.000"
+  - data:
+    modules:
+      - |
+        package test
+
+        p = x {
+          x = sprintf("%f", [1e2])
+        }
+    note: sprintf/float/exponent
+    query: data.test.p = x
+    want_result:
+      - x: "100.000000"

--- a/v1/test/cases/testdata/v1/sprintf/test-sprintf.yaml
+++ b/v1/test/cases/testdata/v1/sprintf/test-sprintf.yaml
@@ -22,3 +22,25 @@ cases:
         }
     want_result:
       - x: "1208925819614629174706175"
+  - note: sprintf/float/zero_fraction
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := x if {
+        	x = sprintf("%f, %3.1f, %.3f", [0.0, 100.0, .0])
+        }
+    want_result:
+      - x: "0.000000, 100.0, 0.000"
+  - note: sprintf/float/exponent
+    query: data.test.p = x
+    modules:
+      - |
+        package test
+
+        p := x if {
+        	x = sprintf("%f", [1e2])
+        }
+    want_result:
+      - x: "100.000000"

--- a/v1/topdown/strings.go
+++ b/v1/topdown/strings.go
@@ -791,7 +791,7 @@ func builtinSprintf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 	// Optimized path for where sprintf is used as a "to_string" function for
 	// a single integer, i.e. sprintf("%d", [x]) where x is an integer.
 	if s == "%d" && a.Len() == 1 {
-		if n, ok := a.Elem(0).Value.(ast.Number); ok {
+		if n, ok := a.Elem(0).Value.(ast.Number); ok && !isFloatNumber(string(n)) {
 			if i, ok := n.Int(); ok {
 				if interned := ast.InternedIntegerString(i); interned != nil {
 					return iter(interned)
@@ -808,23 +808,18 @@ func builtinSprintf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 		switch v := t.Value.(type) {
 		case ast.Number:
 			ns := string(v)
-			if x, ok := util.Atoi64(ns); ok {
-				args[i] = x
-			} else {
-				if strings.ContainsRune(ns, '.') {
-					if f, ok := v.Float64(); ok {
-						args[i] = f
-						continue
-					} else {
-						args[i] = ns
-					}
+			if isFloatNumber(ns) {
+				if f, ok := v.Float64(); ok {
+					args[i] = f
 				} else {
-					if b, ok := new(big.Int).SetString(ns, 10); ok {
-						args[i] = b
-					} else {
-						args[i] = ns
-					}
+					args[i] = ns
 				}
+			} else if x, ok := util.Atoi64(ns); ok {
+				args[i] = x
+			} else if b, ok := new(big.Int).SetString(ns, 10); ok {
+				args[i] = b
+			} else {
+				args[i] = ns
 			}
 		case ast.String:
 			args[i] = string(v)
@@ -834,6 +829,15 @@ func builtinSprintf(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term)
 	}
 
 	return iter(ast.InternedTerm(fmt.Sprintf(string(s), args...)))
+}
+
+// isFloatNumber reports whether the textual representation of a number is that
+// of a floating point value, i.e. it has a fraction or an exponent. Since
+// util.Atoi64 parses numbers with only zeros past the decimal point (1.0) as
+// integers, the text, and not the parsed value, decides how a number is
+// formatted by sprintf.
+func isFloatNumber(s string) bool {
+	return strings.ContainsAny(s, ".eE")
 }
 
 func builtinReverse(_ BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {

--- a/v1/topdown/strings_test.go
+++ b/v1/topdown/strings_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package topdown
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+func TestBuiltinSprintf(t *testing.T) {
+	tests := []struct {
+		note   string
+		format string
+		args   *ast.Array
+		exp    string
+	}{
+		{
+			note:   "integer",
+			format: "%d",
+			args:   ast.NewArray(ast.NumberTerm("42")),
+			exp:    "42",
+		},
+		{
+			note:   "integer, multiple args",
+			format: "%d-%d",
+			args:   ast.NewArray(ast.NumberTerm("42"), ast.NumberTerm("-1")),
+			exp:    "42--1",
+		},
+		{
+			note:   "integer too large for int64",
+			format: "%d",
+			args:   ast.NewArray(ast.NumberTerm("1208925819614629174706175")),
+			exp:    "1208925819614629174706175",
+		},
+		{
+			note:   "float",
+			format: "%f",
+			args:   ast.NewArray(ast.NumberTerm("0.1")),
+			exp:    "0.100000",
+		},
+		{
+			// https://github.com/open-policy-agent/opa/issues/9187
+			note:   "float with zero fraction",
+			format: "float: %f, %3.1f, %.3f, %f, %3.1f, %.3f",
+			args: ast.NewArray(
+				ast.NumberTerm("0.1"), ast.NumberTerm("10.2"), ast.NumberTerm(".5"),
+				ast.NumberTerm("0.0"), ast.NumberTerm("100.0"), ast.NumberTerm(".0"),
+			),
+			exp: "float: 0.100000, 10.2, 0.500, 0.000000, 100.0, 0.000",
+		},
+		{
+			note:   "float in exponent notation",
+			format: "%f",
+			args:   ast.NewArray(ast.NumberTerm("1e2")),
+			exp:    "100.000000",
+		},
+		{
+			note:   "float too large for float64",
+			format: "%s",
+			args:   ast.NewArray(ast.NumberTerm("1e400")),
+			exp:    "1e400",
+		},
+		{
+			// The single argument case is served by an optimized path, and must
+			// agree with the general one.
+			note:   "float with integer verb",
+			format: "%d",
+			args:   ast.NewArray(ast.NumberTerm("1.0")),
+			exp:    "%!d(float64=1)",
+		},
+		{
+			note:   "float with integer verb, multiple args",
+			format: "%d-%d",
+			args:   ast.NewArray(ast.NumberTerm("1.0"), ast.NumberTerm("2")),
+			exp:    "%!d(float64=1)-2",
+		},
+		{
+			note:   "string",
+			format: "%s",
+			args:   ast.NewArray(ast.StringTerm("foo")),
+			exp:    "foo",
+		},
+		{
+			note:   "composite value",
+			format: "%v",
+			args:   ast.NewArray(ast.ArrayTerm(ast.NumberTerm("1"), ast.StringTerm("foo"))),
+			exp:    `[1, "foo"]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			var result *ast.Term
+
+			operands := []*ast.Term{ast.StringTerm(tc.format), ast.NewTerm(tc.args)}
+			err := builtinSprintf(BuiltinContext{}, operands, func(t *ast.Term) error {
+				result = t
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if exp := ast.StringTerm(tc.exp); ast.Compare(exp, result) != 0 {
+				t.Fatalf("Expected result:\n\n%s\n\ngot:\n\n%s", exp, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since util.Atoi64 parses 1.0 as an integer, sprintf passed integral floats to fmt as int64, so %f rendered them as %!f(int64=1). Use the number's text, not its parsed value, to pick the argument type.

Fixes: #9187
