### PR TITLE
runtime: reload the config file on change when --watch is set

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -193,9 +193,9 @@ The --watch flag also applies to the file given by --config-file: when it change
 the running plugins without a restart. Plugins and labels can be added and plugins reconfigured this way. Changes OPA
 cannot apply are rejected and leave the running configuration untouched: options only read at start-up
 ("default_decision", "default_authorization_decision", "discovery", "distributed_tracing", "metrics_export",
-"persistence_directory", "server" and "storage"), changing or removing a label, and removing a plugin. The configuration
-file is not watched when discovery is enabled, as the discovered configuration is then what the plugins are configured
-with.
+"persistence_directory", "server" and "storage"), changing or removing a label, and turning a plugin off. The
+configuration file is not watched when discovery is enabled, as the discovered configuration is then what the plugins
+are configured with.
 
 OPA will automatically perform type checking based on a schema inferred from known input documents and report any errors
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -189,6 +189,14 @@ The --watch flag can be used to monitor policy and data file-system changes. Whe
 and data is reloaded into OPA. Watching individual files (rather than directories) is generally not recommended as some
 updates might cause them to be dropped by OPA.
 
+The --watch flag also applies to the file given by --config-file: when it changes, the new configuration is applied to
+the running plugins without a restart. Plugins and labels can be added and plugins reconfigured this way. Changes OPA
+cannot apply are rejected and leave the running configuration untouched: options only read at start-up
+("default_decision", "default_authorization_decision", "discovery", "distributed_tracing", "metrics_export",
+"persistence_directory", "server" and "storage"), changing or removing a label, and removing a plugin. The configuration
+file is not watched when discovery is enabled, as the discovered configuration is then what the plugins are configured
+with.
+
 OPA will automatically perform type checking based on a schema inferred from known input documents and report any errors
 resulting from the schema check. Currently this check is performed on OPA's Authorization Policy Input document and will
 be expanded in the future. To disable this, use the --skip-known-schema-check flag.
@@ -236,7 +244,7 @@ See https://godoc.org/crypto/tls#pkg-constants for more information.
 	cmdParams.rt.UnixSocketPerm = runCommand.Flags().String("unix-socket-perm", "755", "specify the permissions for the Unix domain socket if used to listen for incoming connections")
 	runCommand.Flags().BoolVar(&cmdParams.rt.H2CEnabled, "h2c", false, "enable H2C for HTTP listeners")
 	runCommand.Flags().StringVarP(&cmdParams.rt.OutputFormat, "format", "f", "pretty", "set shell output format, i.e, pretty, json")
