### PR TITLE
ast: Report keywords used as rule names

### DIFF
--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -459,8 +459,10 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 			if imp := p.parseImport(); imp != nil {
 				if RegoRootDocument.Equal(imp.Path.Value.(Ref)[0]) {
 					p.regoV1Import(imp)
+					p.reclassifyKeyword()
 				} else if FutureRootDocument.Equal(imp.Path.Value.(Ref)[0]) {
 					p.futureImport(imp, allowedFutureKeywords)
+					p.reclassifyKeyword()
 				}
 				stmts = append(stmts, imp)
 				continue
@@ -768,19 +770,37 @@ func scanAheadRef(p *Parser) bool {
 
 // keywordRuleNameFollowers maps a keyword token to the tokens that, following it,
 // make the statement unambiguously a rule declaration.
-//
-// `contains` has a shorter list: outside of rule heads it parses as a plain var,
-// so `contains := x` is still a legal query and as a rule is already caught by
-// the rego-v1 check.
 var (
-	ruleNameFollowers        = []tokens.Token{tokens.Assign, tokens.Unify, tokens.If, tokens.Contains, tokens.LParen}
-	keywordRuleNameFollowers = map[tokens.Token][]tokens.Token{
-		tokens.Every:    ruleNameFollowers,
-		tokens.If:       ruleNameFollowers,
-		tokens.In:       ruleNameFollowers,
+	ruleNameFollowers = []tokens.Token{tokens.Assign, tokens.Unify, tokens.If, tokens.Contains, tokens.LParen}
+	// `not`/`and`/`or` drop '(': at the start of a statement, `not (x)` is a negated
+	// group and `or(x, y)` a call to the set union built-in, not rule heads.
+	operatorRuleNameFollowers = []tokens.Token{tokens.Assign, tokens.Unify, tokens.If, tokens.Contains}
+	keywordRuleNameFollowers  = map[tokens.Token][]tokens.Token{
+		tokens.Every:      ruleNameFollowers,
+		tokens.If:         ruleNameFollowers,
+		tokens.In:         ruleNameFollowers,
+		tokens.Not:        operatorRuleNameFollowers,
+		tokens.LogicalAnd: operatorRuleNameFollowers,
+		tokens.LogicalOr:  operatorRuleNameFollowers,
+		// `contains` outside of a rule head parses as a plain var, so `contains := x`
+		// is still a legal query; as a rule it's caught by the rego-v1 check.
 		tokens.Contains: {tokens.If, tokens.Contains},
 	}
 )
+
+// reclassifyKeyword re-tags the lookahead token after an import that registered
+// new keywords with the scanner. The parser reads one token ahead, so the first
+// token of the statement following the import was scanned before the scanner
+// knew about the keyword, and would otherwise be treated as a plain identifier.
+func (p *Parser) reclassifyKeyword() {
+	if p.s.tok != tokens.Ident {
+		return
+	}
+
+	if tok, ok := allFutureKeywords[p.s.lit]; ok && p.s.s.IsKeyword(p.s.lit) {
+		p.s.tok = tok
+	}
+}
 
 // errKeywordRuleName reports an error if the current token is a keyword used as a
 // rule name, e.g. `every := 1`. A statement that began with `default` can only be

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -443,6 +443,14 @@ func (p *Parser) Parse() ([]Statement, []*Comment, Errors) {
 	// point trying to parse packages, imports, etc. in the same order.
 	for p.s.tok != tokens.EOF {
 		var s *state
+
+		// Reported here rather than in parseRules: `package := 1` and `import := 1`
+		// are consumed by the statement parsers below, which fail pointing at the
+		// assign token instead of the keyword.
+		if !p.po.SkipRules && p.errKeywordRuleName(false) {
+			break
+		}
+
 		if p.s.tok == tokens.Package {
 			s = p.save()
 			if pkg := p.parsePackage(); pkg != nil {
@@ -775,10 +783,17 @@ var (
 	// `not`/`and`/`or` drop '(': at the start of a statement, `not (x)` is a negated
 	// group and `or(x, y)` a call to the set union built-in, not rule heads.
 	operatorRuleNameFollowers = []tokens.Token{tokens.Assign, tokens.Unify, tokens.If, tokens.Contains}
-	keywordRuleNameFollowers  = map[tokens.Token][]tokens.Token{
+	// `package`/`import` drop `if` and `contains`: both take a path that may itself
+	// be named after a keyword, as in `package contains` or `import if.foo`.
+	pathRuleNameFollowers    = []tokens.Token{tokens.Assign, tokens.Unify, tokens.LParen}
+	keywordRuleNameFollowers = map[tokens.Token][]tokens.Token{
 		tokens.Every:      ruleNameFollowers,
 		tokens.If:         ruleNameFollowers,
 		tokens.In:         ruleNameFollowers,
+		tokens.Some:       ruleNameFollowers,
+		tokens.As:         ruleNameFollowers,
+		tokens.Package:    pathRuleNameFollowers,
+		tokens.Import:     pathRuleNameFollowers,
 		tokens.Not:        operatorRuleNameFollowers,
 		tokens.LogicalAnd: operatorRuleNameFollowers,
 		tokens.LogicalOr:  operatorRuleNameFollowers,
@@ -803,12 +818,12 @@ func (p *Parser) reclassifyKeyword() {
 }
 
 // errKeywordRuleName reports an error if the current token is a keyword used as a
-// rule name, e.g. `every := 1`. A statement that began with `default` can only be
-// a rule, so no lookahead is needed there.
-func (p *Parser) errKeywordRuleName(isDefault bool) {
+// rule name, e.g. `every := 1`, and returns whether it did. A statement that began
+// with `default` can only be a rule, so no lookahead is needed there.
+func (p *Parser) errKeywordRuleName(isDefault bool) bool {
 	followers, ok := keywordRuleNameFollowers[p.s.tok]
 	if !ok {
-		return
+		return false
 	}
 
 	keyword, loc := p.s.tok, p.s.Loc()
@@ -820,11 +835,13 @@ func (p *Parser) errKeywordRuleName(isDefault bool) {
 		p.restore(s)
 
 		if !slices.Contains(followers, next) {
-			return
+			return false
 		}
 	}
 
 	p.errorf(loc, "%s keyword cannot be used for rule name", keyword)
+
+	return true
 }
 
 // scanAheadLogicalCall rewrites an `and`/`or` keyword token to tokens.Ident when
@@ -862,7 +879,9 @@ func (p *Parser) parseRules() []*Rule {
 	}
 
 	if p.s.tok != tokens.Ident {
-		p.errKeywordRuleName(rule.Default)
+		if rule.Default {
+			p.errKeywordRuleName(true)
+		}
 		return nil
 	}
 

--- a/v1/ast/parser.go
+++ b/v1/ast/parser.go
@@ -766,6 +766,47 @@ func scanAheadRef(p *Parser) bool {
 	return false
 }
 
+// keywordRuleNameFollowers maps a keyword token to the tokens that, following it,
+// make the statement unambiguously a rule declaration.
+//
+// `contains` has a shorter list: outside of rule heads it parses as a plain var,
+// so `contains := x` is still a legal query and as a rule is already caught by
+// the rego-v1 check.
+var (
+	ruleNameFollowers        = []tokens.Token{tokens.Assign, tokens.Unify, tokens.If, tokens.Contains, tokens.LParen}
+	keywordRuleNameFollowers = map[tokens.Token][]tokens.Token{
+		tokens.Every:    ruleNameFollowers,
+		tokens.If:       ruleNameFollowers,
+		tokens.In:       ruleNameFollowers,
+		tokens.Contains: {tokens.If, tokens.Contains},
+	}
+)
+
+// errKeywordRuleName reports an error if the current token is a keyword used as a
+// rule name, e.g. `every := 1`. A statement that began with `default` can only be
+// a rule, so no lookahead is needed there.
+func (p *Parser) errKeywordRuleName(isDefault bool) {
+	followers, ok := keywordRuleNameFollowers[p.s.tok]
+	if !ok {
+		return
+	}
+
+	keyword, loc := p.s.tok, p.s.Loc()
+
+	if !isDefault {
+		s := p.save()
+		p.scan()
+		next := p.s.tok
+		p.restore(s)
+
+		if !slices.Contains(followers, next) {
+			return
+		}
+	}
+
+	p.errorf(loc, "%s keyword cannot be used for rule name", keyword)
+}
+
 // scanAheadLogicalCall rewrites an `and`/`or` keyword token to tokens.Ident when
 // it's immediately followed by `(`. Only valid where a term is expected: there,
 // the operator reading is impossible, so it must be a function (`&`/`|` set built-ins).
@@ -801,6 +842,7 @@ func (p *Parser) parseRules() []*Rule {
 	}
 
 	if p.s.tok != tokens.Ident {
+		p.errKeywordRuleName(rule.Default)
 		return nil
 	}
 

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -1843,6 +1843,104 @@ func TestKeywordAsRuleName(t *testing.T) {
 		assertParseOneExpr(t, "contains assignment", "contains := 1",
 			MustParseExpr("assign(contains, 1)"))
 	})
+
+	// `and`/`or` are only keywords once imported, so they're checked separately.
+	for _, kw := range []string{"and", "or"} {
+		for _, decl := range []string{
+			kw + ` := 1`,
+			kw + ` = 1`,
+			kw + ` if { true }`,
+			kw + ` contains 1`,
+			`default ` + kw + ` := 1`,
+		} {
+			expected := kw + " keyword cannot be used for rule name"
+
+			t.Run("v1/"+decl, func(t *testing.T) {
+				_, err := ParseModuleWithOpts("test.rego", "package test\nimport future.keywords."+kw+"\n"+decl, ParserOptions{RegoVersion: RegoV1})
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				if !strings.Contains(err.Error(), expected) {
+					t.Fatalf("expected error to contain %q, got:\n\n%v", expected, err)
+				}
+			})
+
+			t.Run("v1/not imported/"+decl, func(t *testing.T) {
+				// Without the import they're plain idents, so these are valid rules.
+				_, err := ParseModuleWithOpts("test.rego", "package test\n"+decl, ParserOptions{RegoVersion: RegoV1})
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			})
+		}
+
+		t.Run("v1/ref head keeps working/"+kw, func(t *testing.T) {
+			if _, err := ParseModuleWithOpts("test.rego", "package test\nimport future.keywords."+kw+"\n"+kw+".foo := 1", ParserOptions{RegoVersion: RegoV1}); err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+
+		// `and(x, y)`/`or(x, y)` are the set intersection/union built-ins, so a
+		// leading '(' doesn't mark a rule head.
+		t.Run("call keeps working/"+kw, func(t *testing.T) {
+			assertParseOneExpr(t, kw+" call", kw+"({1}, {2})",
+				MustParseExpr(kw+"({1}, {2})"))
+		})
+	}
+}
+
+func TestKeywordAsRuleNameFollowingImport(t *testing.T) {
+	// The parser reads one token ahead, so the statement following a keyword
+	// import used to be scanned before the scanner knew about the keyword.
+	tests := []struct {
+		note        string
+		module      string
+		regoVersion RegoVersion
+		expected    string
+	}{
+		{
+			note:        "future keyword import, v1",
+			module:      "package test\nimport future.keywords.or\nor := 1",
+			regoVersion: RegoV1,
+			expected:    "or keyword cannot be used for rule name",
+		},
+		{
+			note:        "future keyword import, v0",
+			module:      "package test\nimport future.keywords.every\nevery := 1",
+			regoVersion: RegoV0,
+			expected:    "every keyword cannot be used for rule name",
+		},
+		{
+			note:        "rego.v1 import, v0",
+			module:      "package test\nimport rego.v1\nif := 1",
+			regoVersion: RegoV0,
+			expected:    "if keyword cannot be used for rule name",
+		},
+		{
+			note:        "reserved keyword following import, v0",
+			module:      "package test\nimport future.keywords\nnot := 1",
+			regoVersion: RegoV0,
+			expected:    "not keyword cannot be used for rule name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			_, err := ParseModuleWithOpts("test.rego", tc.module, ParserOptions{RegoVersion: tc.regoVersion})
+			if err == nil {
+				t.Fatal("expected error, got none")
+			}
+			if !strings.Contains(err.Error(), tc.expected) {
+				t.Fatalf("expected error to contain %q, got:\n\n%v", tc.expected, err)
+			}
+		})
+	}
+
+	t.Run("non-keyword rule name following import", func(t *testing.T) {
+		if _, err := ParseModuleWithOpts("test.rego", "package test\nimport future.keywords.every\nevery_thing := 1", ParserOptions{RegoVersion: RegoV0}); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
 }
 
 func TestRefKeywordsEdgeCases(t *testing.T) {

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -1790,6 +1790,61 @@ func TestRuleHeadsContainingKeywords_RegoV0(t *testing.T) {
 	}
 }
 
+func TestKeywordAsRuleName(t *testing.T) {
+	for _, kw := range []string{"every", "if", "in", "contains"} {
+		for _, decl := range []string{
+			kw + ` := 1`,
+			kw + ` = 1`,
+			kw + ` if { true }`,
+			kw + ` contains 1`,
+			kw + `(x) := x`,
+			`default ` + kw + ` := 1`,
+		} {
+			expected := kw + " keyword cannot be used for rule name"
+
+			t.Run("v1/"+decl, func(t *testing.T) {
+				_, err := ParseModuleWithOpts("test.rego", "package test\n"+decl, ParserOptions{RegoVersion: RegoV1})
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				if !strings.Contains(err.Error(), expected) {
+					t.Fatalf("expected error to contain %q, got:\n\n%v", expected, err)
+				}
+			})
+
+			t.Run("v0+rego.v1/"+decl, func(t *testing.T) {
+				_, err := ParseModuleWithOpts("test.rego", "package test\nimport rego.v1\n"+decl, ParserOptions{RegoVersion: RegoV0})
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				if !strings.Contains(err.Error(), expected) {
+					t.Fatalf("expected error to contain %q, got:\n\n%v", expected, err)
+				}
+			})
+
+			t.Run("v0/"+decl, func(t *testing.T) {
+				// Not keywords in v0, so these are valid rules or fail for other reasons.
+				_, err := ParseModuleWithOpts("test.rego", "package test\n"+decl, ParserOptions{RegoVersion: RegoV0})
+				if err != nil && strings.Contains(err.Error(), expected) {
+					t.Fatalf("unexpected keyword error in v0: %v", err)
+				}
+			})
+		}
+
+		t.Run("v1/ref head keeps working/"+kw, func(t *testing.T) {
+			if _, err := ParseModuleWithOpts("test.rego", "package test\n"+kw+".foo := 1", ParserOptions{RegoVersion: RegoV1}); err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+
+	// `contains` still parses as a var outside rule heads, which queries rely on.
+	t.Run("contains as query var", func(t *testing.T) {
+		assertParseOneExpr(t, "contains assignment", "contains := 1",
+			MustParseExpr("assign(contains, 1)"))
+	})
+}
+
 func TestRefKeywordsEdgeCases(t *testing.T) {
 	t.Run("'in' kw first term in ref head rule following 'contains'", func(t *testing.T) {
 		input := `package test

--- a/v1/ast/parser_test.go
+++ b/v1/ast/parser_test.go
@@ -1889,6 +1889,75 @@ func TestKeywordAsRuleName(t *testing.T) {
 	}
 }
 
+func TestReservedKeywordAsRuleName(t *testing.T) {
+	// These keywords are reserved in every Rego version, so unless the declaration
+	// uses a v1-only keyword, the same error is expected in v0 and v1.
+	tests := []struct {
+		keyword string
+		decls   []string
+		v1Decls []string
+	}{
+		{
+			// `not (x)` is a negated group, so `not(x) := x` isn't reported here.
+			keyword: "not",
+			decls:   []string{`not := 1`, `not = 1`, `default not := 1`},
+			v1Decls: []string{`not if { true }`, `not contains 1`},
+		},
+		{
+			keyword: "some",
+			decls:   []string{`some := 1`, `some = 1`, `some(x) := x`, `default some := 1`},
+			v1Decls: []string{`some if { true }`, `some contains 1`},
+		},
+		{
+			keyword: "as",
+			decls:   []string{`as := 1`, `as = 1`, `as(x) := x`, `default as := 1`},
+			v1Decls: []string{`as if { true }`, `as contains 1`},
+		},
+		{
+			// `package if` and `package contains` name a package after a keyword, so
+			// only the forms that can't be a package path are reported.
+			keyword: "package",
+			decls:   []string{`package := 1`, `package = 1`, `package(x) := x`, `default package := 1`},
+		},
+		{
+			keyword: "import",
+			decls:   []string{`import := 1`, `import = 1`, `import(x) := x`, `default import := 1`},
+		},
+	}
+
+	assert := func(t *testing.T, decl string, v RegoVersion, expected string) {
+		t.Helper()
+		_, err := ParseModuleWithOpts("test.rego", "package test\n"+decl, ParserOptions{RegoVersion: v})
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected error to contain %q, got:\n\n%v", expected, err)
+		}
+	}
+
+	for _, tc := range tests {
+		expected := tc.keyword + " keyword cannot be used for rule name"
+
+		for _, decl := range tc.decls {
+			for _, v := range []RegoVersion{RegoV0, RegoV1} {
+				t.Run(fmt.Sprintf("%v/%s", v, decl), func(t *testing.T) {
+					assert(t, decl, v, expected)
+				})
+			}
+		}
+
+		for _, decl := range tc.v1Decls {
+			t.Run("v1/"+decl, func(t *testing.T) {
+				assert(t, decl, RegoV1, expected)
+			})
+		}
+	}
+
+	// Keyword-named package paths and imports (`package contains`, `import if.foo`)
+	// are covered by TestPackageContainingKeywords and TestImportContainingKeywords.
+}
+
 func TestKeywordAsRuleNameFollowingImport(t *testing.T) {
 	// The parser reads one token ahead, so the statement following a keyword
 	// import used to be scanned before the scanner knew about the keyword.


### PR DESCRIPTION
`every := 1` and friends fell through to query parsing, so the error pointed at the assign token instead of the keyword. Report the same "cannot be used for rule name" error the rego-v1 check already gives for `contains`.

Fixes: #6652