### PR TITLE
plugins/logs: Add trace_id, span_id and request_context to the event AST

### DIFF
--- a/v1/plugins/logs/plugin.go
+++ b/v1/plugins/logs/plugin.go
@@ -110,6 +110,14 @@ func (e *EventV1) AST() (ast.Value, error) {
 		event.Insert(ast.InternedTerm("batch_decision_id"), ast.StringTerm(e.BatchDecisionID))
 	}
 
+	if e.TraceID != "" {
+		event.Insert(ast.InternedTerm("trace_id"), ast.StringTerm(e.TraceID))
+	}
+
+	if e.SpanID != "" {
+		event.Insert(ast.InternedTerm("span_id"), ast.StringTerm(e.SpanID))
+	}
+
 	if e.Labels != nil {
 		labelsObj := ast.NewObject()
 		for k, v := range e.Labels {
@@ -235,6 +243,32 @@ func (e *EventV1) AST() (ast.Value, error) {
 
 	if e.RequestID > 0 {
 		event.Insert(ast.InternedTerm("req_id"), ast.UIntNumberTerm(e.RequestID))
+	}
+
+	// The nesting mirrors the `omitempty` tags on RequestContext, so that a
+	// mask policy sees the same shape as the uploaded event.
+	if e.RequestContext != nil {
+		requestContext := ast.NewObject()
+
+		if httpRequest := e.RequestContext.HTTPRequest; httpRequest != nil {
+			httpObj := ast.NewObject()
+
+			if len(httpRequest.Headers) > 0 {
+				headers := ast.NewObject()
+				for name, values := range httpRequest.Headers {
+					terms := make([]*ast.Term, len(values))
+					for i, v := range values {
+						terms[i] = ast.StringTerm(v)
+					}
+					headers.Insert(ast.StringTerm(name), ast.ArrayTerm(terms...))
+				}
+				httpObj.Insert(ast.InternedTerm("headers"), ast.NewTerm(headers))
+			}
+
+			requestContext.Insert(ast.InternedTerm("http"), ast.NewTerm(httpObj))
+		}
+
+		event.Insert(ast.InternedTerm("request_context"), ast.NewTerm(requestContext))
 	}
 
 	if len(e.Custom) > 0 {

--- a/v1/plugins/logs/plugin_test.go
+++ b/v1/plugins/logs/plugin_test.go
@@ -2801,6 +2801,38 @@ func TestPluginDrop(t *testing.T) {
 			event:    &EventV1{Path: "foo/foo"},
 			expected: false,
 		},
+		{
+			note: "drop on request context header",
+			rawPolicy: []byte(`
+			package system.log
+			import rego.v1
+			drop if {
+				input.request_context.http.headers["X-Skip-Log"][_] == "true"
+			}`),
+			event: &EventV1{
+				Path: "foo/foo",
+				RequestContext: &RequestContext{
+					HTTPRequest: &HTTPRequestContext{
+						Headers: map[string][]string{"X-Skip-Log": {"true"}},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			note: "drop on trace id",
+			rawPolicy: []byte(`
+			package system.log
+			import rego.v1
+			drop if {
+				input.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+			}`),
+			event: &EventV1{
+				Path:    "foo/foo",
+				TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -3502,6 +3534,58 @@ func TestEventV1ToAST(t *testing.T) {
 				Timestamp:           time.Now(),
 				RequestID:           1,
 				inputAST:            astInput,
+			},
+		},
+		{
+			note: "event with trace and span ids",
+			event: EventV1{
+				Labels:      map[string]string{"foo": "1", "bar": "2"},
+				DecisionID:  "1234567890",
+				TraceID:     "4bf92f3577b34da6a3ce929d0e0e4736",
+				SpanID:      "00f067aa0ba902b7",
+				Input:       &goInput,
+				Path:        "/http/authz/allow",
+				RequestedBy: "[::1]:59943",
+				Result:      &result,
+				Timestamp:   time.Now(),
+				inputAST:    astInput,
+			},
+		},
+		{
+			note: "event with request context",
+			event: EventV1{
+				Labels:      map[string]string{"foo": "1", "bar": "2"},
+				DecisionID:  "1234567890",
+				Input:       &goInput,
+				Path:        "/http/authz/allow",
+				RequestedBy: "[::1]:59943",
+				Result:      &result,
+				Timestamp:   time.Now(),
+				RequestContext: &RequestContext{
+					HTTPRequest: &HTTPRequestContext{
+						Headers: map[string][]string{
+							"X-Single": {"one"},
+							"X-Multi":  {"one", "two"},
+						},
+					},
+				},
+				inputAST: astInput,
+			},
+		},
+		{
+			note: "event with empty request context",
+			event: EventV1{
+				DecisionID:     "1234567890",
+				Timestamp:      time.Now(),
+				RequestContext: &RequestContext{},
+			},
+		},
+		{
+			note: "event with request context holding no headers",
+			event: EventV1{
+				DecisionID:     "1234567890",
+				Timestamp:      time.Now(),
+				RequestContext: &RequestContext{HTTPRequest: &HTTPRequestContext{}},
 			},
 		},
 	}


### PR DESCRIPTION
Mask and drop policies are documented to receive the whole decision log event, but AST() never emitted these three fields, so a policy could not key off a trace or a captured HTTP header.