-	runCommand.Flags().BoolVarP(&cmdParams.rt.Watch, "watch", "w", false, "watch command line files for changes")
+	runCommand.Flags().BoolVarP(&cmdParams.rt.Watch, "watch", "w", false, "watch command line files and the configuration file for changes")
 	addV0CompatibleFlag(runCommand.Flags(), &cmdParams.rt.V0Compatible, false)
 	addV1CompatibleFlag(runCommand.Flags(), &cmdParams.rt.V1Compatible, false)
 	addMaxErrorsFlag(runCommand.Flags(), &cmdParams.rt.ErrorLimit)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1090,6 +1090,53 @@ Configuration loaded later via [discovery](#discovery) is validated the same way
 defaults are injected and warnings are logged when the discovered configuration is
 applied.
 
+## Reloading Configuration
+
+> Only supported with the OPA runtime (`opa run`).
+
+By default the configuration file is read once, at start-up. Running with the
+`-w`/`--watch` flag makes `opa run` watch the file and apply changes to the
+running plugins, which is useful where restarting OPA is disruptive — a sidecar,
+for example, where a restart takes down the whole pod.
+
+```bash
+opa run -s -c opa-config.yaml -w
+```
+
+`--set` and `--set-file` overrides are re-applied on top of the file on each
+reload, so a value overridden on the command line stays overridden. The files
+referenced by `--set-file` are not themselves watched.
+
+A few things do not change without a restart:
+
+- **Options read only at start-up.** `default_decision`,
+  `default_authorization_decision`, `discovery`, `distributed_tracing`,
+  `metrics_export`, `persistence_directory`, `server` and `storage` are used to
+  build the store, the exporters and the server before any plugin runs. If a
+  reload changes one of them it is rejected and logged, and the running
+  configuration is left untouched — so a restart is needed, but nothing is
+  applied in part.
+- **Removing a plugin.** Plugins can be added and reconfigured, but not removed:
+  OPA cannot unregister a running plugin, so dropping `bundles`,
+  `decision_logs`, `status` or an entry under `plugins` is rejected rather than
+  leaving one running with settings the configuration no longer mentions.
+  Entries removed from `services` and `keys` are, however, still silently
+  retained.
+- **Changing or removing a label.** Labels can be added, but the labels present
+  at start-up always win, so changing or removing one is rejected the same way
+  as the start-up-only options above.
+
+If a reload fails for any other reason — a syntax error, or a `bundles` entry
+naming a service that doesn't exist — it is logged and the change is not
+completed. Validating those sections requires the new `services` to be
+registered first, so part of the configuration may already be in effect;
+reverting the file undoes it, as each reload is applied on top of the last one
+that succeeded.
+
+The configuration file is not watched when [discovery](#discovery) is enabled,
+since the discovered configuration — not the file on disk — is what the plugins
+are configured with. OPA logs a warning at start-up in that case.
+
 ## Using Environment Variables in Configuration
 
 > Only supported with the OPA runtime (`opa run`).

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1105,7 +1105,9 @@ opa run -s -c opa-config.yaml -w
 
 `--set` and `--set-file` overrides are re-applied on top of the file on each
 reload, so a value overridden on the command line stays overridden. The files
-referenced by `--set-file` are not themselves watched.
+named by `--set-file` are re-read every time, so an edit to one of them is
+picked up too — but they are not watched, so it takes a change to the
+configuration file to trigger the reload that reads them.
 
 A few things do not change without a restart:
 
@@ -1116,15 +1118,23 @@ A few things do not change without a restart:
   reload changes one of them it is rejected and logged, and the running
   configuration is left untouched — so a restart is needed, but nothing is
   applied in part.
-- **Removing a plugin.** Plugins can be added and reconfigured, but not removed:
-  OPA cannot unregister a running plugin, so dropping `bundles`,
-  `decision_logs`, `status` or an entry under `plugins` is rejected rather than
-  leaving one running with settings the configuration no longer mentions.
-  Entries removed from `services` and `keys` are, however, still silently
-  retained.
+- **Turning a plugin off.** Plugins can be added and reconfigured, but not
+  removed: OPA cannot unregister a running plugin, so a reload that would leave
+  `decision_logs`, `status` or an entry under `plugins` without a plugin to run
+  is rejected rather than leaving one running with settings the configuration no
+  longer mentions. That covers dropping the section and emptying it, since an
+  empty `decision_logs` enables nothing either. `bundles` is the exception:
+  emptying it (`bundles: {}`) is applied, because the bundle plugin reads that
+  as "no bundles" and stops downloading and deactivates them. Dropping the
+  section outright is still rejected.
 - **Changing or removing a label.** Labels can be added, but the labels present
   at start-up always win, so changing or removing one is rejected the same way
   as the start-up-only options above.
+
+Entries removed from `services` and `keys` are neither applied nor rejected:
+they stay registered for the rest of the process, and OPA logs a warning saying
+so. Changing an entry that a plugin is already using has a related caveat — see
+below.
 
 If a reload fails for any other reason — a syntax error, or a `bundles` entry
 naming a service that doesn't exist — it is logged and the change is not
@@ -1132,6 +1142,17 @@ completed. Validating those sections requires the new `services` to be
 registered first, so part of the configuration may already be in effect;
 reverting the file undoes it, as each reload is applied on top of the last one
 that succeeded.
+
+:::info
+A running plugin only picks up a changed `services` entry if its own section
+changed too. The `status` plugin looks its client up on every upload and so is
+unaffected, but the `bundles` and `decision_logs` plugins hold on to the client
+they were built with, and both skip reconfiguring when their own configuration
+is unchanged. Rotating a service's credentials or URL on its own therefore
+leaves them talking to the old endpoint until OPA restarts. This is not specific
+to reloading the configuration file: discovery-driven reconfiguration behaves
+the same way.
+:::
 
 The configuration file is not watched when [discovery](#discovery) is enabled,
 since the discovered configuration — not the file on disk — is what the plugins

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1133,8 +1133,9 @@ A few things do not change without a restart:
 
 Entries removed from `services` and `keys` are neither applied nor rejected:
 they stay registered for the rest of the process, and OPA logs a warning saying
-so. Changing an entry that a plugin is already using has a related caveat — see
-below.
+so. Changing an entry is applied normally — a plugin already using a service
+picks the new client up, so credentials and URLs can be rotated without a
+restart.
 
 If a reload fails for any other reason — a syntax error, or a `bundles` entry
 naming a service that doesn't exist — it is logged and the change is not
@@ -1142,17 +1143,6 @@ completed. Validating those sections requires the new `services` to be
 registered first, so part of the configuration may already be in effect;
 reverting the file undoes it, as each reload is applied on top of the last one
 that succeeded.
-
-:::info
-A running plugin only picks up a changed `services` entry if its own section
-changed too. The `status` plugin looks its client up on every upload and so is
-unaffected, but the `bundles` and `decision_logs` plugins hold on to the client
-they were built with, and both skip reconfiguring when their own configuration
-is unchanged. Rotating a service's credentials or URL on its own therefore
-leaves them talking to the old endpoint until OPA restarts. This is not specific
-to reloading the configuration file: discovery-driven reconfiguration behaves
-the same way.
-:::
 
 The configuration file is not watched when [discovery](#discovery) is enabled,
 since the discovered configuration — not the file on disk — is what the plugins

--- a/internal/pluginset/pluginset.go
+++ b/internal/pluginset/pluginset.go
@@ -1,0 +1,220 @@
+// Copyright 2018 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Package pluginset derives the plugins implied by an OPA configuration, split
+// into those needing a start and those needing a reconfigure. Shared by the
+// discovery plugin and the runtime's configuration file reloading.
+package pluginset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/v1/config"
+	"github.com/open-policy-agent/opa/v1/logging"
+	"github.com/open-policy-agent/opa/v1/metrics"
+	"github.com/open-policy-agent/opa/v1/plugins"
+	"github.com/open-policy-agent/opa/v1/plugins/bundle"
+	"github.com/open-policy-agent/opa/v1/plugins/logs"
+	"github.com/open-policy-agent/opa/v1/plugins/status"
+)
+
+// Set holds the plugins Get registered and still need starting, and those
+// already registered that need reconfiguring.
+type Set struct {
+	Start    []plugins.Plugin
+	Reconfig []Reconfig
+}
+
+// Reconfig pairs an already running plugin with its new configuration.
+type Reconfig struct {
+	Config any
+	Plugin plugins.Plugin
+}
+
+// Apply starts the plugins that aren't running, then reconfigures the rest.
+func (s *Set) Apply(ctx context.Context) error {
+	for _, p := range s.Start {
+		if err := p.Start(ctx); err != nil {
+			return err
+		}
+	}
+
+	for _, p := range s.Reconfig {
+		p.Plugin.Reconfigure(ctx, p.Config)
+	}
+
+	return nil
+}
+
+type pluginfactory struct {
+	name    string
+	factory plugins.Factory
+	config  any
+}
+
+// Get validates config and registers any plugin it enables that isn't registered
+// yet. Plugins config no longer mentions are left running as-is.
+func Get(
+	factories map[string]plugins.Factory,
+	manager *plugins.Manager,
+	config *config.Config,
+	m metrics.Metrics,
+	l logging.Logger,
+	trigger *plugins.TriggerMode,
+) (*Set, error) {
+	// Parse and validate plugin configurations.
+	pluginNames := []string{}
+	pluginFactories := []pluginfactory{}
+	serviceNames := manager.Services()
+
+	for k := range config.Plugins {
+		f, ok := factories[k]
+		if !ok {
+			return nil, fmt.Errorf("plugin %q not registered", k)
+		}
+
+		c, err := f.Validate(manager, config.Plugins[k])
+		if err != nil {
+			return nil, err
+		}
+
+		pluginFactories = append(pluginFactories, pluginfactory{
+			name:    k,
+			factory: f,
+			config:  c,
+		})
+
+		pluginNames = append(pluginNames, k)
+	}
+
+	// Parse and validate bundle/logs/status configurations.
+
+	// If `bundle` was configured use that, otherwise try the new `bundles` option
+	bundleConfig, err := bundle.ParseConfig(config.Bundle, serviceNames) //nolint:staticcheck
+	if err != nil {
+		return nil, err
+	}
+	if bundleConfig == nil {
+		bundleConfig, err = bundle.NewConfigBuilder().WithBytes(config.Bundles).WithServices(serviceNames).
+			WithKeyConfigs(manager.PublicKeys()).WithTriggerMode(trigger).Parse()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		manager.Logger().Warn("Deprecated 'bundle' configuration specified. Use 'bundles' instead. See https://www.openpolicyagent.org/docs/latest/configuration/#bundles")
+	}
+
+	decisionLogsConfig, err := logs.NewConfigBuilder().WithBytes(config.DecisionLogs).WithServices(serviceNames).
+		WithPlugins(pluginNames).WithTriggerMode(trigger).WithLogger(l).Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	statusConfig, err := status.NewConfigBuilder().WithBytes(config.Status).WithServices(serviceNames).
+		WithPlugins(pluginNames).WithTriggerMode(trigger).Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	// Accumulate plugins to start or reconfigure.
+	starts := []plugins.Plugin{}
+	reconfigs := []Reconfig{}
+
+	if bundleConfig != nil {
+		p, created := getBundlePlugin(manager, bundleConfig)
+		if created {
+			starts = append(starts, p)
+		} else if p != nil {
+			reconfigs = append(reconfigs, Reconfig{Config: bundleConfig, Plugin: p})
+		}
+	}
+
+	if decisionLogsConfig != nil {
+		p, created := getDecisionLogsPlugin(manager, decisionLogsConfig, m)
+		if created {
+			starts = append(starts, p)
+		} else if p != nil {
+			reconfigs = append(reconfigs, Reconfig{Config: decisionLogsConfig, Plugin: p})
+		}
+	}
+
+	if statusConfig != nil {
+		p, created := getStatusPlugin(manager, statusConfig, m)
+		if created {
+			starts = append(starts, p)
+		} else if p != nil {
+			reconfigs = append(reconfigs, Reconfig{Config: statusConfig, Plugin: p})
+		}
+	}
+
+	result := &Set{Start: starts, Reconfig: reconfigs}
+
+	getCustomPlugins(manager, pluginFactories, result)
+
+	return result, nil
+}
+
+func getBundlePlugin(m *plugins.Manager, config *bundle.Config) (plugin *bundle.Plugin, created bool) {
+	plugin = bundle.Lookup(m)
+	if plugin == nil {
+		plugin = bundle.New(config, m)
+		m.Register(bundle.Name, plugin)
+		registerBundleStatusUpdates(m)
+		created = true
+	}
+	return plugin, created
+}
+
+func getDecisionLogsPlugin(m *plugins.Manager, config *logs.Config, metrics metrics.Metrics) (plugin *logs.Plugin, created bool) {
+	plugin = logs.Lookup(m)
+	if plugin == nil {
+		plugin = logs.New(config, m).WithMetrics(metrics)
+		m.Register(logs.Name, plugin)
+		created = true
+	}
+	return plugin, created
+}
+
+func getStatusPlugin(m *plugins.Manager, config *status.Config, metrics metrics.Metrics) (plugin *status.Plugin, created bool) {
+	plugin = status.Lookup(m)
+
+	if plugin == nil {
+		plugin = status.New(config, m).WithMetrics(metrics)
+		m.Register(status.Name, plugin)
+		registerBundleStatusUpdates(m)
+		created = true
+	}
+
+	return plugin, created
+}
+
+func getCustomPlugins(manager *plugins.Manager, factories []pluginfactory, result *Set) {
+	for _, pf := range factories {
+		if plugin := manager.Plugin(pf.name); plugin != nil {
+			result.Reconfig = append(result.Reconfig, Reconfig{Config: pf.config, Plugin: plugin})
+		} else {
+			plugin := pf.factory.New(manager, pf.config)
+			manager.Register(pf.name, plugin)
+			result.Start = append(result.Start, plugin)
+		}
+	}
+}
+
+func registerBundleStatusUpdates(m *plugins.Manager) {
+	bp := bundle.Lookup(m)
+	sp := status.Lookup(m)
+	if bp == nil || sp == nil {
+		return
+	}
+	type pluginlistener string
+
+	// Depending on how the plugin was configured we will want to use different listeners
+	// for backwards compatibility.
+	if !bp.Config().IsMultiBundle() {
+		bp.Register(pluginlistener(status.Name), sp.UpdateBundleStatus) //nolint:staticcheck
+	} else {
+		bp.RegisterBulkListener(pluginlistener(status.Name), sp.BulkUpdateBundleStatus)
+	}
+}

--- a/internal/pluginset/pluginset.go
+++ b/internal/pluginset/pluginset.go
@@ -10,6 +10,7 @@ package pluginset
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/open-policy-agent/opa/v1/config"
 	"github.com/open-policy-agent/opa/v1/logging"
@@ -20,8 +21,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/plugins/status"
 )
 
-// Set holds the plugins Get registered and still need starting, and those
-// already registered that need reconfiguring.
+// Set holds the plugins Configs.Set registered and that still need starting, and
+// those already registered that need reconfiguring.
 type Set struct {
 	Start    []plugins.Plugin
 	Reconfig []Reconfig
@@ -54,9 +55,27 @@ type pluginfactory struct {
 	config  any
 }
 
-// Get validates config and registers any plugin it enables that isn't registered
-// yet. Plugins config no longer mentions are left running as-is.
-func Get(
+// Configs holds the plugin configurations a configuration enables. Deriving them
+// registers nothing, so a caller can inspect Orphaned and reject a configuration
+// before any plugin has been created.
+type Configs struct {
+	bundle  *bundle.Config
+	logs    *logs.Config
+	status  *status.Config
+	custom  []pluginfactory
+	metrics metrics.Metrics
+
+	// Orphaned names the configuration sections of plugins that are running but
+	// that these configurations no longer enable. Building the set leaves them
+	// running unchanged -- the manager cannot unregister a plugin -- so a caller
+	// that needs the running plugins to match the configuration has to reject it
+	// instead. Discovery ignores this.
+	Orphaned []string
+}
+
+// New validates config and registers any plugin it enables that isn't registered
+// yet. Plugins config no longer enables are left running as-is.
+func New(
 	factories map[string]plugins.Factory,
 	manager *plugins.Manager,
 	config *config.Config,
@@ -64,6 +83,24 @@ func Get(
 	l logging.Logger,
 	trigger *plugins.TriggerMode,
 ) (*Set, error) {
+	configs, err := Parse(factories, manager, config, m, l, trigger)
+	if err != nil {
+		return nil, err
+	}
+
+	return configs.Set(manager), nil
+}
+
+// Parse validates config and derives the plugin configurations it enables,
+// without touching the manager.
+func Parse(
+	factories map[string]plugins.Factory,
+	manager *plugins.Manager,
+	config *config.Config,
+	m metrics.Metrics,
+	l logging.Logger,
+	trigger *plugins.TriggerMode,
+) (*Configs, error) {
 	// Parse and validate plugin configurations.
 	pluginNames := []string{}
 	pluginFactories := []pluginfactory{}
@@ -118,42 +155,74 @@ func Get(
 		return nil, err
 	}
 
+	configs := &Configs{
+		bundle:  bundleConfig,
+		logs:    decisionLogsConfig,
+		status:  statusConfig,
+		custom:  pluginFactories,
+		metrics: m,
+	}
+
+	if bundleConfig == nil && bundle.Lookup(manager) != nil {
+		configs.Orphaned = append(configs.Orphaned, "bundles")
+	}
+	if decisionLogsConfig == nil && logs.Lookup(manager) != nil {
+		configs.Orphaned = append(configs.Orphaned, "decision_logs")
+	}
+	if statusConfig == nil && status.Lookup(manager) != nil {
+		configs.Orphaned = append(configs.Orphaned, "status")
+	}
+	// Only the plugins this package manages: the manager holds others, such as
+	// discovery itself, that no configuration section here enables.
+	for name := range factories {
+		if _, ok := config.Plugins[name]; !ok && manager.Plugin(name) != nil {
+			configs.Orphaned = append(configs.Orphaned, "plugins."+name)
+		}
+	}
+	slices.Sort(configs.Orphaned)
+
+	return configs, nil
+}
+
+// Set registers any plugin these configurations enable that isn't registered
+// yet, and returns the plugins to start and reconfigure.
+func (c *Configs) Set(manager *plugins.Manager) *Set {
 	// Accumulate plugins to start or reconfigure.
 	starts := []plugins.Plugin{}
 	reconfigs := []Reconfig{}
 
-	if bundleConfig != nil {
-		p, created := getBundlePlugin(manager, bundleConfig)
+	if c.bundle != nil {
+		p, created := getBundlePlugin(manager, c.bundle)
 		if created {
 			starts = append(starts, p)
 		} else if p != nil {
-			reconfigs = append(reconfigs, Reconfig{Config: bundleConfig, Plugin: p})
+			reconfigs = append(reconfigs, Reconfig{Config: c.bundle, Plugin: p})
 		}
 	}
 
-	if decisionLogsConfig != nil {
-		p, created := getDecisionLogsPlugin(manager, decisionLogsConfig, m)
+	if c.logs != nil {
+		p, created := getDecisionLogsPlugin(manager, c.logs, c.metrics)
 		if created {
 			starts = append(starts, p)
 		} else if p != nil {
-			reconfigs = append(reconfigs, Reconfig{Config: decisionLogsConfig, Plugin: p})
+			reconfigs = append(reconfigs, Reconfig{Config: c.logs, Plugin: p})
 		}
 	}
 
-	if statusConfig != nil {
-		p, created := getStatusPlugin(manager, statusConfig, m)
+	if c.status != nil {
+		p, created := getStatusPlugin(manager, c.status, c.metrics)
 		if created {
 			starts = append(starts, p)
 		} else if p != nil {
-			reconfigs = append(reconfigs, Reconfig{Config: statusConfig, Plugin: p})
+			reconfigs = append(reconfigs, Reconfig{Config: c.status, Plugin: p})
 		}
 	}
 
 	result := &Set{Start: starts, Reconfig: reconfigs}
 
-	getCustomPlugins(manager, pluginFactories, result)
+	getCustomPlugins(manager, c.custom, result)
 
-	return result, nil
+	return result
 }
 
 func getBundlePlugin(m *plugins.Manager, config *bundle.Config) (plugin *bundle.Plugin, created bool) {

--- a/v1/hooks/hooks.go
+++ b/v1/hooks/hooks.go
@@ -63,7 +63,8 @@ func (hs Hooks) Len() int {
 }
 
 // ConfigHook allows inspecting or rewriting the configuration when the plugin
-// manager is processing it.
+// manager is processing it. It also runs when the runtime reloads its
+// configuration file from disk.
 // Note that this hook is not run when the plugin manager is reconfigured. This
 // usually only happens when there's a new config from a discovery bundle, and
 // for processing _that_, there's `ConfigDiscoveryHook`.

--- a/v1/plugins/bundle/plugin.go
+++ b/v1/plugins/bundle/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/logging"
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/plugins"
+	"github.com/open-policy-agent/opa/v1/plugins/rest"
 	"github.com/open-policy-agent/opa/v1/storage"
 )
 
@@ -58,6 +59,7 @@ type Loader interface {
 // Plugin implements bundle activation.
 type Plugin struct {
 	config            Config
+	clientConfigs     map[string]*rest.Config          // service client each downloader was built with, guarded by cfgMtx
 	manager           *plugins.Manager                 // plugin manager for storage and service clients
 	status            map[string]*Status               // current status for each bundle
 	etags             map[string]string                // etag on last successful activation
@@ -82,13 +84,14 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 	}
 
 	p := &Plugin{
-		manager:     manager,
-		config:      *parsedConfig,
-		status:      initialStatus,
-		downloaders: make(map[string]Loader),
-		etags:       make(map[string]string),
-		ready:       false,
-		logger:      manager.Logger(),
+		manager:       manager,
+		config:        *parsedConfig,
+		clientConfigs: clientConfigs(manager, parsedConfig.Bundles),
+		status:        initialStatus,
+		downloaders:   make(map[string]Loader),
+		etags:         make(map[string]string),
+		ready:         false,
+		logger:        manager.Logger(),
 	}
 
 	manager.UpdatePluginStatus(Name, &plugins.Status{State: plugins.StateNotReady})
@@ -168,6 +171,7 @@ func (p *Plugin) Reconfigure(ctx context.Context, config any) {
 	}
 	newBundles, updatedBundles, deletedBundles := p.configDelta(newConfig)
 	p.config = *newConfig
+	p.clientConfigs = clientConfigs(p.manager, newConfig.Bundles)
 	p.cfgMtx.Unlock()
 
 	if len(updatedBundles) == 0 && len(newBundles) == 0 && len(deletedBundles) == 0 {
@@ -719,13 +723,34 @@ func (p *Plugin) configDelta(newConfig *Config) (map[string]*Source, map[string]
 			newBundles[name] = source
 		} else {
 			delete(deletedBundles, name)
-			if !reflect.DeepEqual(oldSource, source) {
+			// The downloader holds the client it was built with, so a service
+			// re-registered under the same name counts as a change even when the
+			// bundle's own configuration is untouched.
+			if !reflect.DeepEqual(oldSource, source) || !p.clientChanged(name, source) {
 				updatedBundles[name] = source
 			}
 		}
 	}
 
 	return newBundles, updatedBundles, deletedBundles
+}
+
+// clientChanged reports whether the service client a bundle would be downloaded
+// with now matches the one its downloader was built with.
+func (p *Plugin) clientChanged(name string, source *Source) bool {
+	old, ok := p.clientConfigs[name]
+	return ok && old.Equal(p.manager.Client(source.Service).Config())
+}
+
+// clientConfigs snapshots the service client configuration behind each bundle.
+func clientConfigs(manager *plugins.Manager, bundles map[string]*Source) map[string]*rest.Config {
+	configs := make(map[string]*rest.Config, len(bundles))
+	for name, source := range bundles {
+		if source != nil {
+			configs[name] = manager.Client(source.Service).Config()
+		}
+	}
+	return configs
 }
 
 func (p *Plugin) saveBundleToDisk(name string, raw io.Reader) error {

--- a/v1/plugins/bundle/reconfigure_test.go
+++ b/v1/plugins/bundle/reconfigure_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package bundle
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/config"
+	"github.com/open-policy-agent/opa/v1/download"
+	"github.com/open-policy-agent/opa/v1/plugins"
+)
+
+// countingServer answers bundle downloads with a 304, which is enough to see
+// which endpoint the downloader is talking to without building a bundle.
+func countingServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	var hits atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts, &hits
+}
+
+func reconfigureTestPlugin(t *testing.T, url string) (*Plugin, *plugins.Manager, *Config) {
+	t.Helper()
+
+	manager := getTestManager()
+	t.Cleanup(func() { manager.Stop(t.Context()) })
+
+	if err := manager.Reconfigure(&config.Config{
+		Services: fmt.Appendf(nil, `{"acme": {"url": %q}}`, url),
+	}); err != nil {
+		t.Fatalf("configure manager: %v", err)
+	}
+
+	trigger := plugins.TriggerManual
+	cfg := &Config{
+		Bundles: map[string]*Source{
+			"b": {
+				Service:  "acme",
+				Resource: "/bundles/b.tar.gz",
+				Config:   download.Config{Trigger: &trigger},
+			},
+		},
+	}
+
+	plugin := New(cfg, manager)
+	t.Cleanup(func() { plugin.Stop(t.Context()) })
+
+	// Stand in for Start, which would also begin polling.
+	plugin.downloaders["b"] = plugin.newDownloader("b", cfg.Bundles["b"], cfg.Bundles)
+
+	return plugin, manager, cfg
+}
+
+func reconfigureServices(t *testing.T, manager *plugins.Manager, url string) {
+	t.Helper()
+
+	if err := manager.Reconfigure(&config.Config{
+		Services: fmt.Appendf(nil, `{"acme": {"url": %q}}`, url),
+	}); err != nil {
+		t.Fatalf("reconfigure manager: %v", err)
+	}
+}
+
+// The downloader holds the client it was built with, so re-registering the
+// service a bundle points at has to restart it even though the bundle's own
+// configuration is untouched.
+func TestPluginReconfigurePicksUpChangedService(t *testing.T) {
+	first, firstHits := countingServer(t)
+	second, secondHits := countingServer(t)
+
+	plugin, manager, cfg := reconfigureTestPlugin(t, first.URL)
+
+	if err := plugin.Trigger(t.Context()); err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	if firstHits.Load() != 1 || secondHits.Load() != 0 {
+		t.Fatalf("expected the first server to be polled, got first=%d second=%d", firstHits.Load(), secondHits.Load())
+	}
+
+	// Same bundle config as before: only the service moved.
+	reconfigureServices(t, manager, second.URL)
+	plugin.Reconfigure(t.Context(), cfg)
+
+	if err := plugin.Trigger(t.Context()); err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	if secondHits.Load() != 1 {
+		t.Errorf("expected the download to move to the second server, got first=%d second=%d", firstHits.Load(), secondHits.Load())
+	}
+}
+
+// The converse, and the reason this is worth a test: restarting a downloader
+// drops its etag, so a spurious restart re-downloads every bundle in full.
+func TestPluginReconfigureUnchangedServiceIsANoOp(t *testing.T) {
+	first, _ := countingServer(t)
+
+	plugin, manager, cfg := reconfigureTestPlugin(t, first.URL)
+
+	before := plugin.downloaders["b"]
+
+	reconfigureServices(t, manager, first.URL)
+	plugin.Reconfigure(t.Context(), cfg)
+
+	if plugin.downloaders["b"] != before {
+		t.Error("expected the downloader to be left alone when nothing changed")
+	}
+}

--- a/v1/plugins/discovery/discovery.go
+++ b/v1/plugins/discovery/discovery.go
@@ -120,7 +120,7 @@ func New(manager *plugins.Manager, opts ...func(*Discovery)) (*Discovery, error)
 	if err != nil {
 		return nil, err
 	} else if config == nil {
-		if _, err := pluginset.Get(result.factories, manager, managerConfig, result.metrics, result.logger, nil); err != nil {
+		if _, err := pluginset.New(result.factories, manager, managerConfig, result.metrics, result.logger, nil); err != nil {
 			return nil, err
 		}
 		return result, nil
@@ -168,7 +168,7 @@ func (c *Discovery) Start(ctx context.Context) error {
 		c.loadAndActivateBundleFromDisk(ctx)
 	} else {
 		// If bundle persistence isn't enabled, initialise plugins before starting the downloader
-		ps, err := pluginset.Get(c.factories, c.manager, c.manager.GetConfig(), c.metrics, c.logger, nil)
+		ps, err := pluginset.New(c.factories, c.manager, c.manager.GetConfig(), c.metrics, c.logger, nil)
 		if err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 		return nil, err
 	}
 
-	ps, err := pluginset.Get(c.factories, c.manager, overriddenConfig, c.metrics, c.logger, c.config.Trigger)
+	ps, err := pluginset.New(c.factories, c.manager, overriddenConfig, c.metrics, c.logger, c.config.Trigger)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/plugins/discovery/discovery.go
+++ b/v1/plugins/discovery/discovery.go
@@ -20,6 +20,7 @@ import (
 
 	bundleUtils "github.com/open-policy-agent/opa/internal/bundle"
 	cfg "github.com/open-policy-agent/opa/internal/config"
+	"github.com/open-policy-agent/opa/internal/pluginset"
 	"github.com/open-policy-agent/opa/v1/ast"
 	bundleApi "github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/config"
@@ -30,7 +31,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/metrics"
 	"github.com/open-policy-agent/opa/v1/plugins"
 	"github.com/open-policy-agent/opa/v1/plugins/bundle"
-	"github.com/open-policy-agent/opa/v1/plugins/logs"
 	"github.com/open-policy-agent/opa/v1/plugins/status"
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
@@ -120,7 +120,7 @@ func New(manager *plugins.Manager, opts ...func(*Discovery)) (*Discovery, error)
 	if err != nil {
 		return nil, err
 	} else if config == nil {
-		if _, err := getPluginSet(result.factories, manager, managerConfig, result.metrics, result.logger, nil); err != nil {
+		if _, err := pluginset.Get(result.factories, manager, managerConfig, result.metrics, result.logger, nil); err != nil {
 			return nil, err
 		}
 		return result, nil
@@ -168,7 +168,7 @@ func (c *Discovery) Start(ctx context.Context) error {
 		c.loadAndActivateBundleFromDisk(ctx)
 	} else {
 		// If bundle persistence isn't enabled, initialise plugins before starting the downloader
-		ps, err := getPluginSet(c.factories, c.manager, c.manager.GetConfig(), c.metrics, c.logger, nil)
+		ps, err := pluginset.Get(c.factories, c.manager, c.manager.GetConfig(), c.metrics, c.logger, nil)
 		if err != nil {
 			return err
 		}
@@ -423,17 +423,7 @@ func (c *Discovery) reconfigure(ctx context.Context, u download.Update) error {
 		return err
 	}
 
-	for _, p := range ps.Start {
-		if err := p.Start(ctx); err != nil {
-			return err
-		}
-	}
-
-	for _, p := range ps.Reconfig {
-		p.Plugin.Reconfigure(ctx, p.Config)
-	}
-
-	return nil
+	return ps.Apply(ctx)
 }
 
 func (c *Discovery) applyLocalPluginConfigOverride(conf *config.Config) (*config.Config, []string, error) {
@@ -463,7 +453,7 @@ func (c *Discovery) applyLocalPluginConfigOverride(conf *config.Config) (*config
 	return parsedConf, overriddenKeys, nil
 }
 
-func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pluginSet, error) {
+func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pluginset.Set, error) {
 	config, err := evaluateBundle(ctx, c.manager.ID, c.manager.Info, b, c.config.query)
 	if err != nil {
 		return nil, err
@@ -534,7 +524,7 @@ func (c *Discovery) processBundle(ctx context.Context, b *bundleApi.Bundle) (*pl
 		return nil, err
 	}
 
-	ps, err := getPluginSet(c.factories, c.manager, overriddenConfig, c.metrics, c.logger, c.config.Trigger)
+	ps, err := pluginset.Get(c.factories, c.manager, overriddenConfig, c.metrics, c.logger, c.config.Trigger)
 	if err != nil {
 		return nil, err
 	}
@@ -591,185 +581,6 @@ func evaluateBundle(ctx context.Context, id string, info *ast.Term, b *bundleApi
 
 	processedConf := cfg.SubEnvVars(string(bs))
 	return config.ParseConfig([]byte(processedConf), id)
-}
-
-type pluginSet struct {
-	Start    []plugins.Plugin
-	Reconfig []pluginreconfig
-}
-
-type pluginreconfig struct {
-	Config any
-	Plugin plugins.Plugin
-}
-
-type pluginfactory struct {
-	name    string
-	factory plugins.Factory
-	config  any
-}
-
-func getPluginSet(
-	factories map[string]plugins.Factory,
-	manager *plugins.Manager,
-	config *config.Config,
-	m metrics.Metrics,
-	l logging.Logger,
-	trigger *plugins.TriggerMode,
-) (*pluginSet, error) {
-	// Parse and validate plugin configurations.
-	pluginNames := []string{}
-	pluginFactories := []pluginfactory{}
-	serviceNames := manager.Services()
-
-	for k := range config.Plugins {
-		f, ok := factories[k]
-		if !ok {
-			return nil, fmt.Errorf("plugin %q not registered", k)
-		}
-
-		c, err := f.Validate(manager, config.Plugins[k])
-		if err != nil {
-			return nil, err
-		}
-
-		pluginFactories = append(pluginFactories, pluginfactory{
-			name:    k,
-			factory: f,
-			config:  c,
-		})
-
-		pluginNames = append(pluginNames, k)
-	}
-
-	// Parse and validate bundle/logs/status configurations.
-
-	// If `bundle` was configured use that, otherwise try the new `bundles` option
-	bundleConfig, err := bundle.ParseConfig(config.Bundle, serviceNames) //nolint:staticcheck
-	if err != nil {
-		return nil, err
-	}
-	if bundleConfig == nil {
-		bundleConfig, err = bundle.NewConfigBuilder().WithBytes(config.Bundles).WithServices(serviceNames).
-			WithKeyConfigs(manager.PublicKeys()).WithTriggerMode(trigger).Parse()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		manager.Logger().Warn("Deprecated 'bundle' configuration specified. Use 'bundles' instead. See https://www.openpolicyagent.org/docs/latest/configuration/#bundles")
-	}
-
-	decisionLogsConfig, err := logs.NewConfigBuilder().WithBytes(config.DecisionLogs).WithServices(serviceNames).
-		WithPlugins(pluginNames).WithTriggerMode(trigger).WithLogger(l).Parse()
-	if err != nil {
-		return nil, err
-	}
-
-	statusConfig, err := status.NewConfigBuilder().WithBytes(config.Status).WithServices(serviceNames).
-		WithPlugins(pluginNames).WithTriggerMode(trigger).Parse()
-	if err != nil {
-		return nil, err
-	}
-
-	// Accumulate plugins to start or reconfigure.
-	starts := []plugins.Plugin{}
-	reconfigs := []pluginreconfig{}
-
-	if bundleConfig != nil {
-		p, created := getBundlePlugin(manager, bundleConfig)
-		if created {
-			starts = append(starts, p)
-		} else if p != nil {
-			reconfigs = append(reconfigs, pluginreconfig{Config: bundleConfig, Plugin: p})
-		}
-	}
-
-	if decisionLogsConfig != nil {
-		p, created := getDecisionLogsPlugin(manager, decisionLogsConfig, m)
-		if created {
-			starts = append(starts, p)
-		} else if p != nil {
-			reconfigs = append(reconfigs, pluginreconfig{Config: decisionLogsConfig, Plugin: p})
-		}
-	}
-
-	if statusConfig != nil {
-		p, created := getStatusPlugin(manager, statusConfig, m)
-		if created {
-			starts = append(starts, p)
-		} else if p != nil {
-			reconfigs = append(reconfigs, pluginreconfig{Config: statusConfig, Plugin: p})
-		}
-	}
-
-	result := &pluginSet{Start: starts, Reconfig: reconfigs}
-
-	getCustomPlugins(manager, pluginFactories, result)
-
-	return result, nil
-}
-
-func getBundlePlugin(m *plugins.Manager, config *bundle.Config) (plugin *bundle.Plugin, created bool) {
-	plugin = bundle.Lookup(m)
-	if plugin == nil {
-		plugin = bundle.New(config, m)
-		m.Register(bundle.Name, plugin)
-		registerBundleStatusUpdates(m)
-		created = true
-	}
-	return plugin, created
-}
-
-func getDecisionLogsPlugin(m *plugins.Manager, config *logs.Config, metrics metrics.Metrics) (plugin *logs.Plugin, created bool) {
-	plugin = logs.Lookup(m)
-	if plugin == nil {
-		plugin = logs.New(config, m).WithMetrics(metrics)
-		m.Register(logs.Name, plugin)
-		created = true
-	}
-	return plugin, created
-}
-
-func getStatusPlugin(m *plugins.Manager, config *status.Config, metrics metrics.Metrics) (plugin *status.Plugin, created bool) {
-	plugin = status.Lookup(m)
-
-	if plugin == nil {
-		plugin = status.New(config, m).WithMetrics(metrics)
-		m.Register(status.Name, plugin)
-		registerBundleStatusUpdates(m)
-		created = true
-	}
-
-	return plugin, created
-}
-
-func getCustomPlugins(manager *plugins.Manager, factories []pluginfactory, result *pluginSet) {
-	for _, pf := range factories {
-		if plugin := manager.Plugin(pf.name); plugin != nil {
-			result.Reconfig = append(result.Reconfig, pluginreconfig{Config: pf.config, Plugin: plugin})
-		} else {
-			plugin := pf.factory.New(manager, pf.config)
-			manager.Register(pf.name, plugin)
-			result.Start = append(result.Start, plugin)
-		}
-	}
-}
-
-func registerBundleStatusUpdates(m *plugins.Manager) {
-	bp := bundle.Lookup(m)
-	sp := status.Lookup(m)
-	if bp == nil || sp == nil {
-		return
-	}
-	type pluginlistener string
-
-	// Depending on how the plugin was configured we will want to use different listeners
-	// for backwards compatibility.
-	if !bp.Config().IsMultiBundle() {
-		bp.Register(pluginlistener(status.Name), sp.UpdateBundleStatus) //nolint:staticcheck
-	} else {
-		bp.RegisterBulkListener(pluginlistener(status.Name), sp.BulkUpdateBundleStatus)
-	}
 }
 
 // mergeValuesAndListOverrides will merge source and destination map, preferring values from the source map.

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -3487,7 +3487,7 @@ bundle:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+	_, err := pluginset.New(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3524,7 +3524,7 @@ bundles:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+	_, err := pluginset.New(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3583,7 +3583,7 @@ bundles:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.New(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3646,7 +3646,7 @@ decision_logs:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.New(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3716,7 +3716,7 @@ status:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.New(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {

--- a/v1/plugins/discovery/discovery_test.go
+++ b/v1/plugins/discovery/discovery_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-policy-agent/opa/internal/pluginset"
 	"github.com/open-policy-agent/opa/v1/ast"
 	bundleApi "github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/download"
@@ -3486,7 +3487,7 @@ bundle:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+	_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3523,7 +3524,7 @@ bundles:
 `
 	manager := getTestManager(t, conf)
 	trigger := plugins.TriggerManual
-	_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+	_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -3582,7 +3583,7 @@ bundles:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3645,7 +3646,7 @@ decision_logs:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {
@@ -3715,7 +3716,7 @@ status:
 		t.Run(name, func(t *testing.T) {
 			manager := getTestManager(t, tc.conf)
 			trigger := plugins.TriggerManual
-			_, err := getPluginSet(nil, manager, manager.GetConfig(), nil, nil, &trigger)
+			_, err := pluginset.Get(nil, manager, manager.GetConfig(), nil, nil, &trigger)
 
 			if tc.wantErr {
 				if err == nil {

--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -476,6 +476,7 @@ type buffer interface {
 type Plugin struct {
 	manager       *plugins.Manager
 	config        Config
+	clientConfig  *rest.Config // the service client config the buffer was built with
 	reconfigMtx   sync.RWMutex // reconfigMtx blocks reads/writes on buffer reconfiguration
 	b             buffer
 	statusMtx     sync.Mutex
@@ -630,6 +631,7 @@ func New(parsedConfig *Config, manager *plugins.Manager) *Plugin {
 		logger:   manager.Logger().WithFields(map[string]any{"plugin": Name}),
 		status:   &lstat.Status{},
 	}
+	plugin.clientConfig = manager.Client(plugin.config.Service).Config()
 
 	switch parsedConfig.Reporting.BufferType {
 	case eventBufferType:
@@ -1017,8 +1019,12 @@ func (p *Plugin) doOneShot(ctx context.Context) (err error) {
 
 func (p *Plugin) reconfigure(ctx context.Context, config any) {
 	newConfig := config.(*Config)
+	newClientConfig := p.manager.Client(newConfig.Service).Config()
 
-	if reflect.DeepEqual(p.config, *newConfig) {
+	// The client is captured by the buffer, so a service the plugin already
+	// points at having been re-registered has to count as a change too --
+	// otherwise a rotated credential or a moved URL never reaches the uploader.
+	if reflect.DeepEqual(p.config, *newConfig) && p.clientConfig.Equal(newClientConfig) {
 		p.logger.Debug("Decision log uploader configuration unchanged.")
 		return
 	}
@@ -1028,6 +1034,7 @@ func (p *Plugin) reconfigure(ctx context.Context, config any) {
 
 	p.logger.Info("Decision log uploader configuration changed.")
 	p.config = *newConfig
+	p.clientConfig = newClientConfig
 
 	// upload all events in the current buffer type
 	if err := p.b.Upload(ctx); err != nil && !util.ErrorIs[*bufferEmpty](err) {

--- a/v1/plugins/logs/reconfigure_test.go
+++ b/v1/plugins/logs/reconfigure_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package logs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/config"
+	"github.com/open-policy-agent/opa/v1/plugins"
+	inmem "github.com/open-policy-agent/opa/v1/storage/inmem/test"
+)
+
+func servicesConfig(url string) []byte {
+	return fmt.Appendf(nil, `{"acme": {"url": %q}}`, url)
+}
+
+func reconfigureTestPlugin(t *testing.T, url string) (*Plugin, *plugins.Manager) {
+	t.Helper()
+
+	manager, err := plugins.New(nil, "test-instance-id", inmem.New())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if err := manager.Reconfigure(&config.Config{Services: servicesConfig(url)}); err != nil {
+		t.Fatalf("configure manager: %v", err)
+	}
+
+	cfg := &Config{Service: "acme"}
+	trigger := plugins.DefaultTriggerMode
+	if err := cfg.validateAndInjectDefaults([]string{"acme"}, nil, &trigger, nil); err != nil {
+		t.Fatalf("validate config: %v", err)
+	}
+
+	return New(cfg, manager), manager
+}
+
+// The buffer holds the client it was built with, so re-registering the service
+// the plugin already points at has to reach the uploader even though the
+// plugin's own configuration is untouched.
+func TestPluginReconfigurePicksUpChangedService(t *testing.T) {
+	plugin, manager := reconfigureTestPlugin(t, "https://first.example.com")
+
+	if got := plugin.b.(*sizeBuffer).client.Config().URL; got != "https://first.example.com" {
+		t.Fatalf("expected the buffer to start on the first URL, got %q", got)
+	}
+
+	if err := manager.Reconfigure(&config.Config{
+		Services: servicesConfig("https://second.example.com"),
+	}); err != nil {
+		t.Fatalf("reconfigure manager: %v", err)
+	}
+
+	// Same plugin config as before: only the service moved.
+	plugin.reconfigure(t.Context(), plugin.Config())
+
+	if got := plugin.b.(*sizeBuffer).client.Config().URL; got != "https://second.example.com" {
+		t.Errorf("expected the buffer to be rebuilt on the second URL, got %q", got)
+	}
+}
+
+// The converse: an unchanged service must not rebuild the buffer, which would
+// flush and re-upload on every reconfigure.
+func TestPluginReconfigureUnchangedServiceIsANoOp(t *testing.T) {
+	plugin, manager := reconfigureTestPlugin(t, "https://first.example.com")
+
+	before := plugin.b
+
+	if err := manager.Reconfigure(&config.Config{
+		Services: servicesConfig("https://first.example.com"),
+	}); err != nil {
+		t.Fatalf("reconfigure manager: %v", err)
+	}
+
+	plugin.reconfigure(t.Context(), plugin.Config())
+
+	if plugin.b != before {
+		t.Error("expected the buffer to be left alone when nothing changed")
+	}
+}

--- a/v1/runtime/config.go
+++ b/v1/runtime/config.go
@@ -1,0 +1,338 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/open-policy-agent/opa/internal/config"
+	"github.com/open-policy-agent/opa/internal/pluginset"
+	opa_config "github.com/open-policy-agent/opa/v1/config"
+	"github.com/open-policy-agent/opa/v1/hooks"
+	"github.com/open-policy-agent/opa/v1/util"
+)
+
+// Top-level keys OPA only reads at start-up. A reload that changes one is
+// rejected rather than applied in part.
+var nonReloadableConfigKeys = []string{
+	"default_authorization_decision",
+	"default_decision",
+	"discovery",
+	"distributed_tracing",
+	"metrics_export",
+	"persistence_directory",
+	"server",
+	"storage",
+}
+
+// Configuration sections that enable a plugin, grouped where more than one
+// drives the same plugin: "bundle" is the deprecated spelling of "bundles", and
+// either keeps the bundle plugin running. The manager cannot unregister a
+// plugin, so dropping a whole group would leave it running with its old settings
+// while disappearing from the reported configuration.
+var pluginConfigKeys = [][]string{
+	{"bundle", "bundles"},
+	{"decision_logs"},
+	{"status"},
+}
+
+// How long to wait for the file to stop changing before reading it. Writers that
+// truncate before writing leave it briefly empty, and reading that would apply
+// an empty configuration.
+const configCoalesceWindow = 200 * time.Millisecond
+
+// startConfigWatcher applies configuration file changes to the running plugins.
+// A no-op if no configuration file was given.
+func (rt *Runtime) startConfigWatcher(ctx context.Context, onReload func(time.Duration, error)) error {
+	if rt.Params.ConfigFile == "" {
+		return nil
+	}
+
+	// Discovery owns the plugin configuration once enabled, so a reload here
+	// would fight with it.
+	if rt.Manager.GetConfig().Discovery != nil {
+		rt.logger.Warn("Configuration file changes will not be reloaded because discovery is enabled.")
+		return nil
+	}
+
+	watcher, err := rt.getConfigWatcher(rt.Params.ConfigFile)
+	if err != nil {
+		return err
+	}
+
+	rt.configWatcherStop = make(chan struct{})
+	rt.configWatcherDone = make(chan struct{})
+
+	go rt.readConfigWatcher(ctx, watcher, onReload)
+	return nil
+}
+
+// stopConfigWatcher waits for a reload in flight, so no plugin is started after
+// the manager has stopped.
+func (rt *Runtime) stopConfigWatcher() {
+	if rt.configWatcherStop == nil {
+		return
+	}
+
+	close(rt.configWatcherStop)
+	<-rt.configWatcherDone
+}
+
+// getConfigWatcher watches the directory holding path, not the file: editors and
+// ConfigMap volumes replace the file by rename, which drops a watch on it.
+func (rt *Runtime) getConfigWatcher(path string) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(path)
+	if err := watcher.Add(dir); err != nil {
+		watcher.Close()
+		return nil, err
+	}
+
+	rt.logger.WithFields(map[string]any{"path": dir}).Debug("Watching directory of configuration file.")
+	return watcher, nil
+}
+
+// isConfigFileEvent reports whether an event concerns the configuration file. A
+// ConfigMap volume update only swaps the "..data" symlink, so that rename is the
+// only signal there.
+func (rt *Runtime) isConfigFileEvent(name string) bool {
+	base := filepath.Base(name)
+	return base == filepath.Base(rt.Params.ConfigFile) || base == "..data"
+}
+
+func (rt *Runtime) readConfigWatcher(ctx context.Context, watcher *fsnotify.Watcher, onReload func(time.Duration, error)) {
+	defer close(rt.configWatcherDone)
+	defer watcher.Close()
+
+	rt.watchConfigEvents(ctx, watcher.Events, watcher.Errors, onReload)
+}
+
+// watchConfigEvents is split from the watcher's lifecycle so tests can drive it:
+// sending into a live watcher's channel races with the goroutine owning it.
+func (rt *Runtime) watchConfigEvents(ctx context.Context, events <-chan fsnotify.Event, errs <-chan error, onReload func(time.Duration, error)) {
+	mask := fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
+
+	// Armed only while a change settles.
+	settle := time.NewTimer(configCoalesceWindow)
+	settle.Stop()
+	defer settle.Stop()
+
+	for {
+		select {
+		case evt := <-events:
+			if (evt.Op&mask) == 0 || !rt.isConfigFileEvent(evt.Name) {
+				continue
+			}
+
+			rt.logger.WithFields(map[string]any{
+				"event": evt.String(),
+			}).Debug("Registered configuration file event.")
+
+			settle.Reset(configCoalesceWindow)
+		case <-settle.C:
+			t0 := time.Now()
+			changed, err := rt.reloadConfig(ctx)
+			if changed || err != nil {
+				onReload(time.Since(t0), err)
+			}
+		case err := <-errs:
+			rt.logger.WithFields(map[string]any{"err": err}).Error("Configuration file watcher error.")
+		case <-rt.configWatcherStop:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// reloadConfig re-reads the configuration file and any --set overrides and
+// applies them. Reports whether the file differed from the one previously read.
+func (rt *Runtime) reloadConfig(ctx context.Context) (bool, error) {
+	bs, err := config.Load(rt.Params.ConfigFile, rt.Params.ConfigOverrides, rt.Params.ConfigOverrideFiles)
+	if err != nil {
+		return false, err
+	}
+
+	rt.configMtx.Lock()
+	defer rt.configMtx.Unlock()
+
+	// Nothing new, including a change already read and rejected: report once.
+	if bytes.Equal(bs, rt.lastConfig) {
+		return false, nil
+	}
+	rt.lastConfig = bs
+
+	// Diffed against the running configuration, not the last read, so reverting
+	// a change that failed undoes whatever part of it took effect.
+	if err := rt.applyConfig(ctx, bs); err != nil {
+		return true, err
+	}
+
+	rt.appliedConfig = bs
+	return true, nil
+}
+
+// applyConfig hands a new configuration to the plugin manager. Plugins it no
+// longer mentions keep running: as with discovery, plugins can be added and
+// reconfigured but not removed. Validating the plugin sections needs the new
+// services registered first, so a failure there leaves the manager holding the
+// new services, keys and caching.
+func (rt *Runtime) applyConfig(ctx context.Context, bs []byte) error {
+	oldConf, err := rawConfigMap(rt.appliedConfig)
+	if err != nil {
+		return err
+	}
+	newConf, err := rawConfigMap(bs)
+	if err != nil {
+		return err
+	}
+
+	if changed := changedKeys(oldConf, newConf, nonReloadableConfigKeys); len(changed) > 0 {
+		return fmt.Errorf("changes to %s require a restart", strings.Join(changed, ", "))
+	}
+	if relabelled := changedLabels(oldConf, newConf); len(relabelled) > 0 {
+		return fmt.Errorf("changing or removing labels (%s) requires a restart", strings.Join(relabelled, ", "))
+	}
+	if removed := removedPlugins(oldConf, newConf); len(removed) > 0 {
+		return fmt.Errorf("removing %s requires a restart", strings.Join(removed, ", "))
+	}
+
+	parsed, err := opa_config.ParseConfig(bs, rt.Params.ID)
+	if err != nil {
+		return err
+	}
+
+	rt.Params.Hooks.Each(func(h hooks.Hook) {
+		if f, ok := h.(hooks.ConfigHook); ok {
+			if c, e := f.OnConfig(ctx, parsed); e != nil {
+				err = errors.Join(err, e)
+			} else {
+				parsed = c
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, w := range parsed.Warnings {
+		rt.logger.Warn("%s", w)
+	}
+
+	if err := rt.Manager.Reconfigure(parsed); err != nil {
+		return err
+	}
+
+	registeredPluginsMux.Lock()
+	factories := maps.Clone(registeredPlugins)
+	registeredPluginsMux.Unlock()
+
+	ps, err := pluginset.Get(factories, rt.Manager, parsed, rt.metrics, rt.logger, nil)
+	if err != nil {
+		return err
+	}
+
+	return ps.Apply(ctx)
+}
+
+// rawConfigMap decodes a configuration as written, before defaults such as the
+// "id" and "version" labels are injected.
+func rawConfigMap(bs []byte) (map[string]any, error) {
+	var conf map[string]any
+	if err := util.Unmarshal(bs, &conf); err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+// changedKeys returns the keys whose value differs between two configurations.
+func changedKeys(oldConf, newConf map[string]any, keys []string) []string {
+	var changed []string
+	for _, k := range keys {
+		if !reflect.DeepEqual(oldConf[k], newConf[k]) {
+			changed = append(changed, k)
+		}
+	}
+
+	return changed
+}
+
+// changedLabels returns the labels the new configuration changes or drops.
+// Additions are left out because those do take effect; the manager restores the
+// labels captured at start-up over anything else, which would be silent.
+func changedLabels(oldConf, newConf map[string]any) []string {
+	oldLabels, _ := oldConf["labels"].(map[string]any)
+	newLabels, _ := newConf["labels"].(map[string]any)
+
+	var changed []string
+	for k, v := range oldLabels {
+		if nv, ok := newLabels[k]; !ok || !reflect.DeepEqual(nv, v) {
+			changed = append(changed, k)
+		}
+	}
+	slices.Sort(changed)
+
+	return changed
+}
+
+// removedPlugins returns the plugin sections the new configuration drops. An
+// empty section counts as absent, since that enables nothing either.
+func removedPlugins(oldConf, newConf map[string]any) []string {
+	configured := func(conf map[string]any, group []string) string {
+		for _, k := range group {
+			if v, ok := conf[k]; ok && v != nil {
+				return k
+			}
+		}
+		return ""
+	}
+
+	var removed []string
+	for _, group := range pluginConfigKeys {
+		if was := configured(oldConf, group); was != "" && configured(newConf, group) == "" {
+			removed = append(removed, was)
+		}
+	}
+
+	oldCustom, _ := oldConf["plugins"].(map[string]any)
+	newCustom, _ := newConf["plugins"].(map[string]any)
+	for k := range oldCustom {
+		if _, ok := newCustom[k]; !ok {
+			removed = append(removed, "plugins."+k)
+		}
+	}
+	slices.Sort(removed)
+
+	return removed
+}
+
+func (rt *Runtime) onConfigReloadLogger(d time.Duration, err error) {
+	if err != nil {
+		rt.logger.WithFields(map[string]any{
+			"duration": d,
+			"err":      err,
+		}).Error("Failed to reload configuration.")
+		return
+	}
+
+	rt.logger.WithFields(map[string]any{
+		"duration": d,
+	}).Info("Reloaded configuration.")
+}

--- a/v1/runtime/config.go
+++ b/v1/runtime/config.go
@@ -22,11 +22,25 @@ import (
 	"github.com/open-policy-agent/opa/internal/pluginset"
 	opa_config "github.com/open-policy-agent/opa/v1/config"
 	"github.com/open-policy-agent/opa/v1/hooks"
+	"github.com/open-policy-agent/opa/v1/plugins/bundle"
+	"github.com/open-policy-agent/opa/v1/plugins/logs"
+	"github.com/open-policy-agent/opa/v1/plugins/status"
 	"github.com/open-policy-agent/opa/v1/util"
 )
 
 // Top-level keys OPA only reads at start-up. A reload that changes one is
 // rejected rather than applied in part.
+//
+// None of these are inherently unreloadable; they are consumed once, while the
+// runtime is being built, by something that has no way to be handed a new
+// configuration afterwards. "storage" and "persistence_directory" pick the store
+// the compiler and every plugin already hold a reference to; "server",
+// "default_decision" and "default_authorization_decision" are baked into the
+// server and its routes; "distributed_tracing" and "metrics_export" construct a
+// tracer and a meter provider that are wired into the server and into every REST
+// client at creation, and neither is torn back down; "discovery" would hand
+// ownership of the plugin configuration to the discovery plugin, which is why
+// the watcher does not even start when it is set.
 var nonReloadableConfigKeys = []string{
 	"default_authorization_decision",
 	"default_decision",
@@ -43,10 +57,18 @@ var nonReloadableConfigKeys = []string{
 // either keeps the bundle plugin running. The manager cannot unregister a
 // plugin, so dropping a whole group would leave it running with its old settings
 // while disappearing from the reported configuration.
-var pluginConfigKeys = [][]string{
-	{"bundle", "bundles"},
-	{"decision_logs"},
-	{"status"},
+//
+// This catches a section going away outright, before anything is applied. A
+// section that is still there but no longer enables its plugin -- an empty
+// "decision_logs", say -- only shows up once the plugin configuration is parsed,
+// and is caught by pluginset.Configs.Orphaned instead.
+var pluginConfigKeys = []struct {
+	plugin string
+	keys   []string
+}{
+	{bundle.Name, []string{"bundle", "bundles"}},
+	{logs.Name, []string{"decision_logs"}},
+	{status.Name, []string{"status"}},
 }
 
 // How long to wait for the file to stop changing before reading it. Writers that
@@ -190,10 +212,11 @@ func (rt *Runtime) reloadConfig(ctx context.Context) (bool, error) {
 }
 
 // applyConfig hands a new configuration to the plugin manager. Plugins it no
-// longer mentions keep running: as with discovery, plugins can be added and
-// reconfigured but not removed. Validating the plugin sections needs the new
-// services registered first, so a failure there leaves the manager holding the
-// new services, keys and caching.
+// longer enables keep running: as with discovery, plugins can be added and
+// reconfigured but not removed, so a configuration that would drop one is
+// rejected. Validating the plugin sections needs the new services registered
+// first, so a failure there leaves the manager holding the new services, keys
+// and caching.
 func (rt *Runtime) applyConfig(ctx context.Context, bs []byte) error {
 	oldConf, err := rawConfigMap(rt.appliedConfig)
 	if err != nil {
@@ -210,7 +233,7 @@ func (rt *Runtime) applyConfig(ctx context.Context, bs []byte) error {
 	if relabelled := changedLabels(oldConf, newConf); len(relabelled) > 0 {
 		return fmt.Errorf("changing or removing labels (%s) requires a restart", strings.Join(relabelled, ", "))
 	}
-	if removed := removedPlugins(oldConf, newConf); len(removed) > 0 {
+	if removed := removedPlugins(rt.pluginRunning, registeredPluginNames(), newConf); len(removed) > 0 {
 		return fmt.Errorf("removing %s requires a restart", strings.Join(removed, ", "))
 	}
 
@@ -236,6 +259,10 @@ func (rt *Runtime) applyConfig(ctx context.Context, bs []byte) error {
 		rt.logger.Warn("%s", w)
 	}
 
+	if dropped := droppedKeys(oldConf, newConf, "services", "keys"); len(dropped) > 0 {
+		rt.logger.Warn("Entries removed from %s stay registered until OPA restarts.", strings.Join(dropped, " and "))
+	}
+
 	if err := rt.Manager.Reconfigure(parsed); err != nil {
 		return err
 	}
@@ -244,12 +271,20 @@ func (rt *Runtime) applyConfig(ctx context.Context, bs []byte) error {
 	factories := maps.Clone(registeredPlugins)
 	registeredPluginsMux.Unlock()
 
-	ps, err := pluginset.Get(factories, rt.Manager, parsed, rt.metrics, rt.logger, nil)
+	// Parsed before anything is registered, so that rejecting below leaves no
+	// half-built plugin behind.
+	configs, err := pluginset.Parse(factories, rt.Manager, parsed, rt.metrics, rt.logger, nil)
 	if err != nil {
 		return err
 	}
 
-	return ps.Apply(ctx)
+	// A section that is still present but no longer enables its plugin; the
+	// removedPlugins check above only sees one that is gone outright.
+	if len(configs.Orphaned) > 0 {
+		return fmt.Errorf("disabling %s requires a restart", strings.Join(configs.Orphaned, ", "))
+	}
+
+	return configs.Set(rt.Manager).Apply(ctx)
 }
 
 // rawConfigMap decodes a configuration as written, before defaults such as the
@@ -274,6 +309,31 @@ func changedKeys(oldConf, newConf map[string]any, keys []string) []string {
 	return changed
 }
 
+// droppedKeys returns the given keys that held entries the new configuration no
+// longer lists. The manager merges these rather than replacing them, so the
+// entries stay registered. Only the map form is inspected; "services" written as
+// an array is left alone.
+func droppedKeys(oldConf, newConf map[string]any, keys ...string) []string {
+	var dropped []string
+	for _, k := range keys {
+		oldEntries, _ := oldConf[k].(map[string]any)
+		newEntries, _ := newConf[k].(map[string]any)
+		for name := range oldEntries {
+			if _, ok := newEntries[name]; !ok {
+				dropped = append(dropped, k)
+				break
+			}
+		}
+	}
+
+	return dropped
+}
+
+// pluginRunning reports whether a plugin is registered under the given name.
+func (rt *Runtime) pluginRunning(name string) bool {
+	return rt.Manager.Plugin(name) != nil
+}
+
 // changedLabels returns the labels the new configuration changes or drops.
 // Additions are left out because those do take effect; the manager restores the
 // labels captured at start-up over anything else, which would be silent.
@@ -292,35 +352,44 @@ func changedLabels(oldConf, newConf map[string]any) []string {
 	return changed
 }
 
-// removedPlugins returns the plugin sections the new configuration drops. An
-// empty section counts as absent, since that enables nothing either.
-func removedPlugins(oldConf, newConf map[string]any) []string {
-	configured := func(conf map[string]any, group []string) string {
-		for _, k := range group {
-			if v, ok := conf[k]; ok && v != nil {
-				return k
-			}
-		}
-		return ""
-	}
-
+// removedPlugins returns the configuration sections of running plugins that the
+// new configuration drops outright. running reports whether a plugin of that
+// name is registered, so a section that never enabled anything is not mistaken
+// for a removal; custom names the plugins RegisterPlugin knows about.
+//
+// A section that is still present, however empty, is left alone here: the bundle
+// plugin reads an empty "bundles" as "no bundles" and tears its downloaders
+// down, and for the others pluginset reports the plugin as orphaned once the
+// section has been parsed.
+func removedPlugins(running func(name string) bool, custom []string, newConf map[string]any) []string {
 	var removed []string
 	for _, group := range pluginConfigKeys {
-		if was := configured(oldConf, group); was != "" && configured(newConf, group) == "" {
-			removed = append(removed, was)
+		if !running(group.plugin) {
+			continue
+		}
+		if !slices.ContainsFunc(group.keys, func(k string) bool { _, ok := newConf[k]; return ok }) {
+			removed = append(removed, group.keys[len(group.keys)-1])
 		}
 	}
 
-	oldCustom, _ := oldConf["plugins"].(map[string]any)
 	newCustom, _ := newConf["plugins"].(map[string]any)
-	for k := range oldCustom {
-		if _, ok := newCustom[k]; !ok {
-			removed = append(removed, "plugins."+k)
+	for _, name := range custom {
+		if _, ok := newCustom[name]; !ok && running(name) {
+			removed = append(removed, "plugins."+name)
 		}
 	}
 	slices.Sort(removed)
 
 	return removed
+}
+
+// registeredPluginNames returns the names custom plugins have been registered
+// under with RegisterPlugin.
+func registeredPluginNames() []string {
+	registeredPluginsMux.Lock()
+	defer registeredPluginsMux.Unlock()
+
+	return slices.Collect(maps.Keys(registeredPlugins))
 }
 
 func (rt *Runtime) onConfigReloadLogger(d time.Duration, err error) {

--- a/v1/runtime/config_test.go
+++ b/v1/runtime/config_test.go
@@ -546,6 +546,47 @@ bundles:
 	waitForBundle(t, rt, "second")
 }
 
+// A service moving under a bundle whose own configuration is untouched still
+// has to reach the running downloader.
+func TestReloadConfigAppliesServiceChanges(t *testing.T) {
+	first := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/b.tar.gz", map[string]string{
+			"data.json": `{"reload": {"which": "first"}}`,
+		}),
+	)
+	defer first.Stop()
+
+	second := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/b.tar.gz", map[string]string{
+			"data.json": `{"reload": {"which": "second"}}`,
+		}),
+	)
+	defer second.Stop()
+
+	config := func(url string) string {
+		return fmt.Sprintf(`services:
+  acme:
+    url: %q
+bundles:
+  b:
+    resource: /bundles/b.tar.gz
+`, url)
+	}
+
+	rt, configFile := newConfigReloadRuntime(t, config(first.URL()))
+
+	waitForBundle(t, rt, "first")
+
+	// Only the service URL changes; the bundles section is byte-identical.
+	writeConfig(t, configFile, config(second.URL()))
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	waitForBundle(t, rt, "second")
+}
+
 // waitForBundle blocks until data.reload.which has the expected value, which is
 // how far the bundle has got through downloading and activating.
 func waitForBundle(t *testing.T, rt *Runtime, exp string) {

--- a/v1/runtime/config_test.go
+++ b/v1/runtime/config_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	testLog "github.com/open-policy-agent/opa/v1/logging/test"
+	"github.com/open-policy-agent/opa/v1/plugins/bundle"
 	"github.com/open-policy-agent/opa/v1/plugins/logs"
 	"github.com/open-policy-agent/opa/v1/plugins/status"
 	sdktest "github.com/open-policy-agent/opa/v1/sdk/test"
+	"github.com/open-policy-agent/opa/v1/storage"
 )
 
 func newConfigReloadRuntime(t *testing.T, config string) (*Runtime, string) {
@@ -321,6 +323,291 @@ func TestReloadConfigRejectsPluginRemoval(t *testing.T) {
 	}
 	if rt.Manager.GetConfig().DecisionLogs == nil {
 		t.Error("expected decision_logs to remain in the reported configuration")
+	}
+}
+
+func TestReloadConfigRejectsCustomPluginRemoval(t *testing.T) {
+	RegisterPlugin("reload_test", Factory{})
+
+	rt, configFile := newConfigReloadRuntime(t, `plugins:
+  reload_test: {}
+`)
+
+	if rt.Manager.Plugin("reload_test") == nil {
+		t.Fatal("expected custom plugin at boot")
+	}
+
+	writeConfig(t, configFile, `labels:
+  region: west
+`)
+
+	_, err := rt.reloadConfig(t.Context())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if exp := "removing plugins.reload_test requires a restart"; err.Error() != exp {
+		t.Errorf("expected error %q, got %q", exp, err.Error())
+	}
+}
+
+// A section that is still there but no longer enables its plugin is the same
+// removal as dropping it, and has to be rejected the same way.
+func TestReloadConfigRejectsDisablingPlugins(t *testing.T) {
+	for _, tc := range []struct {
+		note    string
+		start   string
+		next    string
+		message string
+	}{
+		{
+			note:    "decision_logs emptied",
+			start:   "decision_logs:\n  console: true\n",
+			next:    "decision_logs: {}\n",
+			message: "disabling decision_logs requires a restart",
+		},
+		{
+			note:    "decision_logs nulled",
+			start:   "decision_logs:\n  console: true\n",
+			next:    "decision_logs:\n",
+			message: "disabling decision_logs requires a restart",
+		},
+		{
+			note:    "decision_logs console turned off",
+			start:   "decision_logs:\n  console: true\n",
+			next:    "decision_logs:\n  console: false\n",
+			message: "disabling decision_logs requires a restart",
+		},
+		{
+			note:    "status emptied",
+			start:   "status:\n  console: true\n",
+			next:    "status: {}\n",
+			message: "disabling status requires a restart",
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			rt, configFile := newConfigReloadRuntime(t, tc.start)
+
+			writeConfig(t, configFile, tc.next)
+
+			_, err := rt.reloadConfig(t.Context())
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tc.message {
+				t.Errorf("expected error %q, got %q", tc.message, err.Error())
+			}
+			if logs.Lookup(rt.Manager) == nil && status.Lookup(rt.Manager) == nil {
+				t.Error("expected the plugin to still be registered")
+			}
+		})
+	}
+}
+
+// A rejected reload must not leave a plugin registered but never started: the
+// next reload would reconfigure it, and a plugin that isn't running never reads
+// from its reconfigure channel.
+func TestReloadConfigRejectedReloadStartsNothing(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `decision_logs:
+  console: true
+`)
+
+	// Adds status, and disables decision_logs in the same write.
+	writeConfig(t, configFile, `decision_logs: {}
+status:
+  console: true
+`)
+
+	if _, err := rt.reloadConfig(t.Context()); err == nil {
+		t.Fatal("expected error")
+	}
+	if status.Lookup(rt.Manager) != nil {
+		t.Fatal("expected the status plugin not to have been registered by a rejected reload")
+	}
+
+	// Reverting leaves both plugins usable.
+	writeConfig(t, configFile, `decision_logs:
+  console: true
+status:
+  console: true
+`)
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if status.Lookup(rt.Manager) == nil {
+		t.Error("expected the status plugin to be started")
+	}
+}
+
+// An empty section still enables the plugin where it names the only configured
+// service, exactly as it would at start-up.
+func TestReloadConfigEmptyDecisionLogsPicksUpTheOnlyService(t *testing.T) {
+	server := sdktest.MustNewServer()
+	defer server.Stop()
+
+	rt, configFile := newConfigReloadRuntime(t, fmt.Sprintf(`services:
+  acme:
+    url: %q
+decision_logs:
+  console: true
+`, server.URL()))
+
+	writeConfig(t, configFile, fmt.Sprintf(`services:
+  acme:
+    url: %q
+decision_logs: {}
+`, server.URL()))
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	p := logs.Lookup(rt.Manager)
+	if p == nil {
+		t.Fatal("expected decision log plugin to still be registered")
+	}
+	if got := p.Config().Service; got != "acme" {
+		t.Errorf("expected the plugin to default to service acme, got %q", got)
+	}
+}
+
+// The bundle plugin takes an empty "bundles" as "no bundles", so unlike the
+// other plugins it can be emptied without a restart.
+func TestReloadConfigEmptyBundlesDropsBundles(t *testing.T) {
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/b.tar.gz", map[string]string{
+			"data.json": `{"reload": {"which": "b"}}`,
+		}),
+	)
+	defer server.Stop()
+
+	rt, configFile := newConfigReloadRuntime(t, fmt.Sprintf(`services:
+  acme:
+    url: %q
+bundles:
+  b:
+    resource: /bundles/b.tar.gz
+`, server.URL()))
+
+	writeConfig(t, configFile, fmt.Sprintf(`services:
+  acme:
+    url: %q
+bundles: {}
+`, server.URL()))
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	p := bundle.Lookup(rt.Manager)
+	if p == nil {
+		t.Fatal("expected bundle plugin to still be registered")
+	}
+	if got := len(p.Config().Bundles); got != 0 {
+		t.Errorf("expected no bundles to be left configured, got %d", got)
+	}
+}
+
+func TestReloadConfigAppliesBundleChanges(t *testing.T) {
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/first.tar.gz", map[string]string{
+			"data.json": `{"reload": {"which": "first"}}`,
+		}),
+		sdktest.MockBundle("/bundles/second.tar.gz", map[string]string{
+			"data.json": `{"reload": {"which": "second"}}`,
+		}),
+	)
+	defer server.Stop()
+
+	config := func(resource string) string {
+		return fmt.Sprintf(`services:
+  acme:
+    url: %q
+bundles:
+  b:
+    resource: %s
+`, server.URL(), resource)
+	}
+
+	rt, configFile := newConfigReloadRuntime(t, config("/bundles/first.tar.gz"))
+
+	waitForBundle(t, rt, "first")
+
+	writeConfig(t, configFile, config("/bundles/second.tar.gz"))
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	if got := bundle.Lookup(rt.Manager).Config().Bundles["b"].Resource; got != "/bundles/second.tar.gz" {
+		t.Fatalf("expected the bundle plugin to be reconfigured, got resource %q", got)
+	}
+
+	waitForBundle(t, rt, "second")
+}
+
+// waitForBundle blocks until data.reload.which has the expected value, which is
+// how far the bundle has got through downloading and activating.
+func waitForBundle(t *testing.T, rt *Runtime, exp string) {
+	t.Helper()
+
+	ctx := t.Context()
+	deadline := time.Now().Add(10 * time.Second)
+
+	for {
+		value, err := storage.ReadOne(ctx, rt.Store, storage.MustParsePath("/reload/which"))
+		if err == nil && value == exp {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for data.reload.which to become %q (last: %v, err: %v)", exp, value, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestReloadConfigWarnsOnDroppedService(t *testing.T) {
+	server := sdktest.MustNewServer()
+	defer server.Stop()
+
+	logger := testLog.New()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	writeConfig(t, configFile, fmt.Sprintf(`services:
+  acme:
+    url: %q
+  other:
+    url: %q
+`, server.URL(), server.URL()))
+
+	params := NewParams()
+	params.ConfigFile = configFile
+	params.Output = io.Discard
+	params.Logger = logger
+
+	rt, err := NewRuntime(t.Context(), params)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	writeConfig(t, configFile, fmt.Sprintf(`services:
+  acme:
+    url: %q
+`, server.URL()))
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	found := slices.ContainsFunc(logger.Entries(), func(e testLog.LogEntry) bool {
+		return strings.Contains(e.Message, "Entries removed from services")
+	})
+	if !found {
+		t.Errorf("expected a warning about the dropped service, got %v", logger.Entries())
+	}
+
+	// Still there, which is what the warning is about.
+	if !slices.Contains(rt.Manager.Services(), "other") {
+		t.Error("expected the dropped service to stay registered")
 	}
 }
 
@@ -646,70 +933,123 @@ func TestChangedConfigKeys(t *testing.T) {
 
 func TestRemovedPlugins(t *testing.T) {
 	tests := []struct {
+		note    string
+		running []string
+		custom  []string
+		new     string
+		exp     []string
+	}{
+		{
+			note: "nothing running",
+			new:  "labels:\n  region: east\n",
+		},
+		{
+			note:    "retained",
+			running: []string{logs.Name},
+			new:     "decision_logs:\n  console: false\n",
+		},
+		{
+			note:    "removed",
+			running: []string{logs.Name},
+			new:     "labels:\n  region: west\n",
+			exp:     []string{"decision_logs"},
+		},
+		{
+			note:    "an empty section is still a section",
+			running: []string{logs.Name},
+			new:     "decision_logs:\n",
+			// pluginset reports this one, once the section has been parsed.
+		},
+		{
+			note: "a section that was never running is not a removal",
+			new:  "labels:\n  region: west\n",
+		},
+		{
+			note:    "several, reported in a stable order",
+			running: []string{bundle.Name, logs.Name, status.Name},
+			new:     "labels:\n  region: west\n",
+			exp:     []string{"bundles", "decision_logs", "status"},
+		},
+		{
+			note:    "the deprecated bundle key keeps the bundle plugin",
+			running: []string{bundle.Name},
+			new:     "bundle:\n  name: b\n  service: s\n",
+		},
+		{
+			note:    "the whole bundle group removed",
+			running: []string{bundle.Name},
+			new:     "labels:\n  region: west\n",
+			exp:     []string{"bundles"},
+		},
+		{
+			note:    "custom plugin removed",
+			running: []string{"foo", "bar"},
+			custom:  []string{"foo", "bar"},
+			new:     "plugins:\n  foo: {}\n",
+			exp:     []string{"plugins.bar"},
+		},
+		{
+			note:    "all custom plugins removed",
+			running: []string{"foo"},
+			custom:  []string{"foo"},
+			new:     "labels:\n  region: west\n",
+			exp:     []string{"plugins.foo"},
+		},
+		{
+			note:   "a registered custom plugin that never ran is not a removal",
+			custom: []string{"foo"},
+			new:    "labels:\n  region: west\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			newConf, err := rawConfigMap([]byte(tc.new))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			running := func(name string) bool { return slices.Contains(tc.running, name) }
+			if removed := removedPlugins(running, tc.custom, newConf); !slices.Equal(removed, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, removed)
+			}
+		})
+	}
+}
+
+func TestDroppedKeys(t *testing.T) {
+	tests := []struct {
 		note     string
 		old, new string
 		exp      []string
 	}{
 		{
-			note: "nothing configured",
+			note: "nothing to drop",
 			old:  "labels:\n  region: west\n",
 			new:  "labels:\n  region: east\n",
 		},
 		{
-			note: "retained",
-			old:  "decision_logs:\n  console: true\n",
-			new:  "decision_logs:\n  console: false\n",
+			note: "service retained",
+			old:  "services:\n  s:\n    url: http://localhost\n",
+			new:  "services:\n  s:\n    url: http://elsewhere\n",
 		},
 		{
-			note: "added",
-			old:  "labels:\n  region: west\n",
-			new:  "decision_logs:\n  console: true\n",
+			note: "service dropped",
+			old:  "services:\n  s:\n    url: http://localhost\n  t:\n    url: http://localhost\n",
+			new:  "services:\n  s:\n    url: http://localhost\n",
+			exp:  []string{"services"},
 		},
 		{
-			note: "removed",
-			old:  "decision_logs:\n  console: true\n",
+			note: "all services dropped",
+			old:  "services:\n  s:\n    url: http://localhost\n",
 			new:  "labels:\n  region: west\n",
-			exp:  []string{"decision_logs"},
+			exp:  []string{"services"},
 		},
 		{
-			note: "emptied counts as removed",
-			old:  "decision_logs:\n  console: true\n",
-			new:  "decision_logs:\n",
-			exp:  []string{"decision_logs"},
-		},
-		{
-			note: "empty to empty is not a removal",
-			old:  "decision_logs:\n",
+			note: "both",
+			old:  "services:\n  s:\n    url: http://localhost\nkeys:\n  k:\n    key: secret\n",
 			new:  "labels:\n  region: west\n",
-		},
-		{
-			note: "several, reported in a stable order",
-			old:  "status:\n  service: s\nbundles:\n  b:\n    service: s\ndecision_logs:\n  console: true\n",
-			new:  "labels:\n  region: west\n",
-			exp:  []string{"bundles", "decision_logs", "status"},
-		},
-		{
-			note: "migrating the deprecated bundle to bundles is not a removal",
-			old:  "bundle:\n  name: b\n  service: s\n",
-			new:  "bundles:\n  b:\n    service: s\n",
-		},
-		{
-			note: "the whole bundle group removed",
-			old:  "bundles:\n  b:\n    service: s\n",
-			new:  "labels:\n  region: west\n",
-			exp:  []string{"bundles"},
-		},
-		{
-			note: "custom plugin removed",
-			old:  "plugins:\n  foo: {}\n  bar: {}\n",
-			new:  "plugins:\n  foo: {}\n",
-			exp:  []string{"plugins.bar"},
-		},
-		{
-			note: "all custom plugins removed",
-			old:  "plugins:\n  foo: {}\n",
-			new:  "labels:\n  region: west\n",
-			exp:  []string{"plugins.foo"},
+			exp:  []string{"services", "keys"},
 		},
 	}
 
@@ -724,8 +1064,8 @@ func TestRemovedPlugins(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if removed := removedPlugins(oldConf, newConf); !slices.Equal(removed, tc.exp) {
-				t.Errorf("expected %v, got %v", tc.exp, removed)
+			if dropped := droppedKeys(oldConf, newConf, "services", "keys"); !slices.Equal(dropped, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, dropped)
 			}
 		})
 	}

--- a/v1/runtime/config_test.go
+++ b/v1/runtime/config_test.go
@@ -1,0 +1,802 @@
+// Copyright 2026 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	testLog "github.com/open-policy-agent/opa/v1/logging/test"
+	"github.com/open-policy-agent/opa/v1/plugins/logs"
+	"github.com/open-policy-agent/opa/v1/plugins/status"
+	sdktest "github.com/open-policy-agent/opa/v1/sdk/test"
+)
+
+func newConfigReloadRuntime(t *testing.T, config string) (*Runtime, string) {
+	t.Helper()
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configFile, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	params := NewParams()
+	params.ConfigFile = configFile
+	params.Output = io.Discard
+	params.Logger = testLog.New()
+
+	ctx := t.Context()
+	rt, err := NewRuntime(ctx, params)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	if err := rt.Manager.Start(ctx); err != nil {
+		t.Fatalf("start plugins: %v", err)
+	}
+	t.Cleanup(func() { rt.Manager.Stop(ctx) })
+
+	return rt, configFile
+}
+
+func writeConfig(t *testing.T, path, config string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestReloadConfigNoChange(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+	// Same content: not a change.
+	writeConfig(t, configFile, `labels:
+  region: west
+`)
+
+	changed, err := rt.reloadConfig(t.Context())
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if changed {
+		t.Error("expected no change to be reported")
+	}
+}
+
+func TestReloadConfigStartsAndReconfiguresPlugins(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+	if p := logs.Lookup(rt.Manager); p != nil {
+		t.Fatal("expected no decision log plugin before reload")
+	}
+
+	writeConfig(t, configFile, `labels:
+  region: west
+  team: infra
+decision_logs:
+  console: true
+`)
+
+	changed, err := rt.reloadConfig(t.Context())
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected change to be reported")
+	}
+
+	if p := logs.Lookup(rt.Manager); p == nil {
+		t.Error("expected decision log plugin to be started")
+	}
+	if labels := rt.Manager.GetConfig().Labels; labels["team"] != "infra" {
+		t.Errorf("expected label team=infra, got %v", labels)
+	}
+
+	// Already running: reconfigured, not started again.
+	writeConfig(t, configFile, `labels:
+  region: west
+  team: infra
+decision_logs:
+  console: true
+  mask_decision: /system/log/mask
+`)
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	p := logs.Lookup(rt.Manager)
+	if p == nil {
+		t.Fatal("expected decision log plugin to still be registered")
+	}
+	if got := p.Config().MaskDecision; got == nil || *got != "/system/log/mask" {
+		t.Errorf("expected mask decision to be reconfigured, got %v", got)
+	}
+}
+
+func TestReloadConfigRejectsNonReloadableChanges(t *testing.T) {
+	for _, tc := range []struct {
+		note   string
+		config string
+		key    string
+	}{
+		{
+			note: "server",
+			config: `labels:
+  region: west
+server:
+  decoding:
+    max_length: 42
+`,
+			key: "server",
+		},
+		{
+			note: "storage",
+			config: `labels:
+  region: west
+storage:
+  disk:
+    directory: /tmp/opa
+`,
+			key: "storage",
+		},
+		{
+			note: "persistence_directory",
+			config: `labels:
+  region: west
+persistence_directory: /var/opa
+`,
+			key: "persistence_directory",
+		},
+		{
+			note: "default_decision",
+			config: `labels:
+  region: west
+default_decision: /example/allow
+`,
+			key: "default_decision",
+		},
+		{
+			note: "several at once",
+			config: `labels:
+  region: west
+server:
+  decoding:
+    max_length: 42
+storage:
+  disk:
+    directory: /tmp/opa
+`,
+			key: "server, storage",
+		},
+	} {
+		t.Run(tc.note, func(t *testing.T) {
+			rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+			writeConfig(t, configFile, tc.config)
+
+			changed, err := rt.reloadConfig(t.Context())
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !changed {
+				t.Error("expected the on-disk change to be reported")
+			}
+			if exp := fmt.Sprintf("changes to %s require a restart", tc.key); err.Error() != exp {
+				t.Errorf("expected error %q, got %q", exp, err.Error())
+			}
+
+			// Reported once, not on every event that follows.
+			changed, err = rt.reloadConfig(t.Context())
+			if err != nil {
+				t.Errorf("expected the rejected config to be reported only once, got %v", err)
+			}
+			if changed {
+				t.Error("expected no further change to be reported")
+			}
+
+			// Reverting is a change again, so it is accepted.
+			writeConfig(t, configFile, `labels:
+  region: west
+`)
+			if _, err := rt.reloadConfig(t.Context()); err != nil {
+				t.Errorf("expected the revert to be accepted, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReloadConfigRevertAfterFailedApply(t *testing.T) {
+	const good = `labels:
+  region: west
+`
+
+	rt, configFile := newConfigReloadRuntime(t, good)
+
+	if rt.Manager.GetConfig().NDBuiltinCacheEnabled() {
+		t.Fatal("expected the ND builtin cache to start out disabled")
+	}
+
+	// nd_builtin_cache applies before status is validated, and the service named
+	// here doesn't exist.
+	writeConfig(t, configFile, `labels:
+  region: west
+nd_builtin_cache: true
+status:
+  service: nonexistent
+`)
+
+	if _, err := rt.reloadConfig(t.Context()); err == nil {
+		t.Fatal("expected error")
+	}
+	if !rt.Manager.GetConfig().NDBuiltinCacheEnabled() {
+		t.Error("expected the ND builtin cache to have been applied before the failure")
+	}
+
+	writeConfig(t, configFile, good)
+
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if rt.Manager.GetConfig().NDBuiltinCacheEnabled() {
+		t.Error("expected the revert to undo the partially applied configuration")
+	}
+}
+
+func TestReloadConfigLabels(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+	writeConfig(t, configFile, `labels:
+  region: west
+  team: infra
+`)
+	if _, err := rt.reloadConfig(t.Context()); err != nil {
+		t.Fatalf("expected an added label to be accepted, got %v", err)
+	}
+	if got := rt.Manager.GetConfig().Labels["team"]; got != "infra" {
+		t.Errorf("expected label team=infra, got %q", got)
+	}
+
+	writeConfig(t, configFile, `labels:
+  region: east
+  team: infra
+`)
+	_, err := rt.reloadConfig(t.Context())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if exp := "changing or removing labels (region) requires a restart"; err.Error() != exp {
+		t.Errorf("expected error %q, got %q", exp, err.Error())
+	}
+	if got := rt.Manager.GetConfig().Labels["region"]; got != "west" {
+		t.Errorf("expected label region to stay west, got %q", got)
+	}
+}
+
+func TestReloadConfigRejectsPluginRemoval(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `decision_logs:
+  console: true
+`)
+
+	if logs.Lookup(rt.Manager) == nil {
+		t.Fatal("expected decision log plugin at boot")
+	}
+
+	writeConfig(t, configFile, `labels:
+  region: west
+`)
+
+	_, err := rt.reloadConfig(t.Context())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if exp := "removing decision_logs requires a restart"; err.Error() != exp {
+		t.Errorf("expected error %q, got %q", exp, err.Error())
+	}
+
+	// The plugin keeps running either way, so the reported configuration has to
+	// keep saying so.
+	if logs.Lookup(rt.Manager) == nil {
+		t.Error("expected decision log plugin to still be registered")
+	}
+	if rt.Manager.GetConfig().DecisionLogs == nil {
+		t.Error("expected decision_logs to remain in the reported configuration")
+	}
+}
+
+func TestReloadConfigReappliesCLIOverrides(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	writeConfig(t, configFile, `labels:
+  region: west
+`)
+
+	params := NewParams()
+	params.ConfigFile = configFile
+	params.ConfigOverrides = []string{"default_decision=/example/allow"}
+	params.Output = io.Discard
+	params.Logger = testLog.New()
+
+	ctx := t.Context()
+	rt, err := NewRuntime(ctx, params)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	writeConfig(t, configFile, `labels:
+  region: west
+  team: infra
+`)
+
+	if _, err := rt.reloadConfig(ctx); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+
+	if got := *rt.Manager.GetConfig().DefaultDecision; got != "/example/allow" {
+		t.Errorf("expected --set override to survive the reload, got %q", got)
+	}
+}
+
+func TestReloadConfigInvalid(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+	writeConfig(t, configFile, `status:
+  service: nonexistent
+`)
+
+	if _, err := rt.reloadConfig(t.Context()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	if p := status.Lookup(rt.Manager); p != nil {
+		t.Error("expected no status plugin to be registered for an invalid config")
+	}
+}
+
+func TestConfigWatcherAppliesChanges(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `labels:
+  region: west
+`)
+
+	reloads := make(chan error, 4)
+	if err := rt.startConfigWatcher(t.Context(), func(_ time.Duration, err error) {
+		reloads <- err
+	}); err != nil {
+		t.Fatalf("start config watcher: %v", err)
+	}
+
+	// Watched directory, but not the config file.
+	writeConfig(t, filepath.Join(filepath.Dir(configFile), "unrelated.txt"), "hello")
+
+	writeConfig(t, configFile, `labels:
+  region: west
+decision_logs:
+  console: true
+`)
+
+	select {
+	case err := <-reloads:
+		if err != nil {
+			t.Fatalf("reload config: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the config file change to be applied")
+	}
+
+	if p := logs.Lookup(rt.Manager); p == nil {
+		t.Error("expected decision log plugin to be started")
+	}
+
+	select {
+	case err := <-reloads:
+		t.Errorf("unexpected second reload (err: %v)", err)
+	default:
+	}
+}
+
+func TestConfigWatcherCoalescesTruncateAndWrite(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `nd_builtin_cache: true
+labels:
+  region: west
+`)
+
+	if !rt.Manager.GetConfig().NDBuiltinCacheEnabled() {
+		t.Fatal("expected the ND builtin cache to start out enabled")
+	}
+
+	// A read of the empty file would show the ND cache turned off.
+	type reload struct {
+		ndCache bool
+		err     error
+	}
+	reloads := make(chan reload, 8)
+
+	// Stands in for inotify's truncate-then-write on Linux; macOS reports the
+	// truncate as a Chmod, which the watcher ignores.
+	events := make(chan fsnotify.Event)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go rt.watchConfigEvents(ctx, events, nil, func(_ time.Duration, err error) {
+		reloads <- reload{ndCache: rt.Manager.GetConfig().NDBuiltinCacheEnabled(), err: err}
+	})
+
+	evt := fsnotify.Event{Name: configFile, Op: fsnotify.Write}
+
+	f, err := os.Create(configFile) // truncates in place
+	if err != nil {
+		t.Fatalf("truncate config: %v", err)
+	}
+	events <- evt
+
+	// Inside configCoalesceWindow, but long enough for a watcher that doesn't wait.
+	time.Sleep(25 * time.Millisecond)
+
+	if _, err := f.WriteString(`nd_builtin_cache: true
+labels:
+  region: west
+  team: infra
+`); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close config: %v", err)
+	}
+	events <- evt
+
+	select {
+	case r := <-reloads:
+		if r.err != nil {
+			t.Fatalf("reload config: %v", r.err)
+		}
+		if !r.ndCache {
+			t.Error("expected the ND builtin cache to stay enabled; the empty file was read")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the config file change to be applied")
+	}
+
+	if labels := rt.Manager.GetConfig().Labels; labels["team"] != "infra" {
+		t.Errorf("expected label team=infra, got %v", labels)
+	}
+
+	// One logical change, so one reload.
+	select {
+	case r := <-reloads:
+		t.Errorf("unexpected second reload (nd_builtin_cache: %v, err: %v)", r.ndCache, r.err)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func TestConfigWatcherIgnoresOtherFiles(t *testing.T) {
+	rt, configFile := newConfigReloadRuntime(t, `nd_builtin_cache: true
+labels:
+  region: west
+`)
+
+	reloads := make(chan error, 4)
+	events := make(chan fsnotify.Event)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go rt.watchConfigEvents(ctx, events, nil, func(_ time.Duration, err error) {
+		reloads <- err
+	})
+
+	// Truncated, as a writer that hasn't finished would leave it.
+	f, err := os.Create(configFile)
+	if err != nil {
+		t.Fatalf("truncate config: %v", err)
+	}
+	defer f.Close()
+
+	events <- fsnotify.Event{
+		Name: filepath.Join(filepath.Dir(configFile), "unrelated.txt"),
+		Op:   fsnotify.Create,
+	}
+
+	select {
+	case err := <-reloads:
+		t.Errorf("unexpected reload for an unrelated file (err: %v)", err)
+	case <-time.After(configCoalesceWindow + 500*time.Millisecond):
+	}
+
+	if !rt.Manager.GetConfig().NDBuiltinCacheEnabled() {
+		t.Error("expected the ND builtin cache to stay enabled; the truncated file was read")
+	}
+}
+
+func TestConfigWatcherNotStartedWithoutConfigFile(t *testing.T) {
+	params := NewParams()
+	params.Output = io.Discard
+	params.Logger = testLog.New()
+
+	rt, err := NewRuntime(t.Context(), params)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	if err := rt.startConfigWatcher(t.Context(), func(time.Duration, error) {
+		t.Error("unexpected reload")
+	}); err != nil {
+		t.Fatalf("start config watcher: %v", err)
+	}
+}
+
+func TestConfigWatcherNotStartedWithDiscovery(t *testing.T) {
+	server := sdktest.MustNewServer(
+		sdktest.MockBundle("/bundles/discovery.tar.gz", map[string]string{
+			"main.rego": "package config\n",
+		}),
+	)
+	defer server.Stop()
+
+	logger := testLog.New()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	writeConfig(t, configFile, fmt.Sprintf(`services:
+  test:
+    url: %q
+discovery:
+  decision: config
+  resource: /bundles/discovery.tar.gz
+`, server.URL()))
+
+	params := NewParams()
+	params.ConfigFile = configFile
+	params.Output = io.Discard
+	params.Logger = logger
+
+	rt, err := NewRuntime(t.Context(), params)
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	if err := rt.startConfigWatcher(t.Context(), func(time.Duration, error) {
+		t.Error("unexpected reload")
+	}); err != nil {
+		t.Fatalf("start config watcher: %v", err)
+	}
+
+	found := slices.ContainsFunc(logger.Entries(), func(e testLog.LogEntry) bool {
+		return strings.Contains(e.Message, "discovery is enabled")
+	})
+	if !found {
+		t.Errorf("expected a warning about discovery, got %v", logger.Entries())
+	}
+}
+
+func TestChangedConfigKeys(t *testing.T) {
+	tests := []struct {
+		note     string
+		old, new string
+		exp      []string
+	}{
+		{
+			note: "no change",
+			old:  "server:\n  decoding:\n    max_length: 42\n",
+			new:  "server:\n  decoding:\n    max_length: 42\n",
+		},
+		{
+			note: "change in a watched key",
+			old:  "server:\n  decoding:\n    max_length: 42\n",
+			new:  "server:\n  decoding:\n    max_length: 43\n",
+			exp:  []string{"server"},
+		},
+		{
+			note: "watched key added",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: west\nstorage:\n  disk:\n    directory: /tmp/opa\n",
+			exp:  []string{"storage"},
+		},
+		{
+			note: "watched key removed",
+			old:  "storage:\n  disk:\n    directory: /tmp/opa\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"storage"},
+		},
+		{
+			note: "change outside the watched keys",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: east\ndecision_logs:\n  console: true\n",
+		},
+		{
+			note: "key order is not a change",
+			old:  "server:\n  encoding:\n    gzip:\n      min_length: 1\n  decoding:\n    max_length: 42\n",
+			new:  "server:\n  decoding:\n    max_length: 42\n  encoding:\n    gzip:\n      min_length: 1\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			oldConf, err := rawConfigMap([]byte(tc.old))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			newConf, err := rawConfigMap([]byte(tc.new))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			changed := changedKeys(oldConf, newConf, nonReloadableConfigKeys)
+			if !slices.Equal(changed, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, changed)
+			}
+		})
+	}
+}
+
+func TestRemovedPlugins(t *testing.T) {
+	tests := []struct {
+		note     string
+		old, new string
+		exp      []string
+	}{
+		{
+			note: "nothing configured",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: east\n",
+		},
+		{
+			note: "retained",
+			old:  "decision_logs:\n  console: true\n",
+			new:  "decision_logs:\n  console: false\n",
+		},
+		{
+			note: "added",
+			old:  "labels:\n  region: west\n",
+			new:  "decision_logs:\n  console: true\n",
+		},
+		{
+			note: "removed",
+			old:  "decision_logs:\n  console: true\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"decision_logs"},
+		},
+		{
+			note: "emptied counts as removed",
+			old:  "decision_logs:\n  console: true\n",
+			new:  "decision_logs:\n",
+			exp:  []string{"decision_logs"},
+		},
+		{
+			note: "empty to empty is not a removal",
+			old:  "decision_logs:\n",
+			new:  "labels:\n  region: west\n",
+		},
+		{
+			note: "several, reported in a stable order",
+			old:  "status:\n  service: s\nbundles:\n  b:\n    service: s\ndecision_logs:\n  console: true\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"bundles", "decision_logs", "status"},
+		},
+		{
+			note: "migrating the deprecated bundle to bundles is not a removal",
+			old:  "bundle:\n  name: b\n  service: s\n",
+			new:  "bundles:\n  b:\n    service: s\n",
+		},
+		{
+			note: "the whole bundle group removed",
+			old:  "bundles:\n  b:\n    service: s\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"bundles"},
+		},
+		{
+			note: "custom plugin removed",
+			old:  "plugins:\n  foo: {}\n  bar: {}\n",
+			new:  "plugins:\n  foo: {}\n",
+			exp:  []string{"plugins.bar"},
+		},
+		{
+			note: "all custom plugins removed",
+			old:  "plugins:\n  foo: {}\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"plugins.foo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			oldConf, err := rawConfigMap([]byte(tc.old))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			newConf, err := rawConfigMap([]byte(tc.new))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if removed := removedPlugins(oldConf, newConf); !slices.Equal(removed, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, removed)
+			}
+		})
+	}
+}
+
+func TestChangedLabels(t *testing.T) {
+	tests := []struct {
+		note     string
+		old, new string
+		exp      []string
+	}{
+		{
+			note: "no labels at all",
+			old:  "decision_logs:\n  console: true\n",
+			new:  "decision_logs:\n  console: false\n",
+		},
+		{
+			note: "unchanged",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: west\n",
+		},
+		{
+			note: "addition is allowed",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: west\n  team: infra\n",
+		},
+		{
+			note: "labels added where there were none",
+			old:  "decision_logs:\n  console: true\n",
+			new:  "labels:\n  region: west\n",
+		},
+		{
+			note: "changed value",
+			old:  "labels:\n  region: west\n",
+			new:  "labels:\n  region: east\n",
+			exp:  []string{"region"},
+		},
+		{
+			note: "removed label",
+			old:  "labels:\n  region: west\n  team: infra\n",
+			new:  "labels:\n  region: west\n",
+			exp:  []string{"team"},
+		},
+		{
+			note: "whole section removed",
+			old:  "labels:\n  region: west\n",
+			new:  "decision_logs:\n  console: true\n",
+			exp:  []string{"region"},
+		},
+		{
+			note: "reported in a stable order",
+			old:  "labels:\n  region: west\n  team: infra\n  zone: a\n",
+			new:  "labels:\n  region: east\n  team: platform\n  zone: b\n",
+			exp:  []string{"region", "team", "zone"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.note, func(t *testing.T) {
+			oldConf, err := rawConfigMap([]byte(tc.old))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			newConf, err := rawConfigMap([]byte(tc.new))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if changed := changedLabels(oldConf, newConf); !slices.Equal(changed, tc.exp) {
+				t.Errorf("expected %v, got %v", tc.exp, changed)
+			}
+		})
+	}
+}

--- a/v1/runtime/runtime.go
+++ b/v1/runtime/runtime.go
@@ -383,6 +383,16 @@ type Runtime struct {
 	serverInitMtx sync.RWMutex
 	done          chan struct{}
 	repl          *repl.REPL
+
+	// appliedConfig is the configuration in effect, lastConfig the one most
+	// recently read from disk. They differ while a reload is failing.
+	appliedConfig []byte
+	lastConfig    []byte
+	configMtx     sync.Mutex
+
+	// Non-nil once the configuration file watcher is running.
+	configWatcherStop chan struct{}
+	configWatcherDone chan struct{}
 }
 
 // NewRuntime returns a new Runtime object initialized with params. Clients must
@@ -615,6 +625,8 @@ func NewRuntime(ctx context.Context, params Params) (*Runtime, error) {
 		meterProvider:     meterProvider,
 		loadedPathsResult: loaded,
 		serverTracingOpts: serverTracingOpts,
+		appliedConfig:     config,
+		lastConfig:        config,
 	}
 
 	return rt, nil
@@ -776,6 +788,12 @@ func (rt *Runtime) Serve(ctx context.Context) (err error) {
 			rt.logger.WithFields(map[string]any{"err": err}).Error("Unable to open watch.")
 			return err
 		}
+		if err := rt.startConfigWatcher(ctx, rt.onConfigReloadLogger); err != nil {
+			rt.logger.WithFields(map[string]any{"err": err}).Error("Unable to open config watch.")
+			return err
+		}
+		// Registered after the deferred Manager.Stop so it runs before it.
+		defer rt.stopConfigWatcher()
 	}
 
 	if rt.Params.EnableVersionCheck {
@@ -893,6 +911,11 @@ func (rt *Runtime) StartREPL(ctx context.Context) error {
 			fmt.Fprintln(rt.Params.Output, "error opening watch:", err)
 			return err
 		}
+		if err := rt.startConfigWatcher(ctx, onConfigReloadPrinter(rt.Params.Output)); err != nil {
+			fmt.Fprintln(rt.Params.Output, "error opening config watch:", err)
+			return err
+		}
+		defer rt.stopConfigWatcher()
 	}
 
 	if rt.Params.EnableVersionCheck {
@@ -1152,6 +1175,16 @@ func onReloadPrinter(output io.Writer) func(time.Duration, error) {
 			fmt.Fprintf(output, "\n# reload error (took %v): %v", d, err)
 		} else {
 			fmt.Fprintf(output, "\n# reloaded files (took %v)", d)
+		}
+	}
+}
+
+func onConfigReloadPrinter(output io.Writer) func(time.Duration, error) {
+	return func(d time.Duration, err error) {
+		if err != nil {
+			fmt.Fprintf(output, "\n# config reload error (took %v): %v", d, err)
+		} else {
+			fmt.Fprintf(output, "\n# reloaded config (took %v)", d)
 		}
 	}
 }


### PR DESCRIPTION
fix: #9184

--watch now also covers the file given by --config-file: it is re-read when it changes and applied to the running plugins. Options OPA only reads at start-up, and changed or removed labels, are rejected rather than applied in part.

You can try it out locally:

Setup OPA:
1. `go build -o /tmp/opa .`
2. `D=$(mktemp -d) && cd "$D"`
3. `: > config.yaml`
4. `/tmp/opa run -s -c config.yaml -w --addr localhost:8199 > log 2>&1 &`

Make changes and see the results:
1. `printf 'decision_logs:\n  console: true\n' > config.yaml`
2. `sleep 2; curl -s localhost:8199/v1/config`

Make changes to startup config and see it reject the changes:
1. `printf 'decision_logs:\n  console: true\nserver:\n  decoding:\n    max_length: 42\n' > config.yaml`
2. `sleep 2; grep 'Failed to reload' log`

Cleanup:
`pkill -f 'addr localhost:8199'; cd - && rm -rf "$D"`